### PR TITLE
Use Optional instead of dataclass default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Changes are grouped as follows
 
 ## Next release
 
+## [2.1.3] - 2022-03-07
+
+### Fixed
+
+ * Use Optional with defaults in code instead of dataclass defaults in
+   `UploaderExtractorConfig`, as this allows non-default config sections in
+   subclasses.
+
+
 ## [2.1.2] - 2022-03-07
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"
 from .base import Extractor

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -41,7 +41,7 @@ class QueueConfigClass:
 
 @dataclass
 class UploaderExtractorConfig(BaseConfig):
-    queues: QueueConfigClass = QueueConfigClass()
+    queues: Optional[QueueConfigClass]
 
 
 UploaderExtractorConfigClass = TypeVar("UploaderExtractorConfigClass", bound=UploaderExtractorConfig)
@@ -131,22 +131,24 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
 
     def __enter__(self) -> "UploaderExtractor":
         super(UploaderExtractor, self).__enter__()
+
+        queue_config = self.config.queues if self.config.queues else QueueConfigClass()
         self.event_queue = EventUploadQueue(
             self.cognite_client,
-            max_queue_size=self.config.queues.event_size,
-            max_upload_interval=self.config.queues.upload_interval,
+            max_queue_size=queue_config.event_size,
+            max_upload_interval=queue_config.upload_interval,
             trigger_log_level="INFO",
         ).__enter__()
         self.raw_queue = RawUploadQueue(
             self.cognite_client,
-            max_queue_size=self.config.queues.raw_size,
-            max_upload_interval=self.config.queues.upload_interval,
+            max_queue_size=queue_config.raw_size,
+            max_upload_interval=queue_config.upload_interval,
             trigger_log_level="INFO",
         ).__enter__()
         self.time_series_queue = TimeSeriesUploadQueue(
             self.cognite_client,
-            max_queue_size=self.config.queues.timeseries_size,
-            max_upload_interval=self.config.queues.upload_interval,
+            max_queue_size=queue_config.timeseries_size,
+            max_upload_interval=queue_config.upload_interval,
             trigger_log_level="INFO",
             create_missing=True,
         ).__enter__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "2.1.2"
+version = "2.1.3"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Python dataclasses requires that all default valued config parameters
are listed at the end, which means that since we have a default value
in `UploaderExtractorConfig` no subclass can have non-default config
parameters (such as the `source` field in the `MqttConfig`).