### PR TITLE
Fix concurrency issue with TimeSeriesUploadQueue

### DIFF
--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -333,13 +333,13 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
         if len(self.upload_queue) == 0:
             return
 
+        self.lock.acquire()
+
         upload_this = [
             {either_id.type(): either_id.content(), "datapoints": datapoints}
             for either_id, datapoints in self.upload_queue.items()
             if len(datapoints) > 0
         ]
-
-        self.lock.acquire()
 
         try:
             if len(upload_this) == 0:


### PR DESCRIPTION
If a new time series is added during the list comprehension in upload()
the iterator for the dict view will fail. Move everything inside lock.