### PR TITLE
Add option to resolve data set either from id or external id

### DIFF
--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -107,7 +107,7 @@ class EitherIdConfig:
 
     @property
     def either_id(self) -> EitherId:
-        return EitherId(internal_id=self.id, external_id=self.external_id)
+        return EitherId(id=self.id, external_id=self.external_id)
 
 
 @dataclass
@@ -161,6 +161,8 @@ class CogniteConfig:
             logging.getLogger(__name__).warning("Using data-set-id is deprecated, please use data-set/id instead")
             return cdf_client.data_sets.retrieve(external_id=self.data_set_external_id)
 
+        eihter = self.data_set.either_id
+        print(eihter)
         return cdf_client.data_sets.retrieve(
             id=self.data_set.either_id.internal_id, external_id=self.data_set.either_id.external_id
         )

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -98,6 +98,8 @@ class EitherId:
     """
 
     def __init__(self, **kwargs):
+        print(kwargs)
+
         internal_id = kwargs.get("id")
         external_id = kwargs.get("externalId") or kwargs.get("external_id")
 

--- a/tests/tests_integration/test_configtools.py
+++ b/tests/tests_integration/test_configtools.py
@@ -1,0 +1,84 @@
+#  Copyright 2021 Cognite AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import random
+import unittest
+from io import StringIO
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes import DataSet
+from cognite.client.exceptions import CogniteDuplicatedError
+from cognite.extractorutils.configtools import BaseConfig, CogniteConfig, load_yaml
+
+
+class TestConfigtools(unittest.TestCase):
+    client: CogniteClient
+
+    data_set_name: str = f"Extractor Utils Test Data Set"
+    data_set_extid: str = f"extractorUtils-testdataset"
+
+    data_set_id: int
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = CogniteClient(client_name="extractor-utils-integration-tests",)
+
+        try:
+            cls.data_set_id = cls.client.data_sets.create(
+                DataSet(name=cls.data_set_name, external_id=cls.data_set_extid)
+            ).id
+        except CogniteDuplicatedError:
+            cls.data_set_id = cls.client.data_sets.retrieve(external_id=cls.data_set_extid).id
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        pass
+
+    def test_dataset_resolve(self):
+        config_file_id = StringIO(
+            f"""
+        logger:
+            console:
+                level: INFO    
+        
+        cognite:
+            host: ${{COGNITE_BASE_URL}}
+            project: ${{COGNITE_PROJECT}}
+            api-key: ${{COGNITE_API_KEY}}
+            data-set:
+                id: {TestConfigtools.data_set_id}
+        """
+        )
+
+        config: CogniteConfig = load_yaml(config_file_id, BaseConfig)
+        self.assertEqual(config.get_data_set(self.client).external_id, TestConfigtools.data_set_extid)
+        self.assertEqual(config.get_data_set(self.client).name, TestConfigtools.data_set_name)
+
+        config_file_extid = StringIO(
+            f"""
+        logger:
+            console:
+                level: INFO    
+        
+        cognite:
+            host: ${{COGNITE_BASE_URL}}
+            project: ${{COGNITE_PROJECT}}
+            api-key: ${{COGNITE_API_KEY}}
+            data-set:
+                external-id: {TestConfigtools.data_set_extid}
+        """
+        )
+
+        config: CogniteConfig = load_yaml(config_file_id, BaseConfig)
+        self.assertEqual(config.get_data_set(self.client).external_id, TestConfigtools.data_set_extid)
+        self.assertEqual(config.get_data_set(self.client).name, TestConfigtools.data_set_name)

--- a/tests/tests_integration/test_configtools_integration.py
+++ b/tests/tests_integration/test_configtools_integration.py
@@ -40,10 +40,6 @@ class TestConfigtools(unittest.TestCase):
         except CogniteDuplicatedError:
             cls.data_set_id = cls.client.data_sets.retrieve(external_id=cls.data_set_extid).id
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        pass
-
     def test_dataset_resolve(self):
         config_file_id = StringIO(
             f"""

--- a/tests/tests_integration/test_configtools_integration.py
+++ b/tests/tests_integration/test_configtools_integration.py
@@ -56,9 +56,10 @@ class TestConfigtools(unittest.TestCase):
         """
         )
 
-        config: CogniteConfig = load_yaml(config_file_id, BaseConfig)
-        self.assertEqual(config.get_data_set(self.client).external_id, TestConfigtools.data_set_extid)
-        self.assertEqual(config.get_data_set(self.client).name, TestConfigtools.data_set_name)
+        config: BaseConfig = load_yaml(config_file_id, BaseConfig)
+        print(config)
+        self.assertEqual(config.cognite.get_data_set(self.client).external_id, TestConfigtools.data_set_extid)
+        self.assertEqual(config.cognite.get_data_set(self.client).name, TestConfigtools.data_set_name)
 
         config_file_extid = StringIO(
             f"""
@@ -75,6 +76,6 @@ class TestConfigtools(unittest.TestCase):
         """
         )
 
-        config: CogniteConfig = load_yaml(config_file_id, BaseConfig)
-        self.assertEqual(config.get_data_set(self.client).external_id, TestConfigtools.data_set_extid)
-        self.assertEqual(config.get_data_set(self.client).name, TestConfigtools.data_set_name)
+        config2: BaseConfig = load_yaml(config_file_extid, BaseConfig)
+        self.assertEqual(config2.cognite.get_data_set(self.client).id, TestConfigtools.data_set_id)
+        self.assertEqual(config2.cognite.get_data_set(self.client).name, TestConfigtools.data_set_name)


### PR DESCRIPTION
Many SAs have asked for an option to use external ID in config files
as it stays the same accross CDF projects. That will for sure be the
case for extraction pipelines too, so introduce a new more generic
schema for data sets, that we can reuse for extraction pipelines later