### PR TITLE
Add Extractor base class

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -17,3 +17,4 @@ Cognite extractor utils is a Python package that simplifies the development of n
 """
 
 __version__ = "1.4.2"
+from .base import Extractor

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -1,0 +1,152 @@
+#  Copyright 2021 Cognite AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import logging
+import sys
+import traceback
+from dataclasses import is_dataclass
+from threading import Event, Thread
+from types import TracebackType
+from typing import Any, Callable, Dict, Generic, Optional, Type, TypeVar
+
+from cognite.client import CogniteClient
+from cognite.extractorutils.configtools import CustomConfigClass, StateStoreConfig, load_yaml
+from cognite.extractorutils.metrics import BaseMetrics
+from cognite.extractorutils.statestore import AbstractStateStore, NoStateStore
+from cognite.extractorutils.util import set_event_on_interrupt
+
+
+class Extractor(Generic[CustomConfigClass]):
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        version: Optional[str] = None,
+        run_handle: Optional[Callable[[CogniteClient, AbstractStateStore, CustomConfigClass, Event], None]] = None,
+        config_class: Type[CustomConfigClass],
+        metrics: Optional[BaseMetrics] = None,
+        use_default_state_store: bool = True,
+        cancelation_token: Event = Event(),
+    ):
+        self.name = name
+        self.description = description
+        self.run_handle = run_handle
+        self.config_class = config_class
+        self.use_default_state_store = use_default_state_store
+        self.version = version
+        self.cancelation_token = cancelation_token
+
+        self.started = False
+        self.configured_logger = False
+
+        self.cognite_client: CogniteClient
+        self.state_store: AbstractStateStore
+        self.config: CustomConfigClass
+
+        if metrics:
+            self.metrics = metrics
+        else:
+            self.metrics = BaseMetrics(extractor_name=name, extractor_version=version)
+
+    def _load_config(self) -> None:
+        argument_parser = argparse.ArgumentParser(sys.argv[0], description=self.description)
+        argument_parser.add_argument(
+            "config", nargs=1, type=str, help="The YAML file containing configuration for the extractor."
+        )
+        argument_parser.add_argument("-v", "--version", action="version", version=f"{self.name} v{self.version}")
+        args = argument_parser.parse_args()
+
+        with open(args.config[0], "r") as stream:
+            self.config = load_yaml(source=stream, config_type=self.config_class)
+
+    def _load_state_store(self) -> None:
+        def recursive_find_state_store(d: Dict[str, Any]) -> Optional[StateStoreConfig]:
+            for k in d:
+                if is_dataclass(d[k]):
+                    res = recursive_find_state_store(d[k].__dict__)
+                    if res:
+                        return res
+                if isinstance(d[k], StateStoreConfig):
+                    return d[k]
+            return None
+
+        state_store_config = recursive_find_state_store(self.config.__dict__)
+        if state_store_config:
+            self.state_store = state_store_config.create_state_store(self.cognite_client, self.use_default_state_store)
+        else:
+            self.state_store = NoStateStore()
+
+    def _report_success(self) -> None:
+        pass
+
+    def _report_error(self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
+        pass
+
+    def __enter__(self) -> "Extractor":
+        self._load_config()
+
+        set_event_on_interrupt(self.cancelation_token)
+
+        if not self.configured_logger:
+            self.config.logger.setup_logging()
+            self.configured_logger = True
+
+        self.cognite_client = self.config.cognite.get_cognite_client(self.name)
+        self._load_state_store()
+
+        try:
+            self.config.metrics.start_pushers(self.cognite_client)
+        except AttributeError:
+            pass
+
+        self.state_store.initialize()
+
+        def heartbeat_loop():
+            while not self.cancelation_token.is_set():
+                self.cancelation_token.wait(60)
+
+        Thread(target=heartbeat_loop, name="HeartbeatLoop", daemon=True).start()
+
+        self.started = True
+        return self
+
+    def __exit__(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> bool:
+        self.cancelation_token.set()
+
+        if self.state_store:
+            self.state_store.synchronize()
+
+        try:
+            self.config.metrics.stop_pushers()
+        except AttributeError:
+            pass
+
+        if exc_val:
+            self._report_error(exc_type, exc_val, exc_tb)
+        else:
+            self._report_success()
+
+        return exc_val is None
+
+    def run(self) -> None:
+        if not self.started:
+            raise ValueError("You must run the extractor in a context manager")
+        if self.run_handle:
+            self.run_handle(self.cognite_client, self.state_store, self.config, self.cancelation_token)
+        else:
+            raise ValueError("No run_handle defined")

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -61,16 +61,21 @@ class Extractor(Generic[CustomConfigClass]):
         else:
             self.metrics = BaseMetrics(extractor_name=name, extractor_version=version)
 
-    def _load_config(self) -> None:
-        argument_parser = argparse.ArgumentParser(sys.argv[0], description=self.description)
-        argument_parser.add_argument(
-            "config", nargs=1, type=str, help="The YAML file containing configuration for the extractor."
-        )
-        argument_parser.add_argument("-v", "--version", action="version", version=f"{self.name} v{self.version}")
-        args = argument_parser.parse_args()
+    def _load_config(self, override_path: Optional[str] = None) -> None:
+        if override_path:
+            with open(override_path) as stream:
+                self.config = load_yaml(source=stream, config_type=self.config_class)
 
-        with open(args.config[0], "r") as stream:
-            self.config = load_yaml(source=stream, config_type=self.config_class)
+        else:
+            argument_parser = argparse.ArgumentParser(sys.argv[0], description=self.description)
+            argument_parser.add_argument(
+                "config", nargs=1, type=str, help="The YAML file containing configuration for the extractor."
+            )
+            argument_parser.add_argument("-v", "--version", action="version", version=f"{self.name} v{self.version}")
+            args = argument_parser.parse_args()
+
+            with open(args.config[0], "r") as stream:
+                self.config = load_yaml(source=stream, config_type=self.config_class)
 
     def _load_state_store(self) -> None:
         def recursive_find_state_store(d: Dict[str, Any]) -> Optional[StateStoreConfig]:

--- a/tests/tests_unit/dummyconfig.yaml
+++ b/tests/tests_unit/dummyconfig.yaml
@@ -1,0 +1,12 @@
+version: "1"
+
+logger:
+  console:
+    level: INFO
+
+cognite:
+  project: mathiaslohne-develop
+  api-key: OWJhYzUyZDEtNmQxNy00OTc2LWI1MWYtYjA4Yjk0YmI3MzFj
+
+source:
+  frequency: 0.1

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -1,0 +1,62 @@
+#  Copyright 2021 Cognite AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from cognite.extractorutils import Extractor
+from cognite.extractorutils.configtools import BaseConfig, StateStoreConfig
+from cognite.extractorutils.statestore import LocalStateStore, NoStateStore
+
+
+@dataclass
+class SourceConfig:
+    frequency: float
+
+
+@dataclass
+class ExtractorConfig:
+    state_store: StateStoreConfig = StateStoreConfig()
+
+
+@dataclass
+class ConfigWithStates(BaseConfig):
+    source: SourceConfig
+    extractor: ExtractorConfig = ExtractorConfig()
+
+
+@dataclass
+class ConfigWithoutStates(BaseConfig):
+    source: SourceConfig
+
+
+class TestExtractorClass(unittest.TestCase):
+    def test_load_config(self):
+        e1 = Extractor(name="my_extractor1", description="description", config_class=ConfigWithStates)
+        e1._load_config("tests/tests_unit/dummyconfig.yaml")
+        self.assertIsInstance(e1.config, ConfigWithStates)
+
+    @patch("cognite.client.CogniteClient")
+    def test_load_state_store(self, get_client_mock):
+        e2 = Extractor(name="my_extractor2", description="description", config_class=ConfigWithStates)
+        e2._load_config("tests/tests_unit/dummyconfig.yaml")
+        e2.cognite_client = get_client_mock()
+        e2._load_state_store()
+        self.assertIsInstance(e2.state_store, LocalStateStore)
+
+        e3 = Extractor(name="my_extractor3", description="description", config_class=ConfigWithoutStates)
+        e3._load_config("tests/tests_unit/dummyconfig.yaml")
+        e3.cognite_client = get_client_mock()
+        e3._load_state_store()
+        self.assertIsInstance(e3.state_store, NoStateStore)


### PR DESCRIPTION
Add a base class for extractors to remove a lot of boilerplate code
necesarry for startup/shutdown, initialization etc.

This will also tie in nicely with automatic reporting of successful or
failed runs and heartbeats to the extraction pipeline API once that is
released.