### PR TITLE
Fix an issue with how we catch errors while reporting heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.0.1]
+
+### Fixed
+
+ * Fixed a bug in the error handling for reporting heartbeats.
+
 ## [4.0.0]
 
 ### Added

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 from .base import Extractor

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -294,8 +294,8 @@ class Extractor(Generic[CustomConfigClass]):
                         self.cognite_client.extraction_pipelines.runs.create(
                             ExtractionPipelineRun(external_id=self.extraction_pipeline.external_id, status="seen")
                         )
-                    except e:
-                        self.logger.error("Failed to report heartbeat: %s", str(e))
+                    except Exception:
+                        self.logger.exception("Failed to report heartbeat")
 
         if self.extraction_pipeline:
             self.logger.info("Starting heartbeat loop")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "4.0.0"
+version = "4.0.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Reported by a user, they received

```
...

During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/layers/google.python.runtime/python/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/layers/google.python.runtime/python/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/cognite/extractorutils/base.py", line 293, in heartbeat_loop
    except e:
NameError: free variable 'e' referenced before assignment in enclosing scope
```

which this should fix.