### PR TITLE
Skip _file_hash in base config init

### DIFF
--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "2.3.0-beta2"
+__version__ = "2.3.0-beta3"
 from .base import Extractor

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -91,7 +91,7 @@ import os
 import re
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from hashlib import sha256
 from logging.handlers import TimedRotatingFileHandler
@@ -438,7 +438,7 @@ class ConfigType(Enum):
 
 @dataclass
 class _BaseConfig:
-    _file_hash: Optional[str]
+    _file_hash: Optional[str] = field(init=False, repr=False)
 
     type: Optional[ConfigType]
     cognite: CogniteConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "2.3.0-beta2"
+version = "2.3.0-beta3"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
It's a private field and should not be required in init, or returned when serializing.