### PR TITLE
Fix 'cancelation_token' typo throughout codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-
 ## Next
+
+### Fixed
+
+ * Fixed a typo throughout the library, `cancelation_token` is now called
+   `cancellation_token` everywhere. If you ever e.g. specify a cancellation
+   token in a keyword argument, make sure to update the spelling.
 
 ### Changed
 
@@ -46,9 +51,28 @@ Changes are grouped as follows
    )
    ```
 
+### Migration guide
+
+In order to update from version 3 to version 4, you need to:
+
+ * Change `cancelation_token` to `cancellation_token` every time you pass one as
+   a keyword argument (or read from an attribute)
+ * Access the `seconds` attribute from any time values you read from the default
+   config (such as `upload_interval`s or `timeout`s)
+ * Consider updating any time value you have in your own config parameters to be
+   of `TimeIntervalConfig` instead of `int` to allow users the option of
+   configuring time values in a human-readable format.
+
+A type checker, like mypy, will be able to detect any breaking changes this
+update introduces. We highly reccomend scanning your code with a type checker.
+
+Updating from version 3 to 4 should not introduce breaking changes to your
+extractor.
 
 ## [3.2.0]
+
 ### Added
+
  * Decorator which adds extraction pipeline functionality
 
 ## [3.1.4]

--- a/cognite/extractorutils/configtools.py
+++ b/cognite/extractorutils/configtools.py
@@ -445,7 +445,7 @@ class MetricsConfig:
     cognite: Optional[_CogniteMetricsConfig]
     server: Optional[_PromServerConfig]
 
-    def start_pushers(self, cdf_client: CogniteClient, cancelation_token: Event = Event()) -> None:
+    def start_pushers(self, cdf_client: CogniteClient, cancellation_token: Event = Event()) -> None:
         self._pushers: List[AbstractMetricsPusher] = []
         self._clear_on_stop: Dict[PrometheusPusher, int] = {}
 
@@ -459,7 +459,7 @@ class MetricsConfig:
                 url=push_gateway.host,
                 push_interval=push_gateway.push_interval.seconds,
                 thread_name=f"MetricsPusher_{counter}",
-                cancelation_token=cancelation_token,
+                cancellation_token=cancellation_token,
             )
 
             pusher.start()
@@ -479,7 +479,7 @@ class MetricsConfig:
                 push_interval=self.cognite.push_interval.seconds,
                 asset=asset,
                 thread_name="CogniteMetricsPusher",  # There is only one Cognite project as a target
-                cancelation_token=cancelation_token,
+                cancellation_token=cancellation_token,
             )
 
             pusher.start()

--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -166,18 +166,21 @@ class AbstractMetricsPusher(ABC):
     Args:
         push_interval: Seconds between each upload call
         thread_name: Name of thread to start. If omitted, a standard name such as Thread-4 will be generated.
-        cancelation_token: Event object to be used as a thread cancelation event
+        cancellation_token: Event object to be used as a thread cancelation event
     """
 
     def __init__(
-        self, push_interval: Optional[int] = None, thread_name: Optional[str] = None, cancelation_token: Event = Event()
+        self,
+        push_interval: Optional[int] = None,
+        thread_name: Optional[str] = None,
+        cancellation_token: Event = Event(),
     ):
         self.push_interval = push_interval
         self.thread_name = thread_name
 
         self.thread: Optional[threading.Thread] = None
         self.thread_name = thread_name
-        self.cancelation_token = cancelation_token
+        self.cancellation_token = cancellation_token
 
         self.logger = logging.getLogger(__name__)
 
@@ -192,16 +195,16 @@ class AbstractMetricsPusher(ABC):
         """
         Run push loop.
         """
-        while not self.cancelation_token.is_set():
+        while not self.cancellation_token.is_set():
             self._push_to_server()
-            self.cancelation_token.wait(self.push_interval)
+            self.cancellation_token.wait(self.push_interval)
 
     def start(self) -> None:
         """
         Starts a thread that pushes the default registry to the configured gateway at certain intervals.
 
         """
-        self.cancelation_token.clear()
+        self.cancellation_token.clear()
         self.thread = threading.Thread(target=self._run, daemon=True, name=self.thread_name)
         self.thread.start()
 
@@ -211,7 +214,7 @@ class AbstractMetricsPusher(ABC):
         """
         # Make sure everything is pushed
         self._push_to_server()
-        self.cancelation_token.set()
+        self.cancellation_token.set()
 
     def __enter__(self) -> "AbstractMetricsPusher":
         """
@@ -246,7 +249,7 @@ class PrometheusPusher(AbstractMetricsPusher):
         url: URL (with portnum) of push gateway
         push_interval: Seconds between each upload call
         thread_name: Name of thread to start. If omitted, a standard name such as Thread-4 will be generated.
-        cancelation_token: Event object to be used as a thread cancelation event
+        cancellation_token: Event object to be used as a thread cancelation event
     """
 
     def __init__(
@@ -257,9 +260,9 @@ class PrometheusPusher(AbstractMetricsPusher):
         username: Optional[str] = None,
         password: Optional[str] = None,
         thread_name: Optional[str] = None,
-        cancelation_token: Event = Event(),
+        cancellation_token: Event = Event(),
     ):
-        super(PrometheusPusher, self).__init__(push_interval, thread_name, cancelation_token)
+        super(PrometheusPusher, self).__init__(push_interval, thread_name, cancellation_token)
 
         self.username = username
         self.job_name = job_name
@@ -321,7 +324,7 @@ class CognitePusher(AbstractMetricsPusher):
         push_interval: Seconds between each upload call
         asset: Optional contextualization.
         thread_name: Name of thread to start. If omitted, a standard name such as Thread-4 will be generated.
-        cancelation_token: Event object to be used as a thread cancelation event
+        cancellation_token: Event object to be used as a thread cancelation event
     """
 
     def __init__(
@@ -331,9 +334,9 @@ class CognitePusher(AbstractMetricsPusher):
         push_interval: int,
         asset: Optional[Asset] = None,
         thread_name: Optional[str] = None,
-        cancelation_token: Event = Event(),
+        cancellation_token: Event = Event(),
     ):
-        super(CognitePusher, self).__init__(push_interval, thread_name, cancelation_token)
+        super(CognitePusher, self).__init__(push_interval, thread_name, cancellation_token)
 
         self.cdf_client = cdf_client
         self.asset = asset

--- a/cognite/extractorutils/retry.py
+++ b/cognite/extractorutils/retry.py
@@ -11,7 +11,7 @@ logging_logger = logging.getLogger(__name__)
 
 def _retry_internal(
     f,
-    cancelation_token: threading.Event = threading.Event(),
+    cancellation_token: threading.Event = threading.Event(),
     exceptions: Iterable[Type[Exception]] = Exception,
     tries: int = -1,
     delay: float = 0,
@@ -21,7 +21,7 @@ def _retry_internal(
     logger: logging.Logger = logging_logger,
 ):
     _tries, _delay = tries, delay
-    while _tries and not cancelation_token.is_set():
+    while _tries and not cancellation_token.is_set():
         try:
             return f()
         except exceptions as e:
@@ -32,7 +32,7 @@ def _retry_internal(
             if logger is not None:
                 logger.warning("%s, retrying in %s seconds...", e, _delay)
 
-            cancelation_token.wait(_delay)
+            cancellation_token.wait(_delay)
             _delay *= backoff
 
             if isinstance(jitter, tuple):
@@ -45,7 +45,7 @@ def _retry_internal(
 
 
 def retry(
-    cancelation_token: threading.Event = threading.Event(),
+    cancellation_token: threading.Event = threading.Event(),
     exceptions: Iterable[Type[Exception]] = Exception,
     tries: int = -1,
     delay: float = 0,
@@ -59,7 +59,7 @@ def retry(
     This is adapted from https://github.com/invl/retry
 
     Args:
-        cancelation_token: a threading token that is waited on.
+        cancellation_token: a threading token that is waited on.
         exceptions: an exception or a tuple of exceptions to catch. default: Exception.
         tries: the maximum number of attempts. default: -1 (infinite).
         delay: initial delay between attempts. default: 0.
@@ -77,7 +77,15 @@ def retry(
         kwargs = fkwargs if fkwargs else dict()
 
         return _retry_internal(
-            partial(f, *args, **kwargs), cancelation_token, exceptions, tries, delay, max_delay, backoff, jitter, logger
+            partial(f, *args, **kwargs),
+            cancellation_token,
+            exceptions,
+            tries,
+            delay,
+            max_delay,
+            backoff,
+            jitter,
+            logger,
         )
 
     return retry_decorator

--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -116,7 +116,7 @@ class AbstractStateStore(ABC):
             methods).
         trigger_log_level: Log level to log synchronize triggers to.
         thread_name: Thread name of synchronize thread.
-        cancelation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
+        cancellation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
     """
 
     def __init__(
@@ -124,7 +124,7 @@ class AbstractStateStore(ABC):
         save_interval: Optional[int] = None,
         trigger_log_level: str = "DEBUG",
         thread_name: Optional[str] = None,
-        cancelation_token: threading.Event = threading.Event(),
+        cancellation_token: threading.Event = threading.Event(),
     ):
         self._initialized = False
         self._local_state: Dict[str, Dict[str, Any]] = {}
@@ -135,7 +135,7 @@ class AbstractStateStore(ABC):
 
         self.thread = threading.Thread(target=self._run, daemon=True, name=thread_name)
         self.lock = threading.RLock()
-        self.cancelation_token: threading.Event = cancelation_token
+        self.cancellation_token: threading.Event = cancellation_token
 
         self._deleted: List[str] = []
 
@@ -147,7 +147,7 @@ class AbstractStateStore(ABC):
         This calls the synchronize method every save_interval seconds.
         """
         if self.save_interval is not None:
-            self.cancelation_token.clear()
+            self.cancellation_token.clear()
             self.thread.start()
 
     def stop(self, ensure_synchronize: bool = True) -> None:
@@ -157,7 +157,7 @@ class AbstractStateStore(ABC):
         Args:
             ensure_synchronize (bool): (Optional). Call synchronize one last time after shutting down thread.
         """
-        self.cancelation_token.set()
+        self.cancellation_token.set()
         if ensure_synchronize:
             self.synchronize()
 
@@ -166,7 +166,7 @@ class AbstractStateStore(ABC):
         Internal run method for synchronize thread
         """
         self.initialize()
-        while not self.cancelation_token.wait(timeout=self.save_interval):
+        while not self.cancellation_token.wait(timeout=self.save_interval):
             try:
                 self.logger.log(self.trigger_log_level, "Triggering scheduled state store synchronization")
                 self.synchronize()
@@ -312,7 +312,7 @@ class RawStateStore(AbstractStateStore):
             methods).
         trigger_log_level: Log level to log synchronize triggers to.
         thread_name: Thread name of synchronize thread.
-        cancelation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
+        cancellation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
     """
 
     def __init__(
@@ -323,9 +323,9 @@ class RawStateStore(AbstractStateStore):
         save_interval: Optional[int] = None,
         trigger_log_level: str = "DEBUG",
         thread_name: Optional[str] = None,
-        cancelation_token: threading.Event = threading.Event(),
+        cancellation_token: threading.Event = threading.Event(),
     ):
-        super().__init__(save_interval, trigger_log_level, thread_name, cancelation_token)
+        super().__init__(save_interval, trigger_log_level, thread_name, cancellation_token)
 
         self._cdf_client = cdf_client
         self.database = database
@@ -434,7 +434,7 @@ class LocalStateStore(AbstractStateStore):
             methods).
         trigger_log_level: Log level to log synchronize triggers to.
         thread_name: Thread name of synchronize thread.
-        cancelation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
+        cancellation_token: Token to cancel event from elsewhere. Cancelled when stop is called.
     """
 
     def __init__(
@@ -443,9 +443,9 @@ class LocalStateStore(AbstractStateStore):
         save_interval: Optional[int] = None,
         trigger_log_level: str = "DEBUG",
         thread_name: Optional[str] = None,
-        cancelation_token: threading.Event = threading.Event(),
+        cancellation_token: threading.Event = threading.Event(),
     ):
-        super().__init__(save_interval, trigger_log_level, thread_name, cancelation_token)
+        super().__init__(save_interval, trigger_log_level, thread_name, cancellation_token)
 
         self._file_path = file_path
 

--- a/cognite/extractorutils/throttle.py
+++ b/cognite/extractorutils/throttle.py
@@ -22,7 +22,7 @@ from time import time
 from typing import Generator
 
 
-def throttled_loop(target_time: int, cancelation_token: Event) -> Generator[None, None, None]:
+def throttled_loop(target_time: int, cancellation_token: Event) -> Generator[None, None, None]:
     """
     A loop generator that automatically sleeps until each iteration has taken the desired amount of time. Useful for
     when you want to avoid overloading a source system with requests.
@@ -37,14 +37,14 @@ def throttled_loop(target_time: int, cancelation_token: Event) -> Generator[None
 
     Args:
         target_time: How long (in seconds) an iteration should take om total
-        cancelation_token: An Event object that will act as the stop event. When set, the loop will stop.
+        cancellation_token: An Event object that will act as the stop event. When set, the loop will stop.
 
     Returns:
         A generator that will only yield when the target iteration time is met
     """
     logger = logging.getLogger(__name__)
 
-    while not cancelation_token.is_set():
+    while not cancellation_token.is_set():
         start_time = time()
         yield
         iteration_time = time() - start_time
@@ -53,4 +53,4 @@ def throttled_loop(target_time: int, cancelation_token: Event) -> Generator[None
 
         else:
             logger.debug(f"Iteration took {iteration_time:.1f} s, sleeping {target_time - iteration_time:.1f} s")
-            cancelation_token.wait(target_time - iteration_time)
+            cancellation_token.wait(target_time - iteration_time)

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -63,7 +63,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         metrics: Metrics collection, a default one with be created if omitted.
         use_default_state_store: Create a simple instance of the LocalStateStore to provide to the run handle. If false
             a NoStateStore will be created in its place.
-        cancelation_token: An event that will be set when the extractor should shut down, an empty one will be created
+        cancellation_token: An event that will be set when the extractor should shut down, an empty one will be created
             if omitted.
         config_file_path: If supplied, the extractor will not use command line arguments to get a config file, but
             rather use the supplied path.
@@ -83,7 +83,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         config_class: Type[UploaderExtractorConfigClass],
         metrics: Optional[BaseMetrics] = None,
         use_default_state_store: bool = True,
-        cancelation_token: Event = Event(),
+        cancellation_token: Event = Event(),
         config_file_path: Optional[str] = None,
         continuous_extractor: bool = False,
         heartbeat_waiting_time: int = 600,
@@ -98,7 +98,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
             config_class=config_class,
             metrics=metrics,
             use_default_state_store=use_default_state_store,
-            cancelation_token=cancelation_token,
+            cancellation_token=cancellation_token,
             config_file_path=config_file_path,
             continuous_extractor=continuous_extractor,
             heartbeat_waiting_time=heartbeat_waiting_time,

--- a/docs/source/remoteconfigs.rst
+++ b/docs/source/remoteconfigs.rst
@@ -45,7 +45,7 @@ with an ``reload_config_action`` enum. The enum can be one of the following valu
   this will have no effect). Be also aware that anything that is set up based
   on the config (upload queues, cognite client objects, loggers, connections to
   source, etc) will not change in this case.
-* ``SHUTDOWN`` will set the ``cancelation_token`` event, and wait for the extractor
+* ``SHUTDOWN`` will set the ``cancellation_token`` event, and wait for the extractor
   to shut down. It is then intended that the service layer running the
   extractor (ie, windows services, systemd, docker, etc) will be configured to
   always restart the service if it shuts down. This is the recomended approach

--- a/tests/tests_unit/test_statestore.py
+++ b/tests/tests_unit/test_statestore.py
@@ -283,7 +283,7 @@ class TestLocalStateStore(unittest.TestCase):
 
         state_store.start()
 
-        time.sleep(1.5)
+        time.sleep(3)
 
         state_store.stop()
 


### PR DESCRIPTION
We had a typo where we asked for `cancelation_token` instead of
`cancellation_token`. Changing this is breaking, but since we are
breaking with the human readable time configs anyway, I want to make
this change too.