### PR TITLE
Retry on requests.exceptions.ConnectionError (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.3.1]
+
+### Fixed
+
+ * Improved the state store retry behavior to handle both fundamental
+   and wrapped network connection errors.
+
 ## [6.3.0]
 
 ### Added

--- a/cognite/extractorutils/statestore.py
+++ b/cognite/extractorutils/statestore.py
@@ -92,6 +92,8 @@ from abc import ABC, abstractmethod
 from types import TracebackType
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
 
+from requests.exceptions import ConnectionError
+
 from cognite.client import CogniteClient
 from cognite.client.exceptions import CogniteAPIError, CogniteException
 from cognite.extractorutils.uploader import DataPointList
@@ -346,7 +348,7 @@ class RawStateStore(AbstractStateStore):
         self._ensure_table()
 
     @retry(
-        exceptions=(CogniteException,),
+        exceptions=(CogniteException, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -368,7 +370,7 @@ class RawStateStore(AbstractStateStore):
         self._initialize_implementation(force)
 
     @retry(
-        exceptions=(CogniteException,),
+        exceptions=(CogniteException, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,
@@ -402,7 +404,7 @@ class RawStateStore(AbstractStateStore):
         self._synchronize_implementation()
 
     @retry(
-        exceptions=(CogniteException,),
+        exceptions=(CogniteException, ConnectionError),
         tries=RETRIES,
         delay=RETRY_DELAY,
         max_delay=RETRY_MAX_DELAY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "6.3.0"
+version = "6.3.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
In a previous PR, we switched from retrying on requests connection errors to the internal Cognite exceptions that wrapped these. This fixed some of the issues encountered by the customer (SLB).

But, in some corner cases, such as for authorization, you can still get an unwrapped requests.exceptions.ConnectionError (as encountered by the customer). So we have to retry on both.

This re-adds the retry on ConnectionError in addition to the internal Cognite SDK classes, to be more resilient.