### PR TITLE
Fix URL creation in OAuth flow

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,4 +16,4 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"

--- a/cognite/extractorutils/authentication.py
+++ b/cognite/extractorutils/authentication.py
@@ -89,8 +89,7 @@ class Authenticator:
         if self._config.resource:
             body["resource"] = self._config.resource
 
-        url = f"{self._token_url}/oauth2/v2.0/token"
-        r = requests.post(url, data=body)
+        r = requests.post(self._token_url, data=body)
         _logger.debug("Request AAD token: %d %s", r.status_code, r.reason)
         return r.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "1.2.3"
+version = "1.2.4"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
It was appending `/oauth2/v2.0/token` always, leading to it being
appended twice when using AAD tenants, and incorrectly appended to urls
when specifying token url directly.