### PR TITLE
Remove newlines from log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+
+## 7.2.1
+
+### Changed
+
+ * Reformat log messages to not have newlines
+
 ## 7.2.0
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.2.0"
+__version__ = "7.2.1"
 from .base import Extractor

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -264,9 +264,9 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
                         missing = [id_dict for id_dict in ex.not_found if id_dict.get("externalId") not in retry_these]
                         missing_num = len(ex.not_found) - len(create_these_ids)
                         self.logger.error(
-                            f"{missing_num} time series not found, and could not be created automatically:\n"
+                            f"{missing_num} time series not found, and could not be created automatically: "
                             + str(missing)
-                            + "\nData will be dropped"
+                            + " Data will be dropped"
                         )
 
                 # Remove entries with non-existing time series from upload queue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.2.0"
+version = "7.2.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This makes the logs less grep-able