### PR TITLE
Nithin/version bump to 7.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes are grouped as follows
 
 ## 7.5.5
 
-### Added
+### Changed
 
 * Added better mapping of log levels to avoid aggressive logging from HTTPX and HTTPCORE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.5.5
+
+### Added
+
+* Added better mapping of log levels to avoid aggressive logging from HTTPX and HTTPCORE
+
+### Fixed
+
+* Handling of files with size 0
+
+
 ## 7.5.4
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes are grouped as follows
 
 ## 7.5.5
 
+### Added
+
+* Added the ability to report a list of files and the reasons they couldn't be uploaded
+
 ### Changed
 
 * Added better mapping of log levels to avoid aggressive logging from HTTPX and HTTPCORE

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,5 +16,5 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.5.4"
+__version__ = "7.5.5"
 from .base import Extractor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.5.5"
+version = "7.5.4"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.5.4"
+version = "7.5.5"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Had to revert the changes from previous PR because `pyproject.toml` wasn't updated. This should trigger a release for extractor-utils