### PR TITLE
Add error reporting to integrations POC

### DIFF
--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -236,4 +236,4 @@ LogHandlerConfig = Union[LogFileHandlerConfig, LogConsoleHandlerConfig]
 
 
 class ExtractorConfig(ConfigModel):
-    log_handlers: List[LogHandlerConfig] = Field(default_factory=lambda: [LogConsoleHandlerConfig(level=LogLevel.INFO)])
+    log_handlers: List[LogHandlerConfig] = Field(default_factory=lambda: [LogConsoleHandlerConfig(level=LogLevel.INFO)])  # type: ignore[arg-type]

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -7,6 +7,8 @@ from typing import Any, Literal
 from humps import camelize
 from pydantic import BaseModel, ConfigDict
 
+from cognite.extractorutils.unstable.core.errors import ErrorLevel
+
 
 class CogniteModel(BaseModel):
     """
@@ -32,3 +34,13 @@ class TaskUpdate(CogniteModel):
     type: Literal["started"] | Literal["ended"]
     name: str
     timestamp: int
+
+
+class Error(CogniteModel):
+    external_id: str
+    level: ErrorLevel
+    description: str
+    details: str | None
+    start_time: int
+    end_time: int | None
+    task: str | None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -7,8 +7,6 @@ from typing import Any, Literal
 from humps import camelize
 from pydantic import BaseModel, ConfigDict
 
-from cognite.extractorutils.unstable.core.errors import ErrorLevel
-
 
 class CogniteModel(BaseModel):
     """
@@ -38,7 +36,7 @@ class TaskUpdate(CogniteModel):
 
 class Error(CogniteModel):
     external_id: str
-    level: ErrorLevel
+    level: str
     description: str
     details: str | None
     start_time: int

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -113,7 +113,13 @@ class Extractor(Generic[ConfigType]):
         details: str | None = None,
         task: Task | None = None,
     ) -> Error:
-        return Error(level=level, description=description, details=details, extractor=self, task=task)
+        return Error(
+            level=level,
+            description=description,
+            details=details,
+            extractor=self,
+            task=task,
+        )
 
     def restart(self) -> None:
         if self._runtime_messages:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -71,7 +71,7 @@ class Extractor(Generic[ConfigType]):
             error_updates = [
                 DtoError(
                     external_id=e.external_id,
-                    level=e.level,
+                    level=e.level.value,
                     description=e.description,
                     details=e.details,
                     start_time=e.start_time,

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -154,7 +154,7 @@ class Extractor(Generic[ConfigType]):
                     ErrorLevel.fatal,
                     description="Task crashed unexpectedly",
                     details="".join(format_exception(e)),
-                ).finish()
+                ).instant()
 
                 raise e
 

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -3,7 +3,6 @@ from enum import Enum
 from types import TracebackType
 from uuid import uuid4
 
-from cognite.extractorutils.unstable.core.tasks import Task
 from cognite.extractorutils.util import now
 
 if typing.TYPE_CHECKING:
@@ -22,7 +21,7 @@ class Error:
         level: ErrorLevel,
         description: str,
         details: str | None,
-        task: Task | None,
+        task_name: str | None,
         extractor: "Extractor",
     ) -> None:
         self.level = level
@@ -34,7 +33,7 @@ class Error:
         self.end_time: int | None = None
 
         self._extractor = extractor
-        self._task = task
+        self._task_name = task_name
 
         self._extractor._report_error(self)
 

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -1,0 +1,71 @@
+import typing
+from enum import Enum
+from types import TracebackType
+from uuid import uuid4
+
+from cognite.extractorutils.unstable.core.tasks import Task
+from cognite.extractorutils.util import now
+
+if typing.TYPE_CHECKING:
+    from .base import Extractor
+
+
+class ErrorLevel(Enum):
+    warning = "warning"
+    error = "error"
+    fatal = "fatal"
+
+
+class Error:
+    def __init__(
+        self,
+        level: ErrorLevel,
+        description: str,
+        details: str | None,
+        task: Task | None,
+        extractor: "Extractor",
+    ) -> None:
+        self.level = level
+        self.description = description
+        self.details = details
+
+        self.external_id = uuid4().hex
+        self.start_time = now()
+        self.end_time: int | None = None
+
+        self._extractor = extractor
+        self._task = task
+
+        self._extractor._report_error(self)
+
+    def instant(self) -> None:
+        # Only end the error once
+        if self.end_time is not None:
+            return
+
+        self.end_time = self.start_time
+
+        # Re-add in case the error has already been reported and dict cleared
+        self._extractor._report_error(self)
+
+    def finish(self) -> None:
+        # Only end the error once
+        if self.end_time is not None:
+            return
+
+        self.end_time = now()
+
+        # Re-add in case the error has already been reported and dict cleared
+        self._extractor._report_error(self)
+
+    def __enter__(self) -> "Error":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: typing.Type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        self.finish()
+        return exc_val is None

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -28,7 +28,7 @@ class Error:
         self.description = description
         self.details = details
 
-        self.external_id = uuid4().hex
+        self.external_id = str(uuid4())
         self.start_time = now()
         self.end_time: int | None = None
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -87,7 +87,7 @@ class Runtime(Generic[ExtractorType]):
         current_config_revision: ConfigRevision,
     ) -> None:
         # This code is run inside the new extractor process
-        extractor = self._extractor_class.init_from_runtime(
+        extractor = self._extractor_class._init_from_runtime(
             connection_config,
             application_config,
             current_config_revision,

--- a/tests/test_unstable/test_errors.py
+++ b/tests/test_unstable/test_errors.py
@@ -1,0 +1,142 @@
+from time import sleep
+
+from cognite.extractorutils.unstable.configuration.models import ConnectionConfig, IntervalConfig, TimeIntervalConfig
+from cognite.extractorutils.unstable.core.errors import ErrorLevel
+from cognite.extractorutils.unstable.core.tasks import ScheduledTask
+from tests.test_unstable.conftest import TestConfig, TestExtractor
+
+
+def test_global_error(
+    connection_config: ConnectionConfig,
+    application_config: TestConfig,
+) -> None:
+    extractor = TestExtractor(
+        connection_config=connection_config,
+        application_config=application_config,
+        current_config_revision=1,
+    )
+
+    err = extractor.error(level=ErrorLevel.error, description="Oh no!", details="There was an error")
+
+    assert len(extractor._errors) == 1
+    assert err.external_id in extractor._errors
+
+    wait_time = 50
+    sleep(wait_time / 1000)
+
+    err.finish()
+
+    slack = 5
+
+    assert len(extractor._errors) == 1
+    assert err.start_time + wait_time - slack < err.end_time < err.start_time + wait_time + slack
+    assert extractor._errors[err.external_id].end_time == err.end_time
+    assert err._task_name is None
+
+
+def test_instant_error(
+    connection_config: ConnectionConfig,
+    application_config: TestConfig,
+) -> None:
+    extractor = TestExtractor(
+        connection_config=connection_config,
+        application_config=application_config,
+        current_config_revision=1,
+    )
+
+    err = extractor.error(level=ErrorLevel.error, description="Oh no!", details="There was an error")
+
+    assert len(extractor._errors) == 1
+    assert err.external_id in extractor._errors
+
+    sleep(0.05)
+
+    err.instant()
+
+    assert len(extractor._errors) == 1
+    assert err.end_time == err.start_time
+    assert extractor._errors[err.external_id].end_time == err.end_time
+    assert err._task_name is None
+
+
+def test_task_error(
+    connection_config: ConnectionConfig,
+    application_config: TestConfig,
+) -> None:
+    extractor = TestExtractor(
+        connection_config=connection_config,
+        application_config=application_config,
+        current_config_revision=1,
+    )
+
+    def task() -> None:
+        sleep(0.05)
+        extractor.error(level=ErrorLevel.warning, description="Hey now").instant()
+        sleep(0.05)
+
+    extractor.add_task(
+        ScheduledTask(
+            "TestTask",
+            target=task,
+            schedule=IntervalConfig(
+                type="interval",
+                expression=TimeIntervalConfig("15m"),
+            ),
+        )
+    )
+
+    extractor._report_extractor_info()
+    extractor._scheduler.trigger("TestTask")
+
+    sleep(0.3)
+
+    assert len(extractor._task_updates) == 2
+    assert len(extractor._errors) == 1
+
+    error = list(extractor._errors.values())[0]
+    assert error.description == "Hey now"
+    assert error.level == ErrorLevel.warning
+
+    # Make sure error was recorded as a task error
+    assert error._task_name == "TestTask"
+
+
+def test_crashing_task(
+    connection_config: ConnectionConfig,
+    application_config: TestConfig,
+) -> None:
+    extractor = TestExtractor(
+        connection_config=connection_config,
+        application_config=application_config,
+        current_config_revision=1,
+    )
+
+    def task() -> None:
+        sleep(0.05)
+        raise ValueError("Try catching this!")
+
+    extractor.add_task(
+        ScheduledTask(
+            "TestTask",
+            target=task,
+            schedule=IntervalConfig(
+                type="interval",
+                expression=TimeIntervalConfig("15m"),
+            ),
+        )
+    )
+
+    extractor._report_extractor_info()
+    extractor._scheduler.trigger("TestTask")
+
+    sleep(0.3)
+
+    assert len(extractor._task_updates) == 2
+    assert len(extractor._errors) == 1
+
+    error = list(extractor._errors.values())[0]
+    assert error.description == "Task crashed unexpectedly"
+    assert error.level == ErrorLevel.fatal
+
+    # Make sure error was recorded as a task error
+    assert error._task_name == "TestTask"


### PR DESCRIPTION
Add an `error` method to the `Extractor` class that starts tracking of an error. This can be used in one of two ways, either by manually starting and stopping the error state:

``` python
e = extractor.error(...)

# handle error

e.finish()
```

or by using it as a context

``` python
with extractor.error(...):
    # Handle error
```

You can create an instant error (with no duration) by using the `instant()` method:

``` python
extractor.error(...).instant()
```

Tracking of start/end times, generating and keeping track of external IDs, reporting in checkins, and so on is all handled automatically.