### PR TITLE
Add type inference to upload queue generation

### DIFF
--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -405,9 +405,16 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
             if self.create_missing:
                 # Get the time series that can be created
                 create_these = [id_dict["externalId"] for id_dict in ex.not_found if "externalId" in id_dict]
+                is_string = {
+                    ts_dict["externalId"]: isinstance(ts_dict["datapoints"][0][1], str)
+                    for ts_dict in upload_this
+                    if ts_dict["externalId"] in create_these
+                }
 
                 self.logger.info(f"Creating {len(create_these)} time series")
-                self.cdf_client.time_series.create([TimeSeries(external_id=i) for i in create_these])
+                self.cdf_client.time_series.create(
+                    [TimeSeries(external_id=i, is_string=is_string[i]) for i in create_these]
+                )
 
                 retry_these.extend([EitherId(external_id=i) for i in create_these])
 

--- a/tests/tests_unit/test_cdf_upload_queues.py
+++ b/tests/tests_unit/test_cdf_upload_queues.py
@@ -221,6 +221,7 @@ class TestUploadQueue(unittest.TestCase):
     @patch("cognite.client.CogniteClient")
     def test_file_uploader(self, MockCogniteClient):
         client: CogniteClient = MockCogniteClient()
+        client.config.max_workers = 10
 
         post_upload_test = {"value": 0}
 


### PR DESCRIPTION
Detect type of time series (numeric/string) based on the value of the
first data point in the queue for that TS.

Add a test for the create_missing feature with both numeric and string
datapoints