### PR TITLE
Allow time interval to be configured as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,41 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+
+## Next
+
+### Changed
+
+ * Allow any interval to be configured as a string in addition to integers, so
+   e.g. upload intervals can be configured as
+
+   ```yaml
+   upload-interval: 2m
+   ```
+
+   with `s`/`m`/`h`/`d` being valid units, and `s` being implied when units are
+   missing (to preserve backwards compatibility with old config files). If your
+   extractor reads from these config fields you need to update to read the
+   `seconds` (or the computed `minutes`, `hours` or `days` ) attribute instead
+   of the fields directly, for example:
+
+   ```python
+   RawUploadQueue(
+       cognite_client,
+       max_upload_interval=config.upload_interval,
+   )
+   ```
+
+   must be changed to
+
+   ```python
+   RawUploadQueue(
+       cognite_client,
+       max_upload_interval=config.upload_interval.seconds,
+   )
+   ```
+
+
 ## [3.2.0]
 ### Added
  * Decorator which adds extraction pipeline functionality
@@ -213,38 +248,6 @@ The config file stored in CDF should omit all of these fields, as they will be
 overwritten by the `ConfigResolver` to be the values given here. In other words,
 for most extractor deployments, you should be able to leave out the `cognite`
 field in the config stored in CDF.
-
-
-### Changed
-
- * Allow any interval to be configured as a string in addition to integers, so
-   e.g. upload intervals can be configured as
-
-   ```yaml
-   upload-interval: 2m
-   ```
-
-   with `s`/`m`/`h`/`d` being valid units, and `s` being implied when units are
-   missing (to preserve backwards compatibility with old config files). If your
-   extractor reads from these config fields you need to update to read the
-   `seconds` (or the computed `minutes`, `hours` or `days` ) attribute instead
-   of the fields directly, for example:
-
-   ```python
-   RawUploadQueue(
-       cognite_client,
-       max_upload_interval=config.upload_interval,
-   )
-   ```
-
-   must be changed to
-
-   ```python
-   RawUploadQueue(
-       cognite_client,
-       max_upload_interval=config.upload_interval.seconds,
-   )
-   ```
 
 
 ## [2.2.0] - 2022-04-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,22 +17,28 @@ Changes are grouped as follows
 
 ### Changed
 
- * Allow any interval to be configured as a string in addition to integers, so e.g. upload intervals can be configured
-   as
+ * Allow any interval to be configured as a string in addition to integers, so
+   e.g. upload intervals can be configured as
+
    ```yaml
    upload-interval: 2m
    ```
-   with `s`/`m`/`h`/`d` being valid units, and `s` being implied when units are missing (to preserve backwards 
-   compatibility with old config files). If your extractor reads from these config fields directly you need to update
-   to read the `seconds` (or the computed `minutes`, `hours` or `days` ) attribute instead of the fields directly, for
-   example:
+
+   with `s`/`m`/`h`/`d` being valid units, and `s` being implied when units are
+   missing (to preserve backwards compatibility with old config files). If your
+   extractor reads from these config fields you need to update to read the
+   `seconds` (or the computed `minutes`, `hours` or `days` ) attribute instead
+   of the fields directly, for example:
+
    ```python
    RawUploadQueue(
        cognite_client,
        max_upload_interval=config.upload_interval,
    )
    ```
+
    must be changed to
+
    ```python
    RawUploadQueue(
        cognite_client,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ Changes are grouped as follows
 
 ## Next release
 
+### Changed
+
+ * Allow any interval to be configured as a string in addition to integers, so e.g. upload intervals can be configured
+   as
+   ```yaml
+   upload-interval: 2m
+   ```
+   with `s`/`m`/`h`/`d` being valid units, and `s` being implied when units are missing (to preserve backwards 
+   compatibility with old config files). If your extractor reads from these config fields directly you need to update
+   to read the `seconds` (or the computed `minutes`, `hours` or `days` ) attribute instead of the fields directly, for
+   example:
+   ```python
+   RawUploadQueue(
+       cognite_client,
+       max_upload_interval=config.upload_interval,
+   )
+   ```
+   must be changed to
+   ```python
+   RawUploadQueue(
+       cognite_client,
+       max_upload_interval=config.upload_interval.seconds,
+   )
+   ```
+
+
 ### Added
 
  * `.env` files will now be loaded if present at runtime

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -187,7 +187,7 @@ class EitherIdConfig:
         return EitherId(id=self.id, external_id=self.external_id)
 
 
-class TimeIntervalConfig:
+class TimeIntervalConfig(yaml.YAMLObject):
     def __init__(self, expression):
         self._interval, self._expression = TimeIntervalConfig._parse_expression(expression)
 

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -90,11 +90,12 @@ import os
 import re
 import time
 from dataclasses import dataclass
+from datetime import timedelta
 from enum import Enum
 from logging.handlers import TimedRotatingFileHandler
 from threading import Event
 from time import sleep
-from typing import Any, Dict, List, Optional, T, TextIO, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, T, TextIO, Tuple, Type, TypeVar, Union
 from urllib.parse import urljoin
 
 import dacite
@@ -179,6 +180,62 @@ class EitherIdConfig:
         return EitherId(id=self.id, external_id=self.external_id)
 
 
+class TimeIntervalConfig:
+    def __init__(self, expression):
+        self._interval, self._expression = TimeIntervalConfig._parse_expression(expression)
+
+    @classmethod
+    def _parse_expression(cls, expression: str) -> Tuple[int, str]:
+        # First, try to parse pure number and assume seconds (for backwards compatibility)
+        try:
+            return int(expression), f"{expression}s"
+        except ValueError:
+            pass
+
+        match = re.match(r"(\d+)(s|m|h|d)", expression)
+        if not match:
+            raise InvalidConfigError("Invalid interval pattern")
+
+        number, unit = match.groups()
+        numeric_unit = {"s": 1, "m": 60, "h": 60 * 60, "d": 60 * 60 * 24}[unit]
+
+        return int(number) * numeric_unit, expression
+
+    @property
+    def seconds(self) -> int:
+        return self._interval
+
+    @property
+    def minutes(self) -> float:
+        return self._interval / 60
+
+    @property
+    def hours(self) -> float:
+        return self._interval / (60 * 60)
+
+    @property
+    def days(self) -> float:
+        return self._interval / (60 * 60 * 24)
+
+    @property
+    def timedelta(self) -> timedelta:
+        days = self._interval // (60 * 60 * 24)
+        seconds = self._interval % (60 * 60 * 24)
+        return timedelta(days=days, seconds=seconds)
+
+    def __int__(self) -> int:
+        return int(self._interval)
+
+    def __float__(self) -> float:
+        return float(self._interval)
+
+    def __str__(self) -> str:
+        return self._expression
+
+    def __repr__(self) -> str:
+        return self._expression
+
+
 @dataclass
 class CogniteConfig:
     """
@@ -192,7 +249,7 @@ class CogniteConfig:
     data_set_id: Optional[int]
     data_set_external_id: Optional[str]
     extraction_pipeline: Optional[EitherIdConfig]
-    timeout: int = 30
+    timeout: TimeIntervalConfig = TimeIntervalConfig("30s")
     external_id_prefix: str = ""
     host: str = "https://api.cognitedata.com"
 
@@ -223,7 +280,7 @@ class CogniteConfig:
             base_url=self.host,
             client_name=client_name,
             disable_pypi_version_check=True,
-            timeout=self.timeout,
+            timeout=self.timeout.seconds,
             **kwargs,
         )
 
@@ -337,8 +394,8 @@ class _PushGatewayConfig:
     username: Optional[str]
     password: Optional[str]
 
-    clear_after: Optional[int]
-    push_interval: int = 30
+    clear_after: Optional[TimeIntervalConfig]
+    push_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
 @dataclass
@@ -347,7 +404,7 @@ class _CogniteMetricsConfig:
     asset_name: Optional[str]
     asset_external_id: Optional[str]
 
-    push_interval: int = 30
+    push_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
 @dataclass
@@ -372,7 +429,7 @@ class MetricsConfig:
                 username=push_gateway.username,
                 password=push_gateway.password,
                 url=push_gateway.host,
-                push_interval=push_gateway.push_interval,
+                push_interval=push_gateway.push_interval.seconds,
                 thread_name=f"MetricsPusher_{counter}",
                 cancelation_token=cancelation_token,
             )
@@ -380,7 +437,7 @@ class MetricsConfig:
             pusher.start()
             self._pushers.append(pusher)
             if push_gateway.clear_after is not None:
-                self._clear_on_stop[pusher] = push_gateway.clear_after
+                self._clear_on_stop[pusher] = push_gateway.clear_after.seconds
 
         if self.cognite:
             asset = None
@@ -391,7 +448,7 @@ class MetricsConfig:
             pusher = CognitePusher(
                 cdf_client=cdf_client,
                 external_id_prefix=self.cognite.external_id_prefix,
-                push_interval=self.cognite.push_interval,
+                push_interval=self.cognite.push_interval.seconds,
                 asset=asset,
                 thread_name="CogniteMetricsPusher",  # There is only one Cognite project as a target
                 cancelation_token=cancelation_token,
@@ -435,13 +492,13 @@ class RawDestinationConfig:
 
 @dataclass
 class RawStateStoreConfig(RawDestinationConfig):
-    upload_interval: int = 30
+    upload_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
 @dataclass
 class LocalStateStoreConfig:
     path: str
-    save_interval: int = 30
+    save_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
 @dataclass
@@ -474,11 +531,11 @@ class StateStoreConfig:
                 cdf_client=cdf_client,
                 database=self.raw.database,
                 table=self.raw.table,
-                save_interval=self.raw.upload_interval,
+                save_interval=self.raw.upload_interval.seconds,
             )
 
         if self.local:
-            return LocalStateStore(file_path=self.local.path, save_interval=self.local.save_interval)
+            return LocalStateStore(file_path=self.local.path, save_interval=self.local.save_interval.seconds)
 
         if default_to_local:
             return LocalStateStore(file_path="states.json")
@@ -535,7 +592,7 @@ def load_yaml(
 
     try:
         config = dacite.from_dict(
-            data=config_dict, data_class=config_type, config=dacite.Config(strict=True, cast=[Enum])
+            data=config_dict, data_class=config_type, config=dacite.Config(strict=True, cast=[Enum, TimeIntervalConfig])
         )
     except (dacite.WrongTypeError, dacite.MissingValueError, dacite.UnionMatchError, dacite.UnexpectedDataError) as e:
         raise InvalidConfigError(str(e))

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -24,7 +24,7 @@ from cognite.client import CogniteClient
 from more_itertools import peekable
 
 from cognite.extractorutils.base import Extractor
-from cognite.extractorutils.configtools import BaseConfig
+from cognite.extractorutils.configtools import BaseConfig, TimeIntervalConfig
 from cognite.extractorutils.metrics import BaseMetrics
 from cognite.extractorutils.statestore import AbstractStateStore
 from cognite.extractorutils.uploader import EventUploadQueue, RawUploadQueue, TimeSeriesUploadQueue
@@ -36,7 +36,7 @@ class QueueConfigClass:
     event_size: int = 10_000
     raw_size: int = 100_000
     timeseries_size: int = 1_000_000
-    upload_interval: int = 60
+    upload_interval: TimeIntervalConfig = TimeIntervalConfig("1m")
 
 
 @dataclass
@@ -136,19 +136,19 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         self.event_queue = EventUploadQueue(
             self.cognite_client,
             max_queue_size=queue_config.event_size,
-            max_upload_interval=queue_config.upload_interval,
+            max_upload_interval=queue_config.upload_interval.seconds,
             trigger_log_level="INFO",
         ).__enter__()
         self.raw_queue = RawUploadQueue(
             self.cognite_client,
             max_queue_size=queue_config.raw_size,
-            max_upload_interval=queue_config.upload_interval,
+            max_upload_interval=queue_config.upload_interval.seconds,
             trigger_log_level="INFO",
         ).__enter__()
         self.time_series_queue = TimeSeriesUploadQueue(
             self.cognite_client,
             max_queue_size=queue_config.timeseries_size,
-            max_upload_interval=queue_config.upload_interval,
+            max_upload_interval=queue_config.upload_interval.seconds,
             trigger_log_level="INFO",
             create_missing=True,
         ).__enter__()

--- a/tests/tests_unit/test_configtools.py
+++ b/tests/tests_unit/test_configtools.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 import pytest
 from cognite.client import CogniteClient
 
-from cognite.extractorutils.configtools import BaseConfig, CogniteConfig, _to_snake_case, load_yaml
+from cognite.extractorutils.configtools import BaseConfig, CogniteConfig, TimeIntervalConfig, _to_snake_case, load_yaml
 from cognite.extractorutils.exceptions import InvalidConfigError
 
 
@@ -248,3 +248,13 @@ class TestConfigtoolsMethods(unittest.TestCase):
         """
         with self.assertRaises(InvalidConfigError):
             load_yaml(config, CastingClass)
+
+    def test_parse_time_interval(self):
+        self.assertEqual(TimeIntervalConfig("54").seconds, 54)
+        self.assertEqual(TimeIntervalConfig("54s").seconds, 54)
+        self.assertEqual(TimeIntervalConfig("120s").seconds, 120)
+        self.assertEqual(TimeIntervalConfig("2m").seconds, 120)
+        self.assertEqual(TimeIntervalConfig("1h").seconds, 3600)
+        self.assertAlmostEqual(TimeIntervalConfig("15m").hours, 0.25)
+        self.assertAlmostEqual(TimeIntervalConfig("15m").minutes, 15)
+        self.assertAlmostEqual(TimeIntervalConfig("1h").minutes, 60)

--- a/tests/tests_unit/test_configtools.py
+++ b/tests/tests_unit/test_configtools.py
@@ -351,6 +351,8 @@ class TestConfigtoolsMethods(unittest.TestCase):
             logger=LoggingConfig(console=None, file=None, metrics=None),
         )
         yaml.emitter.Emitter.process_tag = lambda self, *args, **kwargs: None
+        yaml.add_representer(TimeIntervalConfig, lambda dump, data: dump.represent_scalar("!timeinterval", str(data)))
+
         with open("test_dump_config.yml", "w") as config_file:
             yaml.dump(dataclasses.asdict(config), config_file)
         with open("test_dump_config.yml", "r") as config_file:


### PR DESCRIPTION
Let time intervals be configurable as `2m`, `30s` and so on. Implement
a simple parser that converts the number into seconds, and include
calculations to other common units.