### PR TITLE
Use threading tokens in retry

### DIFF
--- a/cognite/extractorutils/retry.py
+++ b/cognite/extractorutils/retry.py
@@ -58,17 +58,17 @@ def retry(
 
     This is adapted from https://github.com/invl/retry
 
-    :param cancelation_token: a threading token that is waited on.
-    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
-    :param tries: the maximum number of attempts. default: -1 (infinite).
-    :param delay: initial delay between attempts. default: 0.
-    :param max_delay: the maximum value of delay. default: None (no limit).
-    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
-    :param jitter: extra seconds added to delay between attempts. default: 0.
+    Args:
+        cancelation_token: a threading token that is waited on.
+        exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+        tries: the maximum number of attempts. default: -1 (infinite).
+        delay: initial delay between attempts. default: 0.
+        max_delay: the maximum value of delay. default: None (no limit).
+        backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+        jitter: extra seconds added to delay between attempts. default: 0.
                    fixed if a number, random if a range tuple (min, max)
-    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+        logger: logger.warning(fmt, error, delay) will be called on failed attempts.
                    default: retry.logging_logger. if None, logging is disabled.
-    :returns: a retry decorator.
     """
 
     @decorator

--- a/cognite/extractorutils/retry.py
+++ b/cognite/extractorutils/retry.py
@@ -1,0 +1,83 @@
+import logging
+import random
+import threading
+from functools import partial
+from typing import Iterable, Optional, Type
+
+from decorator import decorator
+
+logging_logger = logging.getLogger(__name__)
+
+
+def _retry_internal(
+    f,
+    cancelation_token: threading.Event = threading.Event(),
+    exceptions: Iterable[Type[Exception]] = Exception,
+    tries: int = -1,
+    delay: int = 0,
+    max_delay: Optional[int] = None,
+    backoff: float = 1,
+    jitter: float = 0,
+    logger: logging.Logger = logging_logger,
+):
+    _tries, _delay = tries, delay
+    while _tries and not cancelation_token.is_set():
+        try:
+            return f()
+        except exceptions as e:
+            _tries -= 1
+            if not _tries:
+                raise
+
+            if logger is not None:
+                logger.warning("%s, retrying in %s seconds...", e, _delay)
+
+            cancelation_token.wait(_delay)
+            _delay *= backoff
+
+            if isinstance(jitter, tuple):
+                _delay += random.uniform(*jitter)
+            else:
+                _delay += jitter
+
+            if max_delay is not None:
+                _delay = min(_delay, max_delay)
+
+
+def retry(
+    cancelation_token: threading.Event = threading.Event(),
+    exceptions: Iterable[Type[Exception]] = Exception,
+    tries: int = -1,
+    delay: int = 0,
+    max_delay: Optional[int] = None,
+    backoff: float = 1,
+    jitter: float = 0,
+    logger: logging.Logger = logging_logger,
+):
+    """Returns a retry decorator.
+
+    This is adapted from https://github.com/invl/retry
+
+    :param cancelation_token: a threading token that is waited on.
+    :param exceptions: an exception or a tuple of exceptions to catch. default: Exception.
+    :param tries: the maximum number of attempts. default: -1 (infinite).
+    :param delay: initial delay between attempts. default: 0.
+    :param max_delay: the maximum value of delay. default: None (no limit).
+    :param backoff: multiplier applied to delay between attempts. default: 1 (no backoff).
+    :param jitter: extra seconds added to delay between attempts. default: 0.
+                   fixed if a number, random if a range tuple (min, max)
+    :param logger: logger.warning(fmt, error, delay) will be called on failed attempts.
+                   default: retry.logging_logger. if None, logging is disabled.
+    :returns: a retry decorator.
+    """
+
+    @decorator
+    def retry_decorator(f, *fargs, **fkwargs):
+        args = fargs if fargs else list()
+        kwargs = fkwargs if fkwargs else dict()
+
+        return _retry_internal(
+            partial(f, *args, **kwargs), cancelation_token, exceptions, tries, delay, max_delay, backoff, jitter, logger
+        )
+
+    return retry_decorator

--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -93,13 +93,13 @@ from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from requests.exceptions import ConnectionError
-from retry import retry
 
 from cognite.client import CogniteClient
 from cognite.client.exceptions import CogniteAPIError
 from cognite.extractorutils.uploader import DataPointList
 
 from ._inner_util import _resolve_log_level
+from .retry import retry
 
 RETRY_BACKOFF_FACTOR = 1.5
 RETRY_MAX_DELAY = 15

--- a/cognite/extractorutils/uploader.py
+++ b/cognite/extractorutils/uploader.py
@@ -79,7 +79,6 @@ import arrow
 from arrow import Arrow
 from prometheus_client import Counter, Gauge, Histogram
 from requests.exceptions import ConnectionError
-from retry import retry
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Event, FileMetadata, Sequence, SequenceData, TimeSeries
@@ -87,6 +86,7 @@ from cognite.client.data_classes.raw import Row
 from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError, CogniteNotFoundError, CogniteReadTimeout
 
 from ._inner_util import _resolve_log_level
+from .retry import retry
 from .util import EitherId
 
 RETRY_BACKOFF_FACTOR = 1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ arrow = "^1.0.0"
 pyyaml = "^5.3.0"
 dacite = "^1.6.0"
 psutil = "^5.7.0"
+decorator = "^5.1.1"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ line_length=120                # corresponds to -w  flag
 multi_line_output=3            # corresponds to -m  flag
 include_trailing_comma=true    # corresponds to -tc flag
 skip_glob = '^((?!py$).)*$'    # this makes sort all Python files
-known_third_party = ["arrow", "dacite", "prometheus_client", "psutil", "pytest", "requests", "retry", "yaml"]
+known_third_party = ["arrow", "dacite", "decorator", "prometheus_client", "psutil", "pytest", "requests", "yaml"]
 
 [tool.poetry.dependencies]
 python = "^3.7.0"
@@ -31,7 +31,6 @@ arrow = "^1.0.0"
 pyyaml = "^5.3.0"
 dacite = "^1.6.0"
 psutil = "^5.7.0"
-retry = "^0.9.2"
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
This fixes the issue that retries would block the entire application due to GIL madness or something along those lines.

The solution isn't ideal. I couldn't find a great way to pass cancelation_token into the decorator, so now it just creates a new one. Suggestions are welcome.