### PR TITLE
Add safe_get for metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.4
+    hooks:
+    -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ line_length=120                # corresponds to -w  flag
 multi_line_output=3            # corresponds to -m  flag
 include_trailing_comma=true    # corresponds to -tc flag
 skip_glob = '^((?!py$).)*$'    # this makes sort all Python files
-known_third_party = []
+known_third_party = ["arrow", "dacite", "prometheus_client", "psutil", "pytest", "requests", "yaml"]
 
 [tool.poetry.dependencies]
 python = "^3.6.1"


### PR DESCRIPTION
Add a factory function for metrics that caches instances and never
creates more than one instance of a metrics collection