### PR TITLE
Add `unstable` package

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -42,6 +42,9 @@ jobs:
           KEYVAULT_CLIENT_SECRET: ${{ secrets.KEYVAULT_CLIENT_SECRET }}
           COGNITE_PROJECT: extractor-tests
           COGNITE_BASE_URL: https://greenfield.cognitedata.com
+          COGNITE_DEV_PROJECT: extractor-aws-dub-dev-testing
+          COGNITE_DEV_BASE_URL: https://aws-dub-dev.cognitedata.com/
+          COGNITE_DEV_TOKEN_SCOPES: https://aws-dub-dev.cognitedata.com/.default
       run: |
         coverage run --source cognite.extractorutils -m pytest -v tests
         coverage xml

--- a/cognite/extractorutils/unstable/__init__.py
+++ b/cognite/extractorutils/unstable/__init__.py
@@ -1,0 +1,8 @@
+"""
+The unstable package contains experimental functions and classes currently
+deemed unstable. The contents of this package is subject to change without
+notice, even in minor or patch releases.
+
+Whenever you import anything from the unstable package, you should make sure to
+run a type checker such as mypy to help catch these changes.
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ target-version = "py310"
 [tool.ruff.isort]
 known-third-party = ["alembic"]
 
+[tool.pytest.ini_options]
+markers = [
+    "unstable: tests for the unstable package (deselect with '-m \"not unstable\"')",
+]
+
 [tool.mypy]
 pretty = true
 check_untyped_defs = true

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+from cognite.client import CogniteClient
+from cognite.client.config import ClientConfig
+from cognite.client.credentials import OAuthClientCredentials
+
+
+@pytest.fixture
+def set_client() -> CogniteClient:
+    cognite_project = os.environ["COGNITE_DEV_PROJECT"]
+    cognite_base_url = os.environ["COGNITE_DEV_BASE_URL"]
+    cognite_token_url = os.environ.get("COGNITE_DEV_TOKEN_URL", os.environ["COGNITE_TOKEN_URL"])
+    cognite_client_id = os.environ.get("COGNITE_DEV_CLIENT_ID", os.environ["COGNITE_CLIENT_ID"])
+    cognite_client_secret = os.environ.get("COGNITE_DEV_CLIENT_SECRET", os.environ["COGNITE_CLIENT_SECRET"])
+    cognite_project_scopes = os.environ["COGNITE_DEV_TOKEN_SCOPES"].split(",")
+    client_config = ClientConfig(
+        project=cognite_project,
+        base_url=cognite_base_url,
+        credentials=OAuthClientCredentials(
+            cognite_token_url, cognite_client_id, cognite_client_secret, cognite_project_scopes
+        ),
+        client_name="extractor-utils-integration-tests",
+    )
+    return CogniteClient(client_config)

--- a/tests/test_unstable/test_is_dev_cluster.py
+++ b/tests/test_unstable/test_is_dev_cluster.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+from cognite.client import CogniteClient
+
+
+@pytest.mark.unstable
+def test_is_dev_cluster(set_client: CogniteClient) -> None:
+    # Check that the client works
+    print(set_client.assets.list())
+
+    # Check that we are running against a dev project/cluster
+    assert set_client.config.project == os.environ["COGNITE_DEV_PROJECT"]
+    assert "dev" in set_client.config.base_url


### PR DESCRIPTION
The idea with the `unstable` package is to have a place we can do experimental development without worrying about backwards compatibility.

The tests for the `unstable` package is run against a development cluster, instead of staging. This is to facilitate development against unstable features of CDF.