### PR TITLE
Gracefully handle wrongful data in state stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changes are grouped as follows
 
  * A few type hints in retry module were more restrictive than needed (such as 
    requiring `int` when `float` would work).
+ * Gracefully handle wrongful data in state stores. If JSON parsing fails, use
+   an empty state store as default.
 
 
 ## [2.1.3] - 2022-03-07

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -153,7 +153,11 @@ class Extractor(Generic[CustomConfigClass]):
         else:
             self.state_store = LocalStateStore("states.json") if self.use_default_state_store else NoStateStore()
 
-        self.state_store.initialize()
+        try:
+            self.state_store.initialize()
+        except ValueError as e:
+            self.logger.exception("Could not load state store, using an empty state store as default")
+
         Extractor._statestore_singleton = self.state_store
 
     def _report_success(self) -> None:
@@ -226,8 +230,6 @@ class Extractor(Generic[CustomConfigClass]):
             self.config.metrics.start_pushers(self.cognite_client)
         except AttributeError:
             pass
-
-        self.state_store.initialize()
 
         def heartbeat_loop():
             while not self.cancelation_token.is_set():

--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -465,6 +465,8 @@ class LocalStateStore(AbstractStateStore):
                     self._local_state = json.load(f)
             except FileNotFoundError:
                 pass
+            except json.decoder.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in state store file: {str(e)}") from e
 
         self._initialized = True
 

--- a/tests/tests_unit/test_statestore.py
+++ b/tests/tests_unit/test_statestore.py
@@ -300,3 +300,16 @@ class TestLocalStateStore(unittest.TestCase):
         new_state_store.stop()
 
         os.remove(filename)
+
+    def test_invalid_file(self):
+        filename = "testfile-invalid.json"
+        try:
+            os.remove(filename)
+        except FileNotFoundError:
+            pass
+
+        with open(filename, "w") as f:
+            f.write("Not json :(")
+
+        with self.assertRaises(ValueError):
+            LocalStateStore(filename).initialize()


### PR DESCRIPTION
If JSON parsing fails, use an empty state store as default.