### PR TITLE
make ConfigReloader not refresh auth token each cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.0.5
+
+### Fixed
+
+  * The background thread `ConfigReloader` now caches the `CogniteClient` to avoid repeatedly fetching a new token.
+
 ## 7.0.4
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.0.4"
+__version__ = "7.0.5"
 from .base import Extractor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.0.4"
+version = "7.0.5"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Hey, this is my first contribution to this repo, so if this PR looks crazy, please advise ❤️ 

 The problem I am trying to solve is the following:

By default, `config_refresher` runs every 5 minutes when a no-op `ReloadConfigAction` is given, i.e.:

```py
if self.reload_config_interval and self.reload_config_action != ReloadConfigAction.DO_NOTHING:
    Thread(target=config_refresher, name="ConfigReloader", daemon=True).start()
```

This code ends up calling `get_cognite_client` which forces a token refresh every time `config_refresher` runs:
```
config_refresher
-> self.config_resolver.has_changed
  -> _resolve_config
    -> tmp_config.cognite.get_cognite_client()
```

For some users using Auth0, every refresh incurs a cost... so doing this every 5 minutes VS 24 hours (default lifetime) actually accumulates into some 💲  💲  💲 