### PR TITLE
Override `stop()` in file upload queues

### DIFF
--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -200,6 +200,10 @@ class IOFileUploadQueue(AbstractUploadQueue):
             with self._full_queue:
                 self._full_queue.notify()
 
+    def stop(self, ensure_upload: bool = True) -> None:
+        if ensure_upload:
+            self.upload()
+
     def __enter__(self) -> "IOFileUploadQueue":
         """
         Wraps around start method, for use as context manager


### PR DESCRIPTION
Stop has taken on a different meaning, don't set the cancellation token on `stop()` for file upload queues