### PR TITLE
Fix retry types and other issues with sequence uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [5.3.1]
+## [5.4.0]
 
 ### Fixed
 
  * Fixed the type hint for the `retry` decorator. The list of exception types
    must be given as a tuple, not an arbitrary iterable.
  * Fixed retries for sequence upload queue.
+
+### Removed
+
+ * Latency metrics for upload queues.
 
 ## [5.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [5.3.1]
+
+### Fixed
+
+ * Fixed the type hint for the `retry` decorator. The list of exception types
+   must be given as a tuple, not an arbitrary iterable.
+ * Fixed retries for sequence upload queue.
+
 ## [5.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Changes are grouped as follows
  * Fixed the type hint for the `retry` decorator. The list of exception types
    must be given as a tuple, not an arbitrary iterable.
  * Fixed retries for sequence upload queue.
+ * Sequence upload queue reported number of distinct sequences it had rows
+   for, not the number of rows. That is now changed to number of rows.
+ * When the sequence upload queue uploaded, it always reported 0 rows uploaded
+   because of a bug in the logging.
 
 ### Removed
 

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "5.3.0"
+__version__ = "5.3.1"
 from .base import Extractor

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "5.3.1"
+__version__ = "5.4.0"
 from .base import Extractor

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -223,6 +223,10 @@ class ConfigResolver(Generic[CustomConfigClass]):
                 tmp_config.cognite.get_extraction_pipeline(client).external_id  # type: ignore  # ignoring extpipe None
             )
 
+            if response.config is None:
+                _logger.error("No config included in response from extraction pipelines")
+                return
+
             self._next_config = _load_yaml(
                 source=response.config,
                 config_type=self.config_type,

--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -385,6 +385,10 @@ class RawStateStore(AbstractStateStore):
         with self.lock:
             self._local_state.clear()
             for row in rows:
+                if row.key is None or row.columns is None:
+                    self.logger.warning(f"None encountered in row: {str(row)}")
+                    # should never happen, but type from sdk is optional
+                    continue
                 self._local_state[row.key] = row.columns
 
         self._initialized = True

--- a/cognite/extractorutils/uploader/_metrics.py
+++ b/cognite/extractorutils/uploader/_metrics.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge
 
 RAW_UPLOADER_ROWS_QUEUED = Counter(
     "cognite_raw_uploader_rows_queued", "Total number of records queued", labelnames=["destination"]
@@ -24,11 +24,6 @@ RAW_UPLOADER_ROWS_DUPLICATES = Counter(
     "cognite_raw_uploader_rows_duplicates", "Total number of duplicates found", labelnames=["destination"]
 )
 RAW_UPLOADER_QUEUE_SIZE = Gauge("cognite_raw_uploader_queue_size", "Internal queue size")
-RAW_UPLOADER_LATENCY = Histogram(
-    "cognite_raw_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-    labelnames=["destination"],
-)
 TIMESERIES_UPLOADER_POINTS_QUEUED = Counter(
     "cognite_timeseries_uploader_points_queued", "Total number of datapoints queued"
 )
@@ -36,10 +31,6 @@ TIMESERIES_UPLOADER_POINTS_WRITTEN = Counter(
     "cognite_timeseries_uploader_points_written", "Total number of datapoints written"
 )
 TIMESERIES_UPLOADER_QUEUE_SIZE = Gauge("cognite_timeseries_uploader_queue_size", "Internal queue size")
-TIMESERIES_UPLOADER_LATENCY = Histogram(
-    "cognite_timeseries_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-)
 TIMESERIES_UPLOADER_POINTS_DISCARDED = Counter(
     "cognite_timeseries_uploader_points_discarded",
     "Total number of datapoints discarded due to invalid timestamp or value",
@@ -51,34 +42,15 @@ SEQUENCES_UPLOADER_POINTS_WRITTEN = Counter(
     "cognite_sequences_uploader_points_written", "Total number of sequences written"
 )
 SEQUENCES_UPLOADER_QUEUE_SIZE = Gauge("cognite_sequences_uploader_queue_size", "Internal queue size")
-SEQUENCES_UPLOADER_LATENCY = Histogram(
-    "cognite_sequences_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-)
 EVENTS_UPLOADER_QUEUED = Counter("cognite_events_uploader_queued", "Total number of events queued")
 EVENTS_UPLOADER_WRITTEN = Counter("cognite_events_uploader_written", "Total number of events written")
 EVENTS_UPLOADER_QUEUE_SIZE = Gauge("cognite_events_uploader_queue_size", "Internal queue size")
-EVENTS_UPLOADER_LATENCY = Histogram(
-    "cognite_events_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-)
 FILES_UPLOADER_QUEUED = Counter("cognite_files_uploader_queued", "Total number of files queued")
 FILES_UPLOADER_WRITTEN = Counter("cognite_files_uploader_written", "Total number of files written")
 FILES_UPLOADER_QUEUE_SIZE = Gauge("cognite_files_uploader_queue_size", "Internal queue size")
-FILES_UPLOADER_LATENCY = Histogram(
-    "cognite_files_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-)
 BYTES_UPLOADER_QUEUED = Counter("cognite_bytes_uploader_queued", "Total number of frames queued")
 BYTES_UPLOADER_WRITTEN = Counter("cognite_bytes_uploader_written", "Total number of frames written")
 BYTES_UPLOADER_QUEUE_SIZE = Gauge("cognite_bytes_uploader_queue_size", "Internal queue size")
-BYTES_UPLOADER_LATENCY = Histogram(
-    "cognite_bytes_uploader_latency",
-    "Distribution of times in minutes records spend in the queue",
-)
 ASSETS_UPLOADER_QUEUED = Counter("cognite_assets_uploader_queued", "Total number of assets queued")
 ASSETS_UPLOADER_WRITTEN = Counter("cognite_assets_uploader_written", "Total number of assets written")
 ASSETS_UPLOADER_QUEUE_SIZE = Gauge("cognite_assets_uploader_queue_size", "Internal queue size")
-ASSETS_UPLOADER_LATENCY = Histogram(
-    "cognite_assets_uploader_latency", "Distribution of times in minutes records spend in queue"
-)

--- a/cognite/extractorutils/uploader/raw.py
+++ b/cognite/extractorutils/uploader/raw.py
@@ -32,7 +32,6 @@ from cognite.extractorutils.uploader._base import (
     TimestampedObject,
 )
 from cognite.extractorutils.uploader._metrics import (
-    RAW_UPLOADER_LATENCY,
     RAW_UPLOADER_QUEUE_SIZE,
     RAW_UPLOADER_ROWS_DUPLICATES,
     RAW_UPLOADER_ROWS_QUEUED,
@@ -83,7 +82,6 @@ class RawUploadQueue(AbstractUploadQueue):
         self.rows_written = RAW_UPLOADER_ROWS_WRITTEN
         self.rows_duplicates = RAW_UPLOADER_ROWS_DUPLICATES
         self.queue_size = RAW_UPLOADER_QUEUE_SIZE
-        self.latency = RAW_UPLOADER_LATENCY
 
     def add_to_upload_queue(self, database: str, table: str, raw_row: Row) -> None:
         """
@@ -130,10 +128,6 @@ class RawUploadQueue(AbstractUploadQueue):
                     self._upload_batch(database=database, table=table, patch=list(patch.values()))
                     self.rows_written.labels(_labels).inc(len(patch))
                     _written: Arrow = arrow.utcnow()
-                    for r in rows:
-                        self.latency.labels(_labels).observe(
-                            (_written - r.created).total_seconds() / 60
-                        )  # show data in minutes
 
                     # Perform post-upload logic if applicable
                     try:

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -531,7 +531,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
             self.queue_size.set(self.upload_queue_size)
 
     @retry(
-        exceptions=[CogniteAPIError],
+        exceptions=(CogniteAPIError, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -483,7 +483,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
                 self.upload_queue[either_id] = seq
             else:
                 self.upload_queue[either_id] = rows
-            self.upload_queue_size = len(self.upload_queue)
+            self.upload_queue_size = sum([len(rows) for rows in self.upload_queue.values()])
             self.queue_size.set(self.upload_queue_size)
             self.points_queued.inc()
 
@@ -509,9 +509,9 @@ class SequenceUploadQueue(AbstractUploadQueue):
             except Exception as e:
                 self.logger.error("Error in upload callback: %s", str(e))
 
+            self.logger.info(f"Uploaded {self.upload_queue_size} sequence rows")
             self.upload_queue.clear()
             self.upload_queue_size = 0
-            self.logger.info(f"Uploaded {self.upload_queue_size} sequence rows")
             self.queue_size.set(self.upload_queue_size)
 
     @retry(

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -330,7 +330,7 @@ _T2 = TypeVar("_T2")
 def _retry_internal(
     f: Callable[..., _T2],
     cancellation_token: threading.Event = threading.Event(),
-    exceptions: Iterable[Type[Exception]] = [Exception],
+    exceptions: Tuple[Type[Exception], ...] = (Exception,),
     tries: int = -1,
     delay: float = 0,
     max_delay: Optional[float] = None,
@@ -342,7 +342,7 @@ def _retry_internal(
     while tries and not cancellation_token.is_set():
         try:
             return f()
-        except exceptions as e:  # type: ignore  # Exception is an exception type, smh mypy
+        except exceptions as e:
             tries -= 1
             if not tries:
                 raise e
@@ -366,7 +366,7 @@ def _retry_internal(
 
 def retry(
     cancellation_token: threading.Event = threading.Event(),
-    exceptions: Iterable[Type[Exception]] = [Exception],
+    exceptions: Tuple[Type[Exception], ...] = (Exception,),
     tries: int = -1,
     delay: float = 0,
     max_delay: Optional[float] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "5.3.0"
+version = "5.3.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "5.3.1"
+version = "5.4.0"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Turns out mypy was right about complaining.

 * Fixed the type hint for the `retry` decorator. The list of exception types must be given as a tuple, not an arbitrary iterable.
 * Fixed retries for sequence upload queue.