### PR TITLE
Initial commit for new runtime and base class

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,43 +2,43 @@ name: release
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
-      uses: ./.github/workflows/test_and_build.yml
-      secrets: inherit
+    uses: ./.github/workflows/test_and_build.yml
+    secrets: inherit
 
   build:
     runs-on: ubuntu-latest
     environment: CD
 
     needs:
-    - test
+      - test
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip poetry
-        poetry config virtualenvs.create false
-        poetry lock
-        poetry install
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry lock
+          poetry install
 
-    - name: Build package
-      run: poetry build
+      - name: Build package
+        run: poetry build
 
-    - name: Build docs
-      run: cd docs && make html
+      - name: Build docs
+        run: cd docs && make html
 
-    - name: Release to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload --verbose dist/* || echo 'Version exists'
+      - name: Release to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --verbose dist/* || echo 'Version exists'

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -2,7 +2,7 @@ name: test_and_build
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_call:
 
 jobs:
@@ -12,28 +12,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pip poetry
-        poetry config virtualenvs.create false
-        poetry lock
-        poetry install
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry lock
+          poetry install
 
-    - name: Check codestyle
-      run: pre-commit run --all
+      - name: Check codestyle
+        run: pre-commit run --all
 
-    - name: Run tests
-      env:
+      - name: Run tests
+        env:
           COGNITE_CLIENT_ID: ${{ secrets.COGNITE_PROJECT_CLIENT_ID }}
           COGNITE_CLIENT_SECRET: ${{ secrets.COGNITE_PROJECT_CLIENT_SECRET }}
           COGNITE_TOKEN_SCOPES: ${{ secrets.COGNITE_PROJECT_SCOPES }}
@@ -46,17 +46,17 @@ jobs:
           COGNITE_DEV_PROJECT: extractor-aws-dub-dev-testing
           COGNITE_DEV_BASE_URL: https://aws-dub-dev.cognitedata.com/
           COGNITE_DEV_TOKEN_SCOPES: https://aws-dub-dev.cognitedata.com/.default
-      run: |
-        coverage run --source cognite.extractorutils -m pytest -v tests
-        coverage xml
+        run: |
+          coverage run --source cognite.extractorutils -m pytest -v tests
+          coverage xml
 
-    - uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
 
-    - name: Build package
-      run: poetry build
+      - name: Build package
+        run: poetry build
 
-    - name: Build docs
-      run: cd docs && make html
+      - name: Build docs
+        run: cd docs && make html

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Local test files
 test.py
 test.yaml
+local-test.yaml
 pyrightconfig.json
 
 # Tokens, etc

--- a/cognite/extractorutils/configtools/_util.py
+++ b/cognite/extractorutils/configtools/_util.py
@@ -81,8 +81,10 @@ def _to_snake_case(dictionary: Dict[str, Any], case_style: str) -> Dict[str, Any
         raise ValueError(f"Invalid case style: {case_style}")
 
 
-def _load_certificate_data(cert_path: str, password: Optional[str]) -> Union[Tuple[str, str], Tuple[bytes, bytes]]:
-    path = Path(cert_path)
+def _load_certificate_data(
+    cert_path: str | Path, password: Optional[str]
+) -> Union[Tuple[str, str], Tuple[bytes, bytes]]:
+    path = Path(cert_path) if isinstance(cert_path, str) else cert_path
     cert_data = Path(path).read_bytes()
 
     if path.suffix == ".pem":

--- a/cognite/extractorutils/unstable/configuration/loaders.py
+++ b/cognite/extractorutils/unstable/configuration/loaders.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from io import StringIO
 from pathlib import Path
-from typing import Dict, Optional, TextIO, Type, TypeVar, Union
+from typing import Dict, Optional, TextIO, Tuple, Type, TypeVar, Union
 
 from pydantic import ValidationError
 
@@ -33,7 +33,7 @@ def load_file(path: Path, schema: Type[_T]) -> _T:
 
 def load_from_cdf(
     cognite_client: CogniteClient, external_id: str, schema: Type[_T], revision: Optional[int] = None
-) -> _T:
+) -> Tuple[_T, int]:
     params: Dict[str, Union[str, int]] = {"externalId": external_id}
     if revision:
         params["revision"] = revision
@@ -44,7 +44,7 @@ def load_from_cdf(
     )
     response.raise_for_status()
     data = response.json()
-    return load_io(StringIO(data["config"]), ConfigFormat.YAML, schema)
+    return load_io(StringIO(data["config"]), ConfigFormat.YAML, schema), data["revision"]
 
 
 def load_io(stream: TextIO, format: ConfigFormat, schema: Type[_T]) -> _T:

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -188,7 +188,7 @@ class ConnectionConfig(ConfigModel):
                 )
 
             case _:
-                assert_never()
+                assert_never(self.authentication)
 
         client_config = ClientConfig(
             project=self.project,

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -2,7 +2,13 @@ import re
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union, assert_never
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+try:
+    from typing import assert_never
+except ImportError:
+    # workaround for 3.10
+    from typing_extensions import assert_never
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -2,12 +2,20 @@ import re
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union, assert_never
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
 
+from cognite.client import CogniteClient
+from cognite.client.config import ClientConfig
+from cognite.client.credentials import (
+    CredentialProvider,
+    OAuthClientCertificate,
+    OAuthClientCredentials,
+)
+from cognite.extractorutils.configtools._util import _load_certificate_data
 from cognite.extractorutils.exceptions import InvalidConfigError
 
 
@@ -33,7 +41,9 @@ class _ClientCredentialsConfig(ConfigModel):
 class _ClientCertificateConfig(ConfigModel):
     type: Literal["client-certificate"]
     client_id: str
-    certificate_path: Path
+    path: Path
+    password: Optional[str] = None
+    authority_url: str
     scopes: List[str]
 
 
@@ -121,6 +131,7 @@ class _ConnectionParameters(ConfigModel):
     max_connection_pool_size: int = 50
     ssl_verify: bool = True
     proxies: Dict[str, str] = Field(default_factory=dict)
+    timeout: TimeIntervalConfig = Field(default_factory=lambda: TimeIntervalConfig("30s"))
 
 
 class ConnectionConfig(ConfigModel):
@@ -132,6 +143,61 @@ class ConnectionConfig(ConfigModel):
     authentication: AuthenticationConfig
 
     connection: _ConnectionParameters = Field(default_factory=_ConnectionParameters)
+
+    def get_cognite_client(self, client_name: str) -> CogniteClient:
+        from cognite.client.config import global_config
+
+        global_config.disable_pypi_version_check = True
+        global_config.disable_gzip = not self.connection.gzip_compression
+        global_config.status_forcelist = set(self.connection.status_forcelist)
+        global_config.max_retries = self.connection.max_retries
+        global_config.max_retries_connect = self.connection.max_retries_connect
+        global_config.max_retry_backoff = self.connection.max_retry_backoff.seconds
+        global_config.max_connection_pool_size = self.connection.max_connection_pool_size
+        global_config.disable_ssl = not self.connection.ssl_verify
+        global_config.proxies = self.connection.proxies
+
+        credential_provider: CredentialProvider
+        match self.authentication:
+            case _ClientCredentialsConfig() as client_credentials:
+                kwargs = {
+                    "token_url": client_credentials.token_url,
+                    "client_id": client_credentials.client_id,
+                    "client_secret": client_credentials.client_secret,
+                    "scopes": client_credentials.scopes,
+                }
+                if client_credentials.audience is not None:
+                    kwargs["audience"] = client_credentials.audience
+                if client_credentials.resource is not None:
+                    kwargs["resource"] = client_credentials.resource
+
+                credential_provider = OAuthClientCredentials(**kwargs)  # type: ignore  # I know what I'm doing
+
+            case _ClientCertificateConfig() as client_certificate:
+                thumbprint, key = _load_certificate_data(
+                    client_certificate.path,
+                    client_certificate.password,
+                )
+                credential_provider = OAuthClientCertificate(
+                    authority_url=client_certificate.authority_url,
+                    client_id=client_certificate.client_id,
+                    cert_thumbprint=str(thumbprint),
+                    certificate=str(key),
+                    scopes=client_certificate.scopes,
+                )
+
+            case _:
+                assert_never()
+
+        client_config = ClientConfig(
+            project=self.project,
+            base_url=self.base_url,
+            client_name=client_name,
+            timeout=self.connection.timeout.seconds,
+            credentials=credential_provider,
+        )
+
+        return CogniteClient(client_config)
 
 
 class LogLevel(Enum):

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -4,15 +4,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-try:
-    from typing import assert_never
-except ImportError:
-    # workaround for 3.10
-    from typing_extensions import assert_never
-
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
+from typing_extensions import assert_never
 
 from cognite.client import CogniteClient
 from cognite.client.config import ClientConfig

--- a/cognite/extractorutils/unstable/core/__main__.py
+++ b/cognite/extractorutils/unstable/core/__main__.py
@@ -1,0 +1,31 @@
+"""
+Example of how you would build an extractor with the new base class
+"""
+
+from cognite.extractorutils.unstable.configuration.models import ExtractorConfig
+
+from .base import Extractor
+from .runtime import Runtime
+
+
+class MyConfig(ExtractorConfig):
+    parameter_one: int
+    parameter_two: str
+
+
+class MyExtractor(Extractor[MyConfig]):
+    NAME = "Test extractor"
+    EXTERNAL_ID = "test-extractor"
+    DESCRIPTION = "Test of the new runtime"
+    VERSION = "1.0.0"
+    CONFIG_TYPE = MyConfig
+
+    def run(self) -> None:
+        self.logger.info("Started!")
+        if not self.cancellation_token.wait(10):
+            raise ValueError("Oops")
+
+
+if __name__ == "__main__":
+    runtime = Runtime(MyExtractor)
+    runtime.run()

--- a/cognite/extractorutils/unstable/core/_messaging.py
+++ b/cognite/extractorutils/unstable/core/_messaging.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class RuntimeMessage(Enum):
+    RESTART = 1

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -1,0 +1,119 @@
+import logging
+from multiprocessing import Queue
+from threading import RLock, Thread
+from types import TracebackType
+from typing import Generic, Literal, Optional, Type, TypeVar, Union
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+from cognite.extractorutils.threading import CancellationToken
+from cognite.extractorutils.unstable.configuration.models import ConnectionConfig, ExtractorConfig
+from cognite.extractorutils.unstable.core._messaging import RuntimeMessage
+
+ConfigType = TypeVar("ConfigType", bound=ExtractorConfig)
+ConfigRevision = Union[Literal["local"], int]
+
+
+class Extractor(Generic[ConfigType]):
+    NAME: str
+    EXTERNAL_ID: str
+    DESCRIPTION: str
+    VERSION: str
+
+    CONFIG_TYPE: Type[ConfigType]
+
+    def __init__(
+        self,
+        connection_config: ConnectionConfig,
+        application_config: ConfigType,
+        current_config_revision: ConfigRevision,
+    ) -> None:
+        self.cancellation_token = CancellationToken()
+        self.cancellation_token.cancel_on_interrupt()
+
+        self.connection_config = connection_config
+        self.application_config = application_config
+        self.current_config_revision = current_config_revision
+
+        self.cognite_client = self.connection_config.get_cognite_client(f"{self.EXTERNAL_ID}-{self.VERSION}")
+
+        self._checkin_lock = RLock()
+        self._runtime_messages: Optional[Queue[RuntimeMessage]] = None
+
+        self.logger = logging.getLogger(f"{self.EXTERNAL_ID}.main")
+
+    def _set_runtime_message_queue(self, queue: Queue) -> None:
+        self._runtime_messages = queue
+
+    def _run_checkin(self) -> None:
+        def checkin() -> None:
+            body = {"externalId": self.connection_config.extraction_pipeline}
+
+            with self._checkin_lock:
+                res = self.cognite_client.post(
+                    f"/api/v1/projects/{self.cognite_client.config.project}/odin/checkin",
+                    json=body,
+                    headers={"cdf-version": "alpha"},
+                )
+                new_config_revision = res.json().get("lastConfigRevision")
+
+                if new_config_revision and new_config_revision != self.current_config_revision:
+                    self.restart()
+
+        while not self.cancellation_token.is_cancelled:
+            try:
+                checkin()
+            except Exception:
+                self.logger.exception("Error during checkin")
+            self.cancellation_token.wait(10)
+
+    def restart(self) -> None:
+        if self._runtime_messages:
+            self._runtime_messages.put(RuntimeMessage.RESTART)
+        self.cancellation_token.cancel()
+
+    @classmethod
+    def init_from_runtime(
+        cls,
+        connection_config: ConnectionConfig,
+        application_config: ConfigType,
+        current_config_revision: ConfigRevision,
+    ) -> Self:
+        return cls(connection_config, application_config, current_config_revision)
+
+    def start(self) -> None:
+        self.cognite_client.post(
+            f"/api/v1/projects/{self.cognite_client.config.project}/odin/extractorinfo",
+            json={
+                "externalId": self.connection_config.extraction_pipeline,
+                "activeConfigRevision": self.current_config_revision,
+                "extractor": {
+                    "version": self.VERSION,
+                    "externalId": self.EXTERNAL_ID,
+                },
+            },
+            headers={"cdf-version": "alpha"},
+        )
+        Thread(target=self._run_checkin, name="ExtractorCheckin", daemon=True).start()
+
+    def stop(self) -> None:
+        self.cancellation_token.cancel()
+
+    def __enter__(self) -> Self:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
+        self.stop()
+        return exc_val is None
+
+    def run(self) -> None:
+        raise NotImplementedError()

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -4,10 +4,7 @@ from threading import RLock, Thread
 from types import TracebackType
 from typing import Generic, Literal, Optional, Type, TypeVar, Union
 
-try:
-    from typing import Self
-except ImportError:
-    from typing_extensions import Self
+from typing_extensions import Self
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig, ExtractorConfig

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -1,0 +1,168 @@
+import logging
+import os
+import sys
+import time
+from argparse import ArgumentParser, Namespace
+from multiprocessing import Process, Queue
+from pathlib import Path
+from typing import Any, Generic, Type, TypeVar, assert_never
+
+from cognite.extractorutils.threading import CancellationToken
+from cognite.extractorutils.unstable.configuration.loaders import load_file, load_from_cdf
+from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
+
+from ._messaging import RuntimeMessage
+from .base import ConfigRevision, ConfigType, Extractor
+
+ExtractorType = TypeVar("ExtractorType", bound=Extractor)
+
+
+class Runtime(Generic[ExtractorType]):
+    def __init__(
+        self,
+        extractor: Type[ExtractorType],
+    ) -> None:
+        self._extractor_class = extractor
+        self._cancellation_token = CancellationToken()
+        self._cancellation_token.cancel_on_interrupt()
+        self._message_queue: Queue[RuntimeMessage] = Queue()
+        self.logger = logging.getLogger(f"{self._extractor_class.EXTERNAL_ID}.runtime")
+        self._setup_logging()
+
+    def _create_argparser(self) -> ArgumentParser:
+        argparser = ArgumentParser(
+            prog=sys.argv[0],
+            description=self._extractor_class.DESCRIPTION,
+        )
+        argparser.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version=f"{self._extractor_class.NAME} v{self._extractor_class.VERSION}",
+        )
+        argparser.add_argument(
+            "-c",
+            "--connection-config",
+            nargs=1,
+            type=Path,
+            required=True,
+            help="Connection parameters",
+        )
+        argparser.add_argument(
+            "-l",
+            "--local-override",
+            nargs=1,
+            type=Path,
+            required=False,
+            default=None,
+            help="Include to use a local application configuration instead of fetching it from CDF",
+        )
+
+        return argparser
+
+    def _setup_logging(self) -> None:
+        # TODO: Figure out file logging for runtime
+        fmt = logging.Formatter(
+            "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(threadName)s - %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+        # Set logging to UTC
+        fmt.converter = time.gmtime
+
+        root = logging.getLogger()
+        root.setLevel(logging.INFO)
+
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(fmt)
+
+        root.addHandler(console_handler)
+
+    def _inner_run(
+        self,
+        message_queue: Queue,
+        connection_config: ConnectionConfig,
+        application_config: ConfigType,
+        current_config_revision: ConfigRevision,
+    ) -> None:
+        # This code is run inside the new extractor process
+        extractor = self._extractor_class.init_from_runtime(
+            connection_config,
+            application_config,
+            current_config_revision,
+        )
+        extractor._set_runtime_message_queue(message_queue)
+
+        try:
+            with extractor:
+                extractor.run()
+
+        except Exception:
+            self.logger.exception("Extractor crashed, will attempt restart")
+            message_queue.put(RuntimeMessage.RESTART)
+
+    def _spawn_extractor(
+        self,
+        connection_config: ConnectionConfig,
+        application_config: ConfigType,
+        current_config_revision: ConfigRevision,
+    ) -> Process:
+        self._message_queue = Queue()
+        process = Process(
+            target=self._inner_run,
+            args=(self._message_queue, connection_config, application_config, current_config_revision),
+        )
+
+        process.start()
+        self.logger.info(f"Started extractor as {process.pid}")
+        return process
+
+    def _get_application_config(
+        self,
+        args: Namespace,
+        connection_config: ConnectionConfig,
+    ) -> tuple[ConfigType, ConfigRevision]:
+        current_config_revision: ConfigRevision
+        if args.local_override:
+            current_config_revision = "local"
+            application_config = load_file(args.local_override[0], self._extractor_class.CONFIG_TYPE)
+        else:
+            client = connection_config.get_cognite_client(
+                f"{self._extractor_class.EXTERNAL_ID}-{self._extractor_class.VERSION}"
+            )
+            application_config, current_config_revision = load_from_cdf(
+                client,
+                connection_config.extraction_pipeline,
+                self._extractor_class.CONFIG_TYPE,
+            )
+
+        return application_config, current_config_revision
+
+    def run(self) -> None:
+        argparser = self._create_argparser()
+        args = argparser.parse_args()
+
+        self.logger.info(f"Started runtime as {os.getpid()}")
+
+        connection_config = load_file(args.connection_config[0], ConnectionConfig)
+
+        # This has to be Any. We don't know the type of the extractors' config at type checking since the sel doesn't
+        # exist yet, and I have not found a way to represent it in a generic way that isn't just an Any in disguise.
+        application_config: Any
+        while not self._cancellation_token.is_cancelled:
+            application_config, current_config_revision = self._get_application_config(args, connection_config)
+            # Start extractor in separate process, and wait for it to end
+            process = self._spawn_extractor(connection_config, application_config, current_config_revision)
+            process.join()
+
+            # Check if we are asked to restart the extractor, shut down otherwise
+            if not self._message_queue.empty():
+                match self._message_queue.get_nowait():
+                    case RuntimeMessage.RESTART:
+                        continue
+
+                    case _:
+                        assert_never()
+
+            else:
+                self.logger.info("Shutting down runtime")
+                self._cancellation_token.cancel()

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -7,11 +7,7 @@ from multiprocessing import Process, Queue
 from pathlib import Path
 from typing import Any, Generic, Type, TypeVar
 
-try:
-    from typing import assert_never
-except ImportError:
-    # workaround for 3.10
-    from typing_extensions import assert_never
+from typing_extensions import assert_never
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.loaders import load_file, load_from_cdf

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -5,9 +5,7 @@ import time
 from argparse import ArgumentParser, Namespace
 from multiprocessing import Process, Queue
 from pathlib import Path
-from typing import Any, Generic, Type, TypeVar
-
-from typing_extensions import assert_never
+from typing import Any, Generic, Type, TypeVar, assert_never
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.loaders import load_file, load_from_cdf
@@ -158,12 +156,13 @@ class Runtime(Generic[ExtractorType]):
 
             # Check if we are asked to restart the extractor, shut down otherwise
             if not self._message_queue.empty():
-                match self._message_queue.get_nowait():
+                message = self._message_queue.get_nowait()
+                match message:
                     case RuntimeMessage.RESTART:
                         continue
 
                     case _:
-                        assert_never()
+                        assert_never(message)
 
             else:
                 self.logger.info("Shutting down runtime")

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -5,7 +5,9 @@ import time
 from argparse import ArgumentParser, Namespace
 from multiprocessing import Process, Queue
 from pathlib import Path
-from typing import Any, Generic, Type, TypeVar, assert_never
+from typing import Any, Generic, Type, TypeVar
+
+from typing_extensions import assert_never
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.loaders import load_file, load_from_cdf

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -5,7 +5,13 @@ import time
 from argparse import ArgumentParser, Namespace
 from multiprocessing import Process, Queue
 from pathlib import Path
-from typing import Any, Generic, Type, TypeVar, assert_never
+from typing import Any, Generic, Type, TypeVar
+
+try:
+    from typing import assert_never
+except ImportError:
+    # workaround for 3.10
+    from typing_extensions import assert_never
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.loaders import load_file, load_from_cdf


### PR DESCRIPTION
The idea here is to split the responsibilities of the current base class into two: A runtime and an extractor.

The runtime is responsible for parsing command line arguments, loading config files and so on, before spawning the extractor in a separate process. The runtime will automatically restart the extractor if it crashes, but can also be asked by the extractor to restart it -  for example after a config change.

The extractor class is then only responsible for running the extractor application itself, making it much cleaner.