### PR TITLE
Add option to not handle interrupts

### DIFF
--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -69,6 +69,7 @@ class Extractor(Generic[CustomConfigClass]):
         config_file_path: Optional[str] = None,
         continuous_extractor: bool = False,
         heartbeat_waiting_time: int = 600,
+        handle_interrupts: bool = True,
     ):
         self.name = name
         self.description = description
@@ -80,6 +81,7 @@ class Extractor(Generic[CustomConfigClass]):
         self.config_file_path = config_file_path
         self.continuous_extractor = continuous_extractor
         self.heartbeat_waiting_time = heartbeat_waiting_time
+        self.handle_interrupts = handle_interrupts
 
         self.started = False
         self.configured_logger = False
@@ -187,13 +189,14 @@ class Extractor(Generic[CustomConfigClass]):
         """
         self._load_config(override_path=self.config_file_path)
 
-        set_event_on_interrupt(self.cancelation_token)
-
         if not self.configured_logger:
             self.config.logger.setup_logging()
             self.configured_logger = True
 
         self.logger = logging.getLogger(__name__)
+
+        if self.handle_interrupts:
+            set_event_on_interrupt(self.cancelation_token)
 
         self.cognite_client = self.config.cognite.get_cognite_client(self.name)
         self._load_state_store()

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -81,7 +81,10 @@ def set_event_on_interrupt(stop_event: Event) -> None:
         stop_event.set()
         logger.info("Waiting for threads to complete")
 
-    signal.signal(signal.SIGINT, sigint_handler)
+    try:
+        signal.signal(signal.SIGINT, sigint_handler)
+    except ValueError as e:
+        logging.getLogger(__name__).warning(f"Could not register handler for interrupt signals: {str(e)}")
 
 
 class EitherId:


### PR DESCRIPTION
The win32 library for building windows services runs everything in
dummy threads, so setting the signal handler (which must be done from
the main thread) can't be done.

Add both an option to skip it (for services), and add a try/catch to
avoid the issue of a wrong signal handler crashing the extractor in the
future.