### PR TITLE
Fail on missing tenant and token url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.2.2
+
+### Fixed
+
+ * Produce a config error when missing token-url and tenant, instead of eventually
+   producing an `OAuth 2 MUST utilize https` error when getting the token.
 
 ## 7.2.1
 

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.2.1"
+__version__ = "7.2.2"
 from .base import Extractor

--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -327,6 +327,8 @@ class CogniteConfig:
             elif self.idp_authentication.tenant:
                 base_url = urljoin(self.idp_authentication.authority, self.idp_authentication.tenant)
                 kwargs["token_url"] = f"{base_url}/oauth2/v2.0/token"
+            else:
+                raise InvalidConfigError("Either token-url or tenant is required for client credentials authentication")
             kwargs["client_id"] = self.idp_authentication.client_id
             kwargs["client_secret"] = self.idp_authentication.secret
             kwargs["scopes"] = self.idp_authentication.scopes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.2.1"
+version = "7.2.2"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This may be the most common config error we see, making it clearer can only help us.  This is where missing credentials will hit first, usually.