### PR TITLE
Don't look for config updates when running local configs

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -101,7 +101,11 @@ class Extractor(Generic[ConfigType]):
         )
         new_config_revision = res.json().get("lastConfigRevision")
 
-        if new_config_revision and new_config_revision != self.current_config_revision:
+        if (
+            new_config_revision
+            and self.current_config_revision != "local"
+            and new_config_revision != self.current_config_revision
+        ):
             self.restart()
 
     def _run_checkin(self) -> None:

--- a/cognite/extractorutils/unstable/scheduling/_scheduler.py
+++ b/cognite/extractorutils/unstable/scheduling/_scheduler.py
@@ -56,7 +56,7 @@ class TaskScheduler:
     def _run_job(self, job: Job) -> bool:
         with self._running_lock:
             if job in self._running:
-                self._logger.warning(f"Job {job.name} already running")
+                self._logger.warning(f"Job '{job.name}' already running")
                 return False
 
         def wrap() -> None:
@@ -65,7 +65,7 @@ class TaskScheduler:
             try:
                 job.call()
 
-                self._logger.info(f"Job {job.name} done. Next run at {arrow.get(job.schedule.next()).isoformat()}")
+                self._logger.info(f"Job '{job.name}' done. Next run at {arrow.get(job.schedule.next()).isoformat()}")
 
             finally:
                 with self._running_lock:
@@ -97,7 +97,7 @@ class TaskScheduler:
                     break
 
             for job in next_runs:
-                self._logger.info(f"Starting job {job.name}")
+                self._logger.info(f"Starting job '{job.name}'")
                 self._run_job(job)
 
     def stop(self) -> None:


### PR DESCRIPTION
This caused the extractor to restart after each checkin when running with a local config file