### PR TITLE
docs: fix reference to global_config to connection in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes are grouped as follows
 
 ### Added
 
- * Support for `global_config` parameters
+ * Support for `connection` parameters
 
 ## [5.0.1]
 

--- a/docs/source/configs.rst
+++ b/docs/source/configs.rst
@@ -49,7 +49,7 @@ This means that our users can now configure the extractor like so:
         scopes:
           - ${COGNITE_BASE_URL}/.default
 
-      global-config:
+      connection:
         disable-ssl: False
 
     logging:

--- a/schema/cognite_config.schema.json
+++ b/schema/cognite_config.schema.json
@@ -148,7 +148,7 @@
                     "description": "Dictionary mapping from protocol to url.",
                     "items": {
                         "type": "string",
-                        "description": "A scope requested for the token"
+                        "description": "Provide protocol as key and value as the corresponding url"
                     }
                 }
             }


### PR DESCRIPTION
Noticed a few doc updates I missed fixing when switching to use `connection` instead of `global_config`