### PR TITLE
Throw error when configured extraction pipeline doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes are grouped as follows
 ### Added
 
  * `.env` files will now be loaded if present at runtime
+ * Check that a configured extraction pipeline actually exists, and report an
+   appropriate error if not.
 
 ### Fixed
 

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -250,10 +250,14 @@ class CogniteConfig:
         if not self.extraction_pipeline:
             return None
 
-        return cdf_client.extraction_pipelines.retrieve(
-            id=self.extraction_pipeline.either_id.internal_id,
-            external_id=self.extraction_pipeline.either_id.external_id,
+        either_id = self.extraction_pipeline.either_id
+        extraction_pipeline = cdf_client.extraction_pipelines.retrieve(
+            id=either_id.internal_id,
+            external_id=either_id.external_id,
         )
+        if extraction_pipeline is None:
+            raise ValueError(f"Extraction pipeline with {either_id.type()} {either_id.content()} not found")
+        return extraction_pipeline
 
 
 @dataclass

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -99,7 +99,6 @@ from urllib.parse import urljoin
 
 import dacite
 import yaml
-
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Asset, DataSet, ExtractionPipeline
 
@@ -252,8 +251,7 @@ class CogniteConfig:
 
         either_id = self.extraction_pipeline.either_id
         extraction_pipeline = cdf_client.extraction_pipelines.retrieve(
-            id=either_id.internal_id,
-            external_id=either_id.external_id,
+            id=either_id.internal_id, external_id=either_id.external_id,
         )
         if extraction_pipeline is None:
             raise ValueError(f"Extraction pipeline with {either_id.type()} {either_id.content()} not found")

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -99,6 +99,7 @@ from urllib.parse import urljoin
 
 import dacite
 import yaml
+
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Asset, DataSet, ExtractionPipeline
 

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -251,7 +251,8 @@ class CogniteConfig:
 
         either_id = self.extraction_pipeline.either_id
         extraction_pipeline = cdf_client.extraction_pipelines.retrieve(
-            id=either_id.internal_id, external_id=either_id.external_id,
+            id=either_id.internal_id,
+            external_id=either_id.external_id,
         )
         if extraction_pipeline is None:
             raise ValueError(f"Extraction pipeline with {either_id.type()} {either_id.content()} not found")


### PR DESCRIPTION
Since the retrieve method returns an optional, when it was missing it
looked like no extpipe was configured, leading to some difficult to
understand (and debug) log messages.