### PR TITLE
Don't specify minor sdk version

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -2,4 +2,4 @@
 Extractotutils is a python package ment to simplify the development of new extractors.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     author_email="mathias.lohne@cognite.com",
     packages=["cognite.extractorutils"],
     description="Utilities for use in extractors.",
-    install_requires=["cognite-sdk==1.0.*", "typing", "google-cloud-pubsub==0.41.*", "prometheus-client==0.7.*"],
+    install_requires=["cognite-sdk>=1.0.0", "typing", "google-cloud-pubsub==0.41.*", "prometheus-client==0.7.*"],
     python_requires=">=3.5",
 )


### PR DESCRIPTION
As extractorutils do not rely on specific sdk functionality, we should
only specify major version of the sdk.