### PR TITLE
Make `CancellationToken.wait` only wait for a limited time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.0.1
+
+### Fixed
+
+ * Ensure that `CancellationToken.wait(timeout)` only waits for at most `timeout`, even if it is notified in that time.
+
 ## 7.0.0
 
 ### Changed

--- a/cognite/extractorutils/threading.py
+++ b/cognite/extractorutils/threading.py
@@ -1,6 +1,6 @@
 import logging
 import signal
-from threading import Condition, Event
+from threading import Condition
 from time import time
 from typing import Any, Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.0.0"
+version = "7.0.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
`Event` didn't have this problem, since it assumed any notify implied that the event had been set (frankly a slightly insane assumption, but whatever).

This could prevent a parent token from timing out if a child token was repeatedly cancelled, not a big deal, but worth considering.