### PR TITLE
Catch errors in heartbeat

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "2.3.0-beta1"
+__version__ = "2.3.0-beta2"
 from .base import Extractor

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -286,9 +286,12 @@ class Extractor(Generic[CustomConfigClass]):
 
                 if not self.cancelation_token.is_set():
                     self.logger.info("Reporting new heartbeat")
-                    self.cognite_client.extraction_pipeline_runs.create(
-                        ExtractionPipelineRun(external_id=self.extraction_pipeline.external_id, status="seen")
-                    )
+                    try:
+                        self.cognite_client.extraction_pipeline_runs.create(
+                            ExtractionPipelineRun(external_id=self.extraction_pipeline.external_id, status="seen")
+                        )
+                    except e:
+                        self.logger.error("Failed to report heartbeat: %s", str(e))
 
         if self.extraction_pipeline:
             self.logger.info("Starting heartbeat loop")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "2.3.0-beta1"
+version = "2.3.0-beta2"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The extractor losing connection to CDF is no reason to kill the heartbeat, it may well be designed to handle it.