### PR TITLE
add custom buckets for latency

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,4 +16,4 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -192,7 +192,28 @@ class TimestampedObject:
     payload: Any
     created: Arrow
 
-CUSTOM_BUCKET_LATENCY = (.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 30.0, 60.0, 120.0, float('inf'))
+
+CUSTOM_BUCKET_LATENCY = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1.0,
+    2.5,
+    5.0,
+    7.5,
+    10.0,
+    20.0,
+    30.0,
+    60.0,
+    120.0,
+    float("inf"),
+)
 
 RAW_UPLOADER_ROWS_QUEUED = Counter(
     "cognite_raw_uploader_rows_queued", "Total number of records queued", labelnames=["destination"]
@@ -208,7 +229,7 @@ RAW_UPLOADER_LATENCY = Histogram(
     "cognite_raw_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
     labelnames=["destination"],
-    buckets=CUSTOM_BUCKET_LATENCY
+    buckets=CUSTOM_BUCKET_LATENCY,
 )
 
 TIMESERIES_UPLOADER_POINTS_QUEUED = Counter(
@@ -222,8 +243,9 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency", "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY
+    "cognite_timeseries_uploader_latency",
+    "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY,
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -237,8 +259,9 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
 
 SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency", "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY
+    "cognite_sequences_uploader_latency",
+    "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY,
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -248,8 +271,9 @@ EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total numb
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
 
 EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency", "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY
+    "cognite_events_uploader_latency",
+    "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY,
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -259,8 +283,9 @@ FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
 
 FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency", "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY
+    "cognite_files_uploader_latency",
+    "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY,
 )
 
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -211,7 +211,7 @@ CUSTOM_BUCKET_LATENCY = (
     20.0,
     30.0,
     60.0,
-    120.0,
+    120.0
     float("inf"),
 )
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -205,7 +205,7 @@ RAW_UPLOADER_ROWS_DUPLICATES = Counter(
 RAW_UPLOADER_QUEUE_SIZE = Gauge("cognite_raw_uploader_queue_size", "Internal queue size")
 RAW_UPLOADER_LATENCY = Histogram(
     "cognite_raw_uploader_latency",
-    "Distribution of times in seconds records spend in the queue",
+    "Distribution of times in minutes records spend in the queue",
     labelnames=["destination"],
 )
 
@@ -220,7 +220,8 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    "cognite_timeseries_uploader_latency",
+    "Distribution of times in minutes records spend in the queue",
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -234,7 +235,8 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
 
 SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    "cognite_sequences_uploader_latency",
+    "Distribution of times in minutes records spend in the queue",
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -244,7 +246,8 @@ EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total numb
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
 
 EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    "cognite_events_uploader_latency",
+    "Distribution of times in minutes records spend in the queue",
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -254,7 +257,8 @@ FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
 
 FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    "cognite_files_uploader_latency",
+    "Distribution of times in minutes records spend in the queue",
 )
 
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -193,28 +193,6 @@ class TimestampedObject:
     created: Arrow
 
 
-CUSTOM_BUCKET_LATENCY = (
-    0.005,
-    0.01,
-    0.025,
-    0.05,
-    0.075,
-    0.1,
-    0.25,
-    0.5,
-    0.75,
-    1.0,
-    2.5,
-    5.0,
-    7.5,
-    10.0,
-    20.0,
-    30.0,
-    60.0,
-    120.0,
-    float("inf"),
-)
-
 RAW_UPLOADER_ROWS_QUEUED = Counter(
     "cognite_raw_uploader_rows_queued", "Total number of records queued", labelnames=["destination"]
 )
@@ -229,7 +207,7 @@ RAW_UPLOADER_LATENCY = Histogram(
     "cognite_raw_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
     labelnames=["destination"],
-    buckets=CUSTOM_BUCKET_LATENCY,
+    unit="minutes",
 )
 
 TIMESERIES_UPLOADER_POINTS_QUEUED = Counter(
@@ -245,7 +223,7 @@ TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size",
 TIMESERIES_UPLOADER_LATENCY = Histogram(
     "cognite_timeseries_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY,
+    unit="minutes",
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -261,7 +239,7 @@ SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "
 SEQUENCES_UPLOADER_LATENCY = Histogram(
     "cognite_sequences_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY,
+    unit="minutes",
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -273,7 +251,7 @@ EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Intern
 EVENTS_UPLOADER_LATENCY = Histogram(
     "cognite_events_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY,
+    unit="minutes",
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -285,7 +263,7 @@ FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal
 FILES_UPLOADER_LATENCY = Histogram(
     "cognite_files_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
-    buckets=CUSTOM_BUCKET_LATENCY,
+    unit="minutes",
 )
 
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -192,6 +192,7 @@ class TimestampedObject:
     payload: Any
     created: Arrow
 
+CUSTOM_BUCKET_LATENCY = (.005, .01, .025, .05, .075, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 30.0, 60.0, 120.0, float('inf'))
 
 RAW_UPLOADER_ROWS_QUEUED = Counter(
     "cognite_raw_uploader_rows_queued", "Total number of records queued", labelnames=["destination"]
@@ -207,6 +208,7 @@ RAW_UPLOADER_LATENCY = Histogram(
     "cognite_raw_uploader_latency",
     "Distribution of times in seconds records spend in the queue",
     labelnames=["destination"],
+    buckets=CUSTOM_BUCKET_LATENCY
 )
 
 TIMESERIES_UPLOADER_POINTS_QUEUED = Counter(
@@ -220,7 +222,8 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency", "Distribution of times in seconds records spend in the queue"
+    "cognite_timeseries_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -234,7 +237,8 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
 
 SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency", "Distribution of times in seconds records spend in the queue"
+    "cognite_sequences_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -244,7 +248,8 @@ EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total numb
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
 
 EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency", "Distribution of times in seconds records spend in the queue"
+    "cognite_events_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -254,7 +259,8 @@ FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
 
 FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency", "Distribution of times in seconds records spend in the queue"
+    "cognite_files_uploader_latency", "Distribution of times in seconds records spend in the queue",
+    buckets=CUSTOM_BUCKET_LATENCY
 )
 
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -220,8 +220,7 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency",
-    "Distribution of times in seconds records spend in the queue",
+    "cognite_timeseries_uploader_latency", "Distribution of times in seconds records spend in the queue",
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -235,8 +234,7 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
 
 SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency",
-    "Distribution of times in seconds records spend in the queue",
+    "cognite_sequences_uploader_latency", "Distribution of times in seconds records spend in the queue",
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -246,8 +244,7 @@ EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total numb
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
 
 EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency",
-    "Distribution of times in seconds records spend in the queue",
+    "cognite_events_uploader_latency", "Distribution of times in seconds records spend in the queue",
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -257,8 +254,7 @@ FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
 
 FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency",
-    "Distribution of times in seconds records spend in the queue",
+    "cognite_files_uploader_latency", "Distribution of times in seconds records spend in the queue",
 )
 
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -211,7 +211,7 @@ CUSTOM_BUCKET_LATENCY = (
     20.0,
     30.0,
     60.0,
-    120.0
+    120.0,
     float("inf"),
 )
 

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -220,8 +220,7 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
+    "cognite_timeseries_uploader_latency", "Distribution of times in minutes records spend in the queue",
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -235,8 +234,7 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
 
 SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
+    "cognite_sequences_uploader_latency", "Distribution of times in minutes records spend in the queue",
 )
 
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
@@ -246,8 +244,7 @@ EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total numb
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
 
 EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
+    "cognite_events_uploader_latency", "Distribution of times in minutes records spend in the queue",
 )
 
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
@@ -257,8 +254,7 @@ FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
 
 FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
+    "cognite_files_uploader_latency", "Distribution of times in minutes records spend in the queue",
 )
 
 


### PR DESCRIPTION
changing unit for histograms from seconds to minutes, so it can also cover larger upload queues. 