### PR TITLE
Fix an issue with the retry decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Next
+
+### Fixed
+
+ * Fixed an issue with the `retry` decorator where functions would not be
+   called at all if the cancellation token was set. This resulted in errors
+   with for example upload queues.
 
 ## 7.1.6
 

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -319,11 +319,14 @@ def _retry_internal(
 ) -> _T2:
     logger = logging.getLogger(__name__)
 
-    while tries and not cancellation_token.is_cancelled:
+    while tries:
         try:
             return f()
 
         except Exception as e:
+            if cancellation_token.is_cancelled:
+                break
+
             if isinstance(exceptions, tuple):
                 for ex_type in exceptions:
                     if isinstance(e, ex_type):


### PR DESCRIPTION
By checking for cancellation before even calling the function, the retry decorator was blocking final uploads in e.g. upload queues from even starting.

This resulted in a very obscure bug where functions with retries would seemingly work after the cancellation token was set, but in reality the call stopped in the retry decorator and `None` was returned.