### PR TITLE
Add a custom constructor for extractors

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -60,6 +60,11 @@ class Extractor(Generic[ConfigType]):
 
         self._current_task: ContextVar[str | None] = ContextVar("current_task", default=None)
 
+        self.__init_tasks__()
+
+    def __init_tasks__(self) -> None:
+        pass
+
     def _set_runtime_message_queue(self, queue: Queue) -> None:
         self._runtime_messages = queue
 


### PR DESCRIPTION
The `__init__` method is somewhat clunky to override in subclasses, since you have to remember to take in the correct parameters and call `super(...)`` correctly. I propose this instead as a way to define the tasks for an extractor

``` python
class MyExtractor(Extractor):

    def __init_tasks__(self):
        self.add_task(...)
        self.add_task(...)
```