### PR TITLE
Improve file retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+
+## 7.1.5
+
+### Fixed
+
+ * Fixed an issue preventing retries in file uploads from working properly
+
+### Added
+
+ * File external ID when logging failed file uploads
+
 ## 7.1.4
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.1.4"
+__version__ = "7.1.5"
 from .base import Extractor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.1.4"
+version = "7.1.5"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Include external ID when logging failed files.

I also discovered an issue with how the retries was set up which caused the uploads to not properly retry. The internal try/catch needed for the thread pool ended up stopping retries. I split it out so that we have a 'wrap' function which applies the final layer of error handling.