### PR TITLE
[SBS-2094] Add py.typed file so mypy knows that package is typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "1.0.3"
+version = "1.1.0"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
We (unstructured search) discovered that mypy doesn't know types of an installed package, even when it has been typed.

This change is apparently needed, and is per [this accepted Python Enhancement Proposal](https://www.python.org/dev/peps/pep-0561/). From [mypy docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages):

> If you would like to publish a library package to a package repository (e.g. PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory.

See also [this PR for the cognite-auth package](https://github.com/cognitedata/python-auth/pull/58) and [this PR in the sdk](https://github.com/cognitedata/cognite-sdk-python/pull/727).

I bumped the minor version. Should I update the changelog?