### PR TITLE
Allow aliases for key vault config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [6.3.2]
+
+### Added
+
+ * Aliases for keyvault config to align with dotnet utils
+
 ## [6.3.1]
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "6.3.0"
+__version__ = "6.3.2"
 from .base import Extractor

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -61,7 +61,7 @@ class KeyVaultLoader:
                 "Include an `azure-keyvault` section in your config to use the !keyvault tag."
             )
 
-        keyvault_name = self.config.get("keyvault-name", self.config.get("key-vault-name"))
+        keyvault_name = self.config.get("keyvault-name")
         if not keyvault_name:
             raise InvalidConfigError("Please add the keyvault-name")
 

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -61,7 +61,8 @@ class KeyVaultLoader:
                 "Include an `azure-keyvault` section in your config to use the !keyvault tag."
             )
 
-        if "keyvault-name" not in self.config:
+        keyvault_name = self.config.get("keyvault-name", self.config.get("key-vault-name"))
+        if not keyvault_name:
             raise InvalidConfigError("Please add the keyvault-name")
 
         if "authentication-method" not in self.config:
@@ -70,7 +71,7 @@ class KeyVaultLoader:
                 "Possible values are: default or client-secret"
             )
 
-        vault_url = f"https://{self.config['keyvault-name']}.vault.azure.net"
+        vault_url = f"https://{keyvault_name}.vault.azure.net"
 
         if self.config["authentication-method"] == KeyVaultAuthenticationMethod.DEFAULT.value:
             _logger.info("Using Azure DefaultCredentials to access KeyVault")
@@ -151,7 +152,7 @@ def _load_yaml_dict(
     if not isinstance(source, str):
         source.seek(0)
 
-    keyvault_config = initial_load.get("azure-keyvault")
+    keyvault_config = initial_load.get("azure-keyvault", initial_load.get("key-vault"))
 
     _EnvLoader.add_implicit_resolver("!env", re.compile(r"\$\{([^}^{]+)\}"), None)
     _EnvLoader.add_constructor("!env", _env_constructor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "6.3.1"
+version = "6.3.2"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
To keep consistency with the dotnet variant, let's also allow to configure `key-vault` as an alias for `azure-keyvault` and `key-vault-name` as an alias for `keyvault-name`.