### PR TITLE
Methods to remove invalid datapoints

### DIFF
--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -65,6 +65,7 @@ instead. If both are used, the condition being met first will trigger the upload
 """
 
 import logging
+import math
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -249,6 +250,11 @@ TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size",
 
 TIMESERIES_UPLOADER_LATENCY = Histogram(
     "cognite_timeseries_uploader_latency", "Distribution of times in minutes records spend in the queue",
+)
+
+TIMESERIES_UPLOADER_POINTS_DISCARDED = Counter(
+    "cognite_timeseries_uploader_points_discarded",
+    "Total number of datapoints discarded due to invalid timestamp or value",
 )
 
 SEQUENCES_UPLOADER_POINTS_QUEUED = Counter(
@@ -456,6 +462,12 @@ def default_time_series_factory(external_id: str, datapoints: DataPointList) -> 
     return TimeSeries(external_id=external_id, is_string=is_string)
 
 
+MIN_DATAPOINT_TIMESTAMP = 31536000000
+MAX_DATAPOINT_STRING_LENGTH = 255
+MAX_DATAPOINT_VALUE = 1e100
+MIN_DATAPOINT_VALUE = -1e100
+
+
 class TimeSeriesUploadQueue(AbstractUploadQueue):
     """
     Upload queue for time series
@@ -512,6 +524,37 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
         self.latency = TIMESERIES_UPLOADER_LATENCY
         self.latency_zero_point = arrow.utcnow()
 
+    def _verify_datapoint_time(self, time: Union[int, float, datetime]) -> bool:
+        if isinstance(time, int) or isinstance(time, float):
+            return not math.isnan(time) and time >= MIN_DATAPOINT_TIMESTAMP
+        else:
+            return time.timestamp() * 1000.0 >= MIN_DATAPOINT_TIMESTAMP
+
+    def _verify_datapoint_value(self, value: Union[int, float, str]) -> bool:
+        if isinstance(value, float):
+            return not (
+                math.isnan(value) or math.isinf(value) or value > MAX_DATAPOINT_VALUE or value < MIN_DATAPOINT_VALUE
+            )
+        elif isinstance(value, str):
+            return len(value) <= MAX_DATAPOINT_STRING_LENGTH
+        else:
+            return True
+
+    def _is_datapoint_valid(
+        self,
+        dp: Union[
+            Dict[Union[int, float, datetime], Union[int, float, str]],
+            Tuple[Union[int, float, datetime], Union[int, float, str]],
+        ],
+    ) -> bool:
+        if isinstance(dp, Dict):
+            return self._verify_datapoint_time(dp["timestamp"]) and self._verify_datapoint_value(dp["value"])
+        elif isinstance(dp, Tuple):
+            return self._verify_datapoint_time(dp[0]) and self._verify_datapoint_value(dp[1])
+        else:
+            # I don't know how many different legal permutations there are, since the type hints are incomplete.
+            return True
+
     def add_to_upload_queue(self, *, id: int = None, external_id: str = None, datapoints: DataPointList = []) -> None:
         """
         Add data points to upload queue. The queue will be uploaded if the queue size is larger than the threshold
@@ -522,6 +565,16 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
             external_id: External ID of time series. Either this or external_id must be set.
             datapoints: List of data points to add
         """
+        old_len = len(datapoints)
+        datapoints = list(filter(self._is_datapoint_valid, datapoints))
+
+        new_len = len(datapoints)
+
+        if old_len > new_len:
+            diff = old_len - new_len
+            self.logger.warning(f"Discarding {diff} datapoints due to bad timestamp or value")
+            TIMESERIES_UPLOADER_POINTS_DISCARDED.inc(diff)
+
         either_id = EitherId(id=id, external_id=external_id)
 
         with self.lock:

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -94,10 +94,10 @@ RETRY_MAX_DELAY = 15
 RETRY_DELAY = 5
 RETRIES = 10
 
-DataPointList = Union[
-    List[Dict[Union[int, float, datetime], Union[int, float, str]]],
-    List[Tuple[Union[int, float, datetime], Union[int, float, str]]],
+DataPoint = Union[
+    Dict[str, Union[int, float, str, datetime]], Tuple[Union[int, float, datetime], Union[int, float, str]]
 ]
+DataPointList = List[DataPoint]
 
 
 class AbstractUploadQueue(ABC):
@@ -540,19 +540,12 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
         else:
             return True
 
-    def _is_datapoint_valid(
-        self,
-        dp: Union[
-            Dict[Union[int, float, datetime], Union[int, float, str]],
-            Tuple[Union[int, float, datetime], Union[int, float, str]],
-        ],
-    ) -> bool:
+    def _is_datapoint_valid(self, dp: DataPoint,) -> bool:
         if isinstance(dp, Dict):
             return self._verify_datapoint_time(dp["timestamp"]) and self._verify_datapoint_value(dp["value"])
         elif isinstance(dp, Tuple):
             return self._verify_datapoint_time(dp[0]) and self._verify_datapoint_value(dp[1])
         else:
-            # I don't know how many different legal permutations there are, since the type hints are incomplete.
             return True
 
     def add_to_upload_queue(self, *, id: int = None, external_id: str = None, datapoints: DataPointList = []) -> None:

--- a/tests/tests_unit/test_statestore.py
+++ b/tests/tests_unit/test_statestore.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import datetime
 import os
 import time
 import unittest
@@ -121,25 +122,27 @@ class TestBaseStateStore(unittest.TestCase):
             cdf_client=MockCogniteClient(), post_upload_function=state_store.post_upload_handler()
         )
 
-        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(1, 1), (4, 4)])
+        start: float = datetime.datetime.now().timestamp() * 1000.0
+
+        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(start + 1, 1), (start + 4, 4)])
         upload_queue.upload()
 
-        self.assertTupleEqual(state_store.get_state("testId"), (1, 4))
+        self.assertTupleEqual(state_store.get_state("testId"), (start + 1, start + 4))
 
-        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(2, 2), (3, 3)])
+        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(start + 2, 2), (start + 3, 3)])
         upload_queue.upload()
 
-        self.assertTupleEqual(state_store.get_state("testId"), (1, 4))
+        self.assertTupleEqual(state_store.get_state("testId"), (start + 1, start + 4))
 
-        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(5, 5)])
+        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(start + 5, 5)])
         upload_queue.upload()
 
-        self.assertTupleEqual(state_store.get_state("testId"), (1, 5))
+        self.assertTupleEqual(state_store.get_state("testId"), (start + 1, start + 5))
 
-        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(0, 0)])
+        upload_queue.add_to_upload_queue(external_id="testId", datapoints=[(start + 0, 0)])
         upload_queue.upload()
 
-        self.assertTupleEqual(state_store.get_state("testId"), (0, 5))
+        self.assertTupleEqual(state_store.get_state("testId"), (start + 0, start + 5))
 
 
 class TestRawStateStore(unittest.TestCase):


### PR DESCRIPTION
Also metrics, and a test to verify that this works.

The rules are:

No NaN or +/-Inf

Points in range (-1E100, 1E100)

String datapoints no longer than 255 characters.

Timestamps after 01.01.1971