### PR TITLE
Improve error messages from invalid configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
     -   id: isort
         additional_dependencies: [toml]
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -26,6 +26,7 @@ from cognite.client.data_classes import ExtractionPipeline, ExtractionPipelineRu
 from dotenv import find_dotenv, load_dotenv
 
 from cognite.extractorutils.configtools import BaseConfig, CustomConfigClass, StateStoreConfig, load_yaml
+from cognite.extractorutils.exceptions import InvalidConfigError
 from cognite.extractorutils.metrics import BaseMetrics
 from cognite.extractorutils.statestore import AbstractStateStore, LocalStateStore, NoStateStore
 from cognite.extractorutils.util import set_event_on_interrupt
@@ -204,7 +205,12 @@ class Extractor(Generic[CustomConfigClass]):
         else:
             dotenv_message = "No .env file found"
 
-        self._load_config(override_path=self.config_file_path)
+        try:
+            self._load_config(override_path=self.config_file_path)
+        except InvalidConfigError as e:
+            print("Critical error: Could not read config file", file=sys.stderr)
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
 
         if not self.configured_logger:
             self.config.logger.setup_logging()

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -94,13 +94,14 @@ from enum import Enum
 from logging.handlers import TimedRotatingFileHandler
 from threading import Event
 from time import sleep
-from typing import Any, Dict, List, Optional, T, TextIO, Type, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Optional, T, TextIO, Type, TypeVar, Union
 from urllib.parse import urljoin
 
 import dacite
 import yaml
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Asset, DataSet, ExtractionPipeline
+from yaml.scanner import ScannerError
 
 from .authentication import AuthenticatorConfig
 from .exceptions import InvalidConfigError
@@ -517,9 +518,6 @@ def load_yaml(
         expanded_value = os.path.expandvars(node.value)
         return bool_values.get(expanded_value.lower(), expanded_value)
 
-    class EnvLoader:
-        pass
-
     class EnvLoader(yaml.SafeLoader):
         pass
 
@@ -529,7 +527,13 @@ def load_yaml(
     loader = EnvLoader if expand_envvars else yaml.SafeLoader
 
     # Safe to use load instead of safe_load since both loader classes are based on SafeLoader
-    config_dict = yaml.load(source, Loader=loader)
+    try:
+        config_dict = yaml.load(source, Loader=loader)
+    except ScannerError as e:
+        location = e.problem_mark or e.context_mark
+        formatted_location = f" at line {location.line+1}, column {location.column+1}" if location is not None else ""
+        cause = e.problem or e.context
+        raise InvalidConfigError(f"Invalid YAML{formatted_location}: {cause or ''}") from e
 
     config_dict = _to_snake_case(config_dict, case_style)
 
@@ -537,8 +541,28 @@ def load_yaml(
         config = dacite.from_dict(
             data=config_dict, data_class=config_type, config=dacite.Config(strict=True, cast=[Enum])
         )
-    except (dacite.WrongTypeError, dacite.MissingValueError, dacite.UnionMatchError, dacite.UnexpectedDataError) as e:
-        raise InvalidConfigError(str(e))
+    except dacite.UnexpectedDataError as e:
+        unknowns = [f'"{k.replace("_", "-") if case_style == "hyphen" else k}"' for k in e.keys]
+        raise InvalidConfigError(f"Unknown config parameter{'s' if len(unknowns) > 1 else ''} {', '.join(unknowns)}")
+
+    except (dacite.WrongTypeError, dacite.MissingValueError, dacite.UnionMatchError) as e:
+        path = e.field_path.replace("_", "-") if case_style == "hyphen" else e.field_path
+
+        def name(type_: Type) -> str:
+            return type_.__name__ if hasattr(type_, "__name__") else str(type_)
+
+        def all_types(type_: Type) -> Iterable[Type]:
+            return type_.__args__ if hasattr(type_, "__args__") else [type_]
+
+        if isinstance(e, (dacite.WrongTypeError, dacite.UnionMatchError)) and e.value is not None:
+            got_type = name(type(e.value))
+            need_type = ", ".join(name(t) for t in all_types(e.field_type))
+
+            raise InvalidConfigError(
+                f'Wrong type for field "{path}" - got "{e.value}" of type {got_type} instead of {need_type}'
+            )
+        raise InvalidConfigError(f'Missing mandatory field "{path}"')
+
     except dacite.ForwardReferenceError as e:
         raise ValueError(f"Invalid config class: {str(e)}")
 


### PR DESCRIPTION
Improve the exception messages generated in load_yaml. Instead of just
wrapping in an InvalidConfigError, make a custom error message. Handle
these error messages better in the base extractor class.

Some examples of new error messages:

```
$ poetry run python test.py test.yaml
Critical error: Could not read config file
Invalid config: Wrong type for field "source.test-number" - got "123"
of type str instead of int

$ poetry run python test.py test.yaml
Critical error: Could not read config file
Invalid config: Wrong type for field "source.test-number" - got "123"
of type str instead of int, float

$ poetry run python test.py test.yaml
Critical error: Could not read config file
Invalid config: Invalid YAML at line 22, column 21: mapping values are
not allowed here

$ poetry run python test.py test.yaml
Critical error: Could not read config file
Invalid config: Missing mandatory field "source"

$ poetry run python test.py test.yaml
Critical error: Could not read config file
Invalid config: Unknown config parameter "invalid-field"
```