### PR TITLE
Revert "Version change to 7.5.5"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,6 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## 7.5.5
-
-### Added
-
-* Added the ability to report a list of files and the reasons they couldn't be uploaded
-
-### Changed
-
-* Added better mapping of log levels to avoid aggressive logging from HTTPX and HTTPCORE
-
-### Fixed
-
-* Handling of files with size 0
-
-
 ## 7.5.4
 
 ### Fixed

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.5.5"
+__version__ = "7.5.4"
 from .base import Extractor
 
 __all__ = ["Extractor"]


### PR DESCRIPTION
Reverts cognitedata/python-extractor-utils#407

Need to revert this since `pyproject.toml` was not updated as part of this, due to which release was unsuccesful. 