### PR TITLE
Add option to create missing time series from upload queue

### DIFF
--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -144,11 +144,11 @@ class EitherId:
         """
         return "{}: {}".format(self.type(), self.content())
 
-    def __repr__(self) -> Dict[str, Union[str, int]]:
+    def __repr__(self) -> str:
         """
-        Returns a dict containing the ID type as key and ID as value
+        Get a string representation of the EitherId on the format "type: content".
 
         Returns:
-            A dictionary representation of the EitherId
+            A string rep of the EitherId
         """
-        return {self.type(): self.content()}
+        return self.__str__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "1.1.0"
+version = "1.1.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"

--- a/tests/tests_unit/test_util.py
+++ b/tests/tests_unit/test_util.py
@@ -97,4 +97,4 @@ class TestEitherId(unittest.TestCase):
         self.assertTrue(hash(id1) == hash(id2))
 
     def test_repr(self):
-        self.assertDictEqual(EitherId(externalId="extId").__repr__(), {"externalId": "extId"})
+        self.assertEqual(EitherId(externalId="extId").__repr__(), "externalId: extId")


### PR DESCRIPTION
This will create the missing time series whenever external ids are
used.

Also fixes an issue in EitherId where the repr method didn't return a
string (as expected).