### PR TITLE
Update Cognite SDK to version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Changes are grouped as follows
    This has first and foremost been done to improve the codebase and make it
    easier to continue to develop.
 
+ * Updated the version of the Cognite SDK to version 6. Refer to the
+   [changelog](https://github.com/cognitedata/cognite-sdk-python/blob/master/CHANGELOG.md#600---19-04-23)
+   and [migration
+   guide](https://github.com/cognitedata/cognite-sdk-python/blob/master/MIGRATION_GUIDE.md#from-v5-to-v6)
+   for the SDK for details on the changes it entails for users.
+
 ## [4.3.1]
 
 ### Changed 
@@ -182,7 +188,8 @@ extractor.
 
 ### Added
 
- * Support for exposing prometheus metrics on a local port instead of pushing to pushgateway
+ * Support for exposing prometheus metrics on a local port instead of pushing to
+   pushgateway
 
 ## [3.0.2]
 
@@ -194,7 +201,8 @@ extractor.
 
 ### Fixed
  
- * Correctly do not request the experimental SDK  when using remote configuration files
+ * Correctly do not request the experimental SDK  when using remote
+   configuration files
 
 ## [3.0.0]
 
@@ -202,7 +210,8 @@ extractor.
 
  * `SequenceUploadQueue`'s `create_missing` funtionality can now be used to set
    Name and Description values on newly created sequences.
- * Remote configuration files is now fully released and supported without using the experimental SDK.
+ * Remote configuration files is now fully released and supported without using
+   the experimental SDK.
 
 ### Fixed
 
@@ -213,13 +222,15 @@ extractor.
 
 ### Added
 
- * Option to set data set id when creating missing time series in the time series upload queue.
+ * Option to set data set id when creating missing time series in the time
+   series upload queue.
 
 ## [3.0.0-beta2]
 
 ### Changed
 
- * Update cognite-sdk to version 4.0.1, which removes the support for reserved environment variables such as `COGNITE_API_KEY` and `COGNITE_CLIENT_ID`.
+ * Update cognite-sdk to version 4.0.1, which removes the support for reserved
+   environment variables such as `COGNITE_API_KEY` and `COGNITE_CLIENT_ID`.
 
 ## [3.0.0-beta]
 

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -206,7 +206,9 @@ class Extractor(Generic[CustomConfigClass]):
             self.logger.info("Reporting new successful run")
             self.cognite_client.extraction_pipelines.runs.create(
                 ExtractionPipelineRun(
-                    external_id=self.extraction_pipeline.external_id, status="success", message="Successful shutdown"
+                    extpipe_external_id=self.extraction_pipeline.external_id,
+                    status="success",
+                    message="Successful shutdown",
                 )
             )
 
@@ -226,7 +228,7 @@ class Extractor(Generic[CustomConfigClass]):
             self.logger.info(f"Reporting new failed run: {message}")
             self.cognite_client.extraction_pipelines.runs.create(
                 ExtractionPipelineRun(
-                    external_id=self.extraction_pipeline.external_id, status="failure", message=message
+                    extpipe_external_id=self.extraction_pipeline.external_id, status="failure", message=message
                 )
             )
 
@@ -286,7 +288,9 @@ class Extractor(Generic[CustomConfigClass]):
                     self.logger.info("Reporting new heartbeat")
                     try:
                         self.cognite_client.extraction_pipelines.runs.create(
-                            ExtractionPipelineRun(external_id=self.extraction_pipeline.external_id, status="seen")
+                            ExtractionPipelineRun(
+                                extpipe_external_id=self.extraction_pipeline.external_id, status="seen"
+                            )
                         )
                     except Exception:
                         self.logger.exception("Failed to report heartbeat")
@@ -300,7 +304,7 @@ class Extractor(Generic[CustomConfigClass]):
         if self.extraction_pipeline and self.continuous_extractor:
             self.cognite_client.extraction_pipelines.runs.create(
                 ExtractionPipelineRun(
-                    external_id=self.extraction_pipeline.external_id,
+                    extpipe_external_id=self.extraction_pipeline.external_id,
                     status="success",
                     message=f"New startup of {self.name}",
                 )

--- a/cognite/extractorutils/extraction_pipelines.py
+++ b/cognite/extractorutils/extraction_pipelines.py
@@ -49,8 +49,6 @@ def add_extraction_pipeline(
 
     # TODO 1. Consider refactoring this decorator to share methods with the Extractor context manager in .base.py
     # as they serve a similar purpose
-    # TODO 2. Change 'cognite_client.extraction_pipeline_runs' -> 'cognite_client.extraction_pipelines.runs'
-    # when Cognite SDK is updated
 
     cancellation_token: Event = Event()
 
@@ -66,8 +64,10 @@ def add_extraction_pipeline(
 
             def _report_success() -> None:
                 message = f"Successful shutdown of function '{input_function.__name__}'. {added_message}"
-                cognite_client.extraction_pipeline_runs.create(  # cognite_client.extraction_pipelines.runs.create(
-                    ExtractionPipelineRun(external_id=extraction_pipeline_ext_id, status="success", message=message)
+                cognite_client.extraction_pipelines.runs.create(  # cognite_client.extraction_pipelines.runs.create(
+                    ExtractionPipelineRun(
+                        extpipe_external_id=extraction_pipeline_ext_id, status="success", message=message
+                    )
                 )
 
             def _report_error(exception: Exception) -> None:
@@ -77,14 +77,16 @@ def add_extraction_pipeline(
                 message = (
                     f"Exception for function '{input_function.__name__}'. {added_message}:\n" f"{str(exception)[:1000]}"
                 )
-                cognite_client.extraction_pipeline_runs.create(
-                    ExtractionPipelineRun(external_id=extraction_pipeline_ext_id, status="failure", message=message)
+                cognite_client.extraction_pipelines.runs.create(
+                    ExtractionPipelineRun(
+                        extpipe_external_id=extraction_pipeline_ext_id, status="failure", message=message
+                    )
                 )
 
             def heartbeat_loop() -> None:
                 while not cancellation_token.is_set():
-                    cognite_client.extraction_pipeline_runs.create(
-                        ExtractionPipelineRun(external_id=extraction_pipeline_ext_id, status="seen")
+                    cognite_client.extraction_pipelines.runs.create(
+                        ExtractionPipelineRun(extpipe_external_id=extraction_pipeline_ext_id, status="seen")
                     )
 
                     cancellation_token.wait(heartbeat_waiting_time)

--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -396,5 +396,5 @@ class CognitePusher(AbstractMetricsPusher):
                 external_id = self.external_id_prefix + metric.name
                 datapoints.append({"externalId": external_id, "datapoints": [(timestamp, metric.samples[0].value)]})
 
-        self.cdf_client.datapoints.insert_multiple(datapoints)
+        self.cdf_client.time_series.data.insert_multiple(datapoints)
         self.logger.debug("Pushed metrics to CDF tenant '%s'", self._cdf_project)

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -242,7 +242,7 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
             return upload_this
 
         try:
-            self.cdf_client.datapoints.insert_multiple(upload_this)
+            self.cdf_client.time_series.data.insert_multiple(upload_this)
 
         except CogniteNotFoundError as ex:
             if not retries:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ known_third_party = ["arrow", "cryptography", "dacite", "decorator", "dotenv", "
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-cognite-sdk = ">=5.8, <6"
+cognite-sdk = ">=6.0, <7"
 prometheus-client = ">0.7.0, <=1.0.0"
 arrow = "^1.0.0"
 pyyaml = ">=5.3.0, <7"
@@ -35,7 +35,6 @@ decorator = "^5.1.1"
 more-itertools = "^9.0.0"
 typing-extensions = ">=3.7.4, <5"
 python-dotenv = "^1.0.0"
-cognite-sdk-experimental = {version = "^0.110.0", optional = true}
 jq = [{version = "^1.3.0", platform = "macos"}, {version = "^1.3.0", platform = "linux"}]
 
 [tool.poetry.extras]

--- a/tests/tests_integration/test_cdf_upload_integration.py
+++ b/tests/tests_integration/test_cdf_upload_integration.py
@@ -143,10 +143,10 @@ class IntegrationTests(unittest.TestCase):
 
         time.sleep(30)
 
-        recv_points1 = self.client.datapoints.retrieve(
+        recv_points1 = self.client.time_series.data.retrieve(
             external_id=self.time_series1, start="1w-ago", end="now", limit=None
         )
-        recv_points2 = self.client.datapoints.retrieve(
+        recv_points2 = self.client.time_series.data.retrieve(
             external_id=self.time_series2, start="1w-ago", end="now", limit=None
         )
 
@@ -173,7 +173,7 @@ class IntegrationTests(unittest.TestCase):
 
         time.sleep(20)
 
-        recv_points1 = self.client.datapoints.retrieve(
+        recv_points1 = self.client.time_series.data.retrieve(
             external_id=self.time_series1, start="1w-ago", end="now", limit=None
         )
 
@@ -205,9 +205,9 @@ class IntegrationTests(unittest.TestCase):
         queue.upload()
         time.sleep(3)
 
-        recv_points1 = self.client.datapoints.retrieve(external_id=id1, start="1w-ago", end="now", limit=None)
-        recv_points2 = self.client.datapoints.retrieve(external_id=id2, start="1w-ago", end="now", limit=None)
-        recv_points3 = self.client.datapoints.retrieve(external_id=id3, start="1w-ago", end="now", limit=None)
+        recv_points1 = self.client.time_series.data.retrieve(external_id=id1, start="1w-ago", end="now", limit=None)
+        recv_points2 = self.client.time_series.data.retrieve(external_id=id2, start="1w-ago", end="now", limit=None)
+        recv_points3 = self.client.time_series.data.retrieve(external_id=id3, start="1w-ago", end="now", limit=None)
 
         self.assertListEqual([int(p) for p in recv_points1.value], [p[1] for p in points1])
         self.assertListEqual([p for p in recv_points2.value], [p[1] for p in points2])

--- a/tests/tests_unit/test_cdf_upload_queues.py
+++ b/tests/tests_unit/test_cdf_upload_queues.py
@@ -87,9 +87,9 @@ class TestUploadQueue(unittest.TestCase):
         queue.add_to_upload_queue(id=1, datapoints=[(start + 5, 5), (start + 6, 6)])
         queue.add_to_upload_queue(id=3, datapoints=[(start + 7, 7), (start + 8, 8)])
 
-        client.datapoints.insert_multiple.assert_not_called()
+        client.time_series.data.insert_multiple.assert_not_called()
         queue.upload()
-        client.datapoints.insert_multiple.assert_called_with(
+        client.time_series.data.insert_multiple.assert_called_with(
             [
                 {"id": 1, "datapoints": [(start + 1, 1), (start + 2, 2), (start + 5, 5), (start + 6, 6)]},
                 {"id": 2, "datapoints": [(start + 3, 3), (start + 4, 4)]},
@@ -118,7 +118,7 @@ class TestUploadQueue(unittest.TestCase):
 
         time.sleep(2.1)
 
-        client.datapoints.insert_multiple.assert_called_with(
+        client.time_series.data.insert_multiple.assert_called_with(
             [
                 {"id": 1, "datapoints": [(start + 1, 1), (start + 2, 2), (start + 5, 5), (start + 6, 6)]},
                 {"id": 2, "datapoints": [(start + 3, 3), (start + 4, 4)]},
@@ -156,7 +156,7 @@ class TestUploadQueue(unittest.TestCase):
 
         time.sleep(2.1)
 
-        client.datapoints.insert_multiple.assert_called_with(
+        client.time_series.data.insert_multiple.assert_called_with(
             [
                 {"id": 1, "datapoints": [(start + 1, 1), (start + 2, 2), (start + 5, 5), (start + 6, 6)]},
                 {"id": 2, "datapoints": [(start + 3, 3), (start + 4, 4)]},

--- a/tests/tests_unit/test_extraction_pipelines.py
+++ b/tests/tests_unit/test_extraction_pipelines.py
@@ -35,8 +35,8 @@ class TestExtractionPipelines(unittest.TestCase):
 
             test_success()
 
-            print(f"{self.m_client.extraction_pipeline_runs.create.call_count=}")
-            self.assertEqual(self.m_client.extraction_pipeline_runs.create.call_count, 2)
+            print(f"{self.m_client.extraction_pipelines.runs.create.call_count=}")
+            self.assertEqual(self.m_client.extraction_pipelines.runs.create.call_count, 2)
 
     with monkeypatch_cognite_client() as m2_client:
 
@@ -66,8 +66,8 @@ class TestExtractionPipelines(unittest.TestCase):
 
             test_success_2()
 
-            print(f"{self.m3_client.extraction_pipeline_runs.create.call_count=}")
-            self.assertEqual(self.m3_client.extraction_pipeline_runs.create.call_count, 3)
+            print(f"{self.m3_client.extraction_pipelines.runs.create.call_count=}")
+            self.assertEqual(self.m3_client.extraction_pipelines.runs.create.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/tests/tests_unit/test_metrics.py
+++ b/tests/tests_unit/test_metrics.py
@@ -169,8 +169,8 @@ class TestCognitePusher(unittest.TestCase):
         TestCognitePusher.gauge.set(5)
         pusher._push_to_server()
 
-        self.client.datapoints.insert_multiple.assert_called_once()
-        args = self.client.datapoints.insert_multiple.call_args_list[0][0][0][-1]
+        self.client.time_series.data.insert_multiple.assert_called_once()
+        args = self.client.time_series.data.insert_multiple.call_args_list[0][0][0][-1]
 
         timestamp = int(arrow.get().float_timestamp * 1000)
         self.assertEqual(args["externalId"], "pre_gauge")

--- a/tests/tests_unit/test_uploader_extractor.py
+++ b/tests/tests_unit/test_uploader_extractor.py
@@ -100,7 +100,7 @@ class TestUploaderExtractorClass(unittest.TestCase):
         ex.handle_output(ts)
 
         ex.time_series_queue.upload()
-        client.datapoints.insert_multiple.assert_called_with(
+        client.time_series.data.insert_multiple.assert_called_with(
             [
                 {"externalId": "some-id", "datapoints": ts.datapoints},
             ]
@@ -113,7 +113,7 @@ class TestUploaderExtractorClass(unittest.TestCase):
         ex.handle_output(tss)
 
         ex.time_series_queue.upload()
-        client.datapoints.insert_multiple.assert_called_with(
+        client.time_series.data.insert_multiple.assert_called_with(
             [
                 {"externalId": "some-id", "datapoints": tss[0].datapoints},
                 {"externalId": "some-other-id", "datapoints": tss[1].datapoints},


### PR DESCRIPTION
This should be considered breaking, as there are several breaking changes in the SDK, among other things relating to extraction pipelines and writing time series data.

Many extractors projects, including those set up by `cogex` will not have a direct dependency to the SDK but only a transient one through the utils.