### PR TITLE
Update logging for upload queues to be more consistent

### DIFF
--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -366,6 +366,9 @@ class RawUploadQueue(AbstractUploadQueue):
         """
         Trigger an upload of the queue, clears queue afterwards
         """
+        if len(self.upload_queue) == 0:
+            return
+
         with self.lock:
             for database, tables in self.upload_queue.items():
                 for table, rows in tables.items():
@@ -391,7 +394,7 @@ class RawUploadQueue(AbstractUploadQueue):
                         self.logger.error("Error in upload callback: %s", str(e))
 
             self.upload_queue.clear()
-            self.logger.info(f"Uploaded {self.upload_queue_size} rows in total")
+            self.logger.info(f"Uploaded {self.upload_queue_size} raw rows")
             self.upload_queue_size = 0
             self.queue_size.set(self.upload_queue_size)
 
@@ -566,6 +569,7 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
                 self.logger.error("Error in upload callback: %s", str(e))
 
             self.upload_queue.clear()
+            self.logger.info(f"Uploaded {self.upload_queue_size} datapoints")
             self.upload_queue_size = 0
             self.queue_size.set(self.upload_queue_size)
 
@@ -746,6 +750,7 @@ class EventUploadQueue(AbstractUploadQueue):
             except Exception as e:
                 self.logger.error("Error in upload callback: %s", str(e))
             self.upload_queue.clear()
+            self.logger.info(f"Uploaded {self.upload_queue_size} events")
             self.upload_queue_size = 0
             self.queue_size.set(self.upload_queue_size)
 
@@ -964,6 +969,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
 
             self.upload_queue.clear()
             self.upload_queue_size = 0
+            self.logger.info(f"Uploaded {self.upload_queue_size} sequence rows")
             self.queue_size.set(self.upload_queue_size)
 
     @retry(
@@ -1148,6 +1154,7 @@ class FileUploadQueue(AbstractUploadQueue):
             except Exception as e:
                 self.logger.error("Error in upload callback: %s", str(e))
             self.upload_queue.clear()
+            self.logger.info(f"Uploaded {self.upload_queue_size} files")
             self.upload_queue_size = 0
             self.queue_size.set(self.upload_queue_size)
 
@@ -1291,6 +1298,7 @@ class BytesUploadQueue(AbstractUploadQueue):
             # Clear queue
             self.upload_queue.clear()
             self.upload_queue_size = 0
+            self.logger.info(f"Uploaded {self.upload_queue_size} files")
             self.queue_size.set(self.upload_queue_size)
 
     def _upload_batch(self):


### PR DESCRIPTION
Only the RAW upload queue were logging what it uploaded, change it to
be more consistent across the queues, and change the wording a bit to
make it clearer.

Add the `if empty` check for RAW queues that exists for other queues,
which removes all the `uploaded 0 rows` lines that can occur