### PR TITLE
Add doc segments

### DIFF
--- a/schema/docs/envsub.md
+++ b/schema/docs/envsub.md
@@ -1,0 +1,22 @@
+## Using values from environment variables
+
+The configuration file allows substitutions with environment variables. For example:
+
+```yaml
+cognite:
+  secret: ${COGNITE_CLIENT_SECRET}
+```
+
+will load the value from the `COGNITE_CLIENT_SECRET` environment variable into the `cognite/secret` parameter. You can also do string interpolation with environment variables, for example:
+
+```yaml
+url: http://my-host.com/api/endpoint?secret=${MY_SECRET_TOKEN}
+```
+
+:::info Note
+Implicit substitutions only work for unquoted value strings. For quoted strings, use the `!env` tag to activate environment substitution:
+
+```yaml
+url: !env 'http://my-host.com/api/endpoint?secret=${MY_SECRET_TOKEN}'
+```
+:::

--- a/schema/docs/keyvault.md
+++ b/schema/docs/keyvault.md
@@ -1,0 +1,28 @@
+## Using values from Azure Key Vault
+
+The DB extractor also supports loading values from Azure Key Vault. To load a configuration value from Azure Key Vault, use the `!keyvault` tag followed by the name of the secret you want to load. For example, to load the value of the `my-secret-name` secret in Key Vault into a `password` parameter, configure your extractor like this:
+
+``` yaml
+password: !keyvault my-secret-name
+```
+
+To use Key Vault, you also need to include the `azure-keyvault` section in your configuration, with the following parameters:
+
+| Parameter | Description |
+| - | - |
+| `keyvault-name` | Name of Key Vault to load secrets from |
+| `authentication-method` | How to authenticate to Azure. Either `default` or `client-secret`. For `default`, the extractor will look at the user running the extractor, and look for pre-configured Azure logins from tools like the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli). For `client-secret`, the extractor will authenticate with a configured client ID/secret pair.
+| `client-id` | Required for using the `client-secret` authentication method. The client ID to use when authenticating to Azure. |
+| `secret` | Required for using the `client-secret` authentication method. The client secret to use when authenticating to Azure. |
+| `tenant-id` | Required for using the `client-secret` authentication method. The tenant ID of the Key Vault in Azure. |
+
+__Example:__
+
+``` yaml
+azure-keyvault:
+  keyvault-name: my-keyvault-name
+  authentication-method: client-secret
+  tenant-id: 6f3f324e-5bfc-4f12-9abe-22ac56e2e648
+  client-id: 6b4cc73e-ee58-4b61-ba43-83c4ba639be6
+  secret: 1234abcd
+```

--- a/schema/docs/remote_tip.md
+++ b/schema/docs/remote_tip.md
@@ -1,0 +1,3 @@
+:::tip Tip
+You can set up [extraction pipelines](../../interfaces/configure_integrations.md) to use versioned extractor configuration files stored in the cloud.
+:::


### PR DESCRIPTION
These are taken from the DB extractor, but I imagine they can be useful for other extractors. If we put them here, we can load them while creating docs the same way we reuse config schemas