### PR TITLE
delete login and use config to get project

### DIFF
--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -338,7 +338,7 @@ class CognitePusher(AbstractMetricsPusher):
 
         self._init_cdf()
 
-        self._cdf_project = cdf_client.login.status().project
+        self._cdf_project = cdf_client.config.project
 
     def _init_cdf(self) -> None:
         """

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -30,7 +30,10 @@ def main():
 
     config = load_yaml(open("config.yaml"), CogniteConfig)
     cdf = config.get_cognite_client("AAD test")
-    print("Login status", cdf.login.status())
+    if config.api_key:
+        print("Login status", cdf.login.status())
+    else:
+        print("Token status", cdf.iam.token.inspect())
 
     tss = cdf.time_series.list(limit=100)
     print("Found %d time series" % len(tss))


### PR DESCRIPTION
Using login will cause error when accessing with OIDC configuration.

https://cognitedata.atlassian.net/browse/CDF-13268

Because this change doesn't seem to affect current tests, I didn't add any test code.
If necessary, I'll do.