### PR TITLE
Upsert events in upload queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.2.0]
+
+### Changed
+ 
+ * The event upload queue now upserts events. If creating an event fails due
+   to the event already existing, it will be updated instead.
 
 ## [5.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes are grouped as follows
 ## [5.2.0]
 
 ### Changed
- 
+
  * The event upload queue now upserts events. If creating an event fails due
    to the event already existing, it will be updated instead.
 

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 from .base import Extractor

--- a/cognite/extractorutils/uploader/events.py
+++ b/cognite/extractorutils/uploader/events.py
@@ -14,7 +14,7 @@
 
 import threading
 from types import TracebackType
-from typing import Callable, List, Optional, Set, Type
+from typing import Callable, List, Optional, Type
 
 import arrow
 from requests import ConnectionError
@@ -137,20 +137,18 @@ class EventUploadQueue(AbstractUploadQueue):
             self.cdf_client.events.create([e for e in self.upload_queue])
         except CogniteDuplicatedError as e:
             duplicated_ids = set([dup["externalId"] for dup in e.duplicated if "externalId" in dup])
-            failed: List[Event] = e.failed
+            failed: List[Event] = [e for e in e.failed]
             to_create = []
             to_update = []
-            for e in failed:
-                if e.external_id is not None and e.external_id in duplicated_ids:
-                    to_update.append(e)
+            for evt in failed:
+                if evt.external_id is not None and evt.external_id in duplicated_ids:
+                    to_update.append(evt)
                 else:
-                    to_create.append(e)
+                    to_create.append(evt)
             if to_create:
                 self.cdf_client.events.create(to_create)
             if to_update:
                 self.cdf_client.events.update(to_update)
-
-            
 
     def __enter__(self) -> "EventUploadQueue":
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "5.1.0"
+version = "5.2.0"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"

--- a/tests/tests_integration/test_cdf_upload_integration.py
+++ b/tests/tests_integration/test_cdf_upload_integration.py
@@ -24,9 +24,11 @@ from parameterized import parameterized_class
 from cognite.client import CogniteClient
 from cognite.client.config import ClientConfig
 from cognite.client.credentials import OAuthClientCredentials
-from cognite.client.data_classes import Row, TimeSeries
+from cognite.client.data_classes import Row, TimeSeries, Event
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.extractorutils.uploader import RawUploadQueue, TimeSeriesUploadQueue
+
+from cognite.extractorutils.uploader.events import EventUploadQueue
 
 test_id = random.randint(0, 2**31)
 
@@ -44,6 +46,10 @@ class IntegrationTests(unittest.TestCase):
     time_series1: str = f"util_integration_ts_test_1-{test_id}"
     time_series2: str = f"util_integration_ts_test_2-{test_id}"
     time_series3: str = f"util_integration_ts_test_3-{test_id}"
+
+    event1: str = f"util_integration_event_test_1-{test_id}"
+    event2: str = f"util_integration_event_test_2-{test_id}"
+    event3: str = f"util_integration_event_test_3-{test_id}"
 
     def setUp(self):
         os.environ["COGNITE_FUNCTION_RUNTIME"] = self.functions_runtime
@@ -82,14 +88,9 @@ class IntegrationTests(unittest.TestCase):
             self.client.raw.tables.delete(self.database_name, self.table_name)
         except CogniteAPIError:
             pass
-        try:
-            self.client.time_series.delete(external_id=self.time_series1)
-        except CogniteNotFoundError:
-            pass
-        try:
-            self.client.time_series.delete(external_id=self.time_series2)
-        except CogniteNotFoundError:
-            pass
+        self.client.time_series.delete(external_id=[self.time_series1, self.time_series2], ignore_unknown_ids=True)
+        self.client.events.delete(external_id=[self.event1, self.event2, self.event3], ignore_unknown_ids=True)
+
 
     def test_raw_upload_queue(self):
         queue = RawUploadQueue(cdf_client=self.client, max_queue_size=500)
@@ -215,3 +216,23 @@ class IntegrationTests(unittest.TestCase):
 
         queue.stop()
         self.client.time_series.delete(external_id=[id1, id2, id3], ignore_unknown_ids=True)
+
+    def test_events_upload_queue_upsert(self):
+        queue = EventUploadQueue(cdf_client=self.client)
+
+        # Upload a pair of events
+        queue.add_to_upload_queue(Event(external_id=self.event1, description="desc"))
+        queue.add_to_upload_queue(Event(external_id=self.event2, description="desc"))
+
+        queue.upload()
+        
+        # This should result in an update and a create
+        queue.add_to_upload_queue(Event(external_id=self.event2, description="new desc"))
+        queue.add_to_upload_queue(Event(external_id=self.event3, description="new desc"))
+
+        queue.upload()
+
+        retrieved = self.client.events.retrieve_multiple(external_ids=[self.event1, self.event2, self.event3])
+        assert retrieved[0].description == "desc"
+        assert retrieved[1].description == "new desc"
+        assert retrieved[2].description == "new desc"

--- a/tests/tests_integration/test_cdf_upload_integration.py
+++ b/tests/tests_integration/test_cdf_upload_integration.py
@@ -24,10 +24,9 @@ from parameterized import parameterized_class
 from cognite.client import CogniteClient
 from cognite.client.config import ClientConfig
 from cognite.client.credentials import OAuthClientCredentials
-from cognite.client.data_classes import Row, TimeSeries, Event
+from cognite.client.data_classes import Event, Row, TimeSeries
 from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 from cognite.extractorutils.uploader import RawUploadQueue, TimeSeriesUploadQueue
-
 from cognite.extractorutils.uploader.events import EventUploadQueue
 
 test_id = random.randint(0, 2**31)
@@ -90,7 +89,6 @@ class IntegrationTests(unittest.TestCase):
             pass
         self.client.time_series.delete(external_id=[self.time_series1, self.time_series2], ignore_unknown_ids=True)
         self.client.events.delete(external_id=[self.event1, self.event2, self.event3], ignore_unknown_ids=True)
-
 
     def test_raw_upload_queue(self):
         queue = RawUploadQueue(cdf_client=self.client, max_queue_size=500)
@@ -225,7 +223,7 @@ class IntegrationTests(unittest.TestCase):
         queue.add_to_upload_queue(Event(external_id=self.event2, description="desc"))
 
         queue.upload()
-        
+
         # This should result in an update and a create
         queue.add_to_upload_queue(Event(external_id=self.event2, description="new desc"))
         queue.add_to_upload_queue(Event(external_id=self.event3, description="new desc"))


### PR DESCRIPTION
This will be necessary to create a proper events upload queue in the db extractor. In general, IMO the upload queues should not require the user to care about the state of CDF.