### PR TITLE
Retry connection being dropped

### DIFF
--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -26,6 +26,7 @@ from abc import ABC, abstractmethod
 from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from requests.exceptions import ConnectionError
 from retry import retry
 
 from cognite.client import CogniteClient
@@ -195,7 +196,7 @@ class RawStateStore(AbstractStateStore):
         self._ensure_table()
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -217,7 +218,7 @@ class RawStateStore(AbstractStateStore):
         self._initialize_implementation(force)
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -246,7 +247,7 @@ class RawStateStore(AbstractStateStore):
         self._synchronize_implementation()
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -43,6 +43,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from requests.exceptions import ConnectionError
 from retry import retry
 
 from cognite.client import CogniteClient
@@ -254,7 +255,7 @@ class RawUploadQueue(AbstractUploadQueue):
             self.upload_queue_size = 0
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -373,7 +374,7 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
             self.upload_queue_size = 0
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -496,7 +497,7 @@ class EventUploadQueue(AbstractUploadQueue):
             self.upload_queue_size = 0
 
     @retry(
-        exceptions=CogniteAPIError,
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,


### PR DESCRIPTION
Cognite SDK doesn't handle connection being dropped at the moment.