### PR TITLE
Update raw queue sizes for uploader extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.3.1]
+
+### Changed 
+
+ * Default size of RAW queues is now 50 000 for `UploaderExtractor`s as well.
+
 ## [4.3.0]
 
 ### Added

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 from .base import Extractor

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -34,7 +34,7 @@ from cognite.extractorutils.uploader_types import CdfTypes, Event, InsertDatapoi
 @dataclass
 class QueueConfigClass:
     event_size: int = 10_000
-    raw_size: int = 100_000
+    raw_size: int = 50_000
     timeseries_size: int = 1_000_000
     upload_interval: TimeIntervalConfig = TimeIntervalConfig("1m")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "4.3.0"
+version = "4.3.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This change was made for db extractor etc before, but was missed here