### PR TITLE
Retry file upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.1.2
+
+### Fixed
+
+ * `cognite_exceptions()` did not properly retry file uploads
+
 ## 7.1.1
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.1.1"
+__version__ = "7.1.2"
 from .base import Extractor

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -16,6 +16,7 @@
 The ``util`` package contains miscellaneous functions and classes that can some times be useful while developing
 extractors.
 """
+
 import logging
 import random
 from functools import partial, wraps
@@ -27,7 +28,7 @@ from decorator import decorator
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Asset, ExtractionPipelineRun, TimeSeries
-from cognite.client.exceptions import CogniteAPIError, CogniteException, CogniteNotFoundError
+from cognite.client.exceptions import CogniteAPIError, CogniteException, CogniteFileUploadError, CogniteNotFoundError
 from cognite.extractorutils.threading import CancellationToken
 
 
@@ -492,7 +493,7 @@ def cognite_exceptions(
     status_codes = status_codes or [408, 425, 429, 500, 502, 503, 504]
 
     def handle_cognite_errors(exception: CogniteException) -> bool:
-        if isinstance(exception, CogniteAPIError):
+        if isinstance(exception, (CogniteAPIError, CogniteFileUploadError)):
             return exception.code in status_codes
         return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ exclude = "tests/*"
 
 [tool.poetry.dependencies]
 python = "^3.8.0"
-cognite-sdk = "^7.28.1"
+cognite-sdk = ">=7.28.1, <7.35.0"
 prometheus-client = ">0.7.0, <=1.0.0"
 arrow = "^1.0.0"
 pyyaml = ">=5.3.0, <7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.1.1"
+version = "7.1.2"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
File uploads raises their own `CogniteFileUploadError` exception, which is not a subclass of `CogniteAPIError`. So we need to catch both.