### PR TITLE
Enable `UP` rule in ruff

### DIFF
--- a/cognite/extractorutils/_inner_util.py
+++ b/cognite/extractorutils/_inner_util.py
@@ -40,7 +40,7 @@ class _DecimalEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> dict[str, str]:
         if isinstance(obj, Decimal):
             return {"type": "decimal_encoded", "value": str(obj)}
-        return super(_DecimalEncoder, self).default(obj)
+        return super().default(obj)
 
 
 class _DecimalDecoder(json.JSONDecoder):

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -15,11 +15,12 @@
 import logging
 import os
 import sys
+from collections.abc import Callable
 from dataclasses import is_dataclass
 from enum import Enum
 from threading import Thread
 from types import TracebackType
-from typing import Any, Callable, Generic, Type, TypeVar
+from typing import Any, Generic, TypeVar
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -79,7 +80,7 @@ class Extractor(Generic[CustomConfigClass]):
         description: str,
         version: str | None = None,
         run_handle: RunHandle | None = None,
-        config_class: Type[CustomConfigClass],
+        config_class: type[CustomConfigClass],
         metrics: BaseMetrics | None = None,
         use_default_state_store: bool = True,
         cancellation_token: CancellationToken | None = None,
@@ -322,7 +323,7 @@ class Extractor(Generic[CustomConfigClass]):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> bool:
         """
         Shuts down the extractor. Makes sure states are preserved, that all uploads of data and metrics are done, etc.

--- a/cognite/extractorutils/configtools/_util.py
+++ b/cognite/extractorutils/configtools/_util.py
@@ -13,8 +13,9 @@
 #  limitations under the License.
 import base64
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization as serialization

--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -770,7 +770,7 @@ class CastableInt(int):
         floats and other types supported by standard int.
         """
 
-        if not isinstance(value, (int, str, bytes)):
+        if not isinstance(value, int | str | bytes):
             raise ValueError(f"CastableInt cannot be created form value {value!r} of type {type(value)!r}.")
 
         return super().__new__(cls, value)

--- a/cognite/extractorutils/exceptions.py
+++ b/cognite/extractorutils/exceptions.py
@@ -23,7 +23,7 @@ class InvalidConfigError(Exception):
     """
 
     def __init__(self, message: str, details: list[str] | None = None):
-        super(InvalidConfigError, self).__init__()
+        super().__init__()
         self.message = message
         self.details = details
 

--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -41,9 +41,10 @@ import logging
 import os
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from time import sleep
 from types import TracebackType
-from typing import Any, Callable, Type, TypeVar
+from typing import Any, TypeVar
 
 import arrow
 import psutil
@@ -65,7 +66,7 @@ _metrics_singularities = {}
 T = TypeVar("T")
 
 
-def safe_get(cls: Type[T], *args: Any, **kwargs: Any) -> T:
+def safe_get(cls: type[T], *args: Any, **kwargs: Any) -> T:
     """
     A factory for instances of metrics collections.
 
@@ -232,7 +233,7 @@ class AbstractMetricsPusher(ABC):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         """
         Wraps around stop method, for use as context manager
@@ -269,7 +270,7 @@ class PrometheusPusher(AbstractMetricsPusher):
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
     ):
-        super(PrometheusPusher, self).__init__(push_interval, thread_name, cancellation_token)
+        super().__init__(push_interval, thread_name, cancellation_token)
 
         self.username = username
         self.job_name = job_name
@@ -345,7 +346,7 @@ class CognitePusher(AbstractMetricsPusher):
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
     ):
-        super(CognitePusher, self).__init__(push_interval, thread_name, cancellation_token)
+        super().__init__(push_interval, thread_name, cancellation_token)
 
         self.cdf_client = cdf_client
         self.asset = asset
@@ -409,7 +410,7 @@ class CognitePusher(AbstractMetricsPusher):
         datapoints: list[dict[str, str | int | list[Any] | Datapoints | DatapointsArray]] = []
 
         for metric in REGISTRY.collect():
-            if type(metric) == Metric and metric.type in ["gauge", "counter"]:
+            if isinstance(metric, Metric) and metric.type in ["gauge", "counter"]:
                 if len(metric.samples) == 0:
                     continue
 

--- a/cognite/extractorutils/statestore/hashing.py
+++ b/cognite/extractorutils/statestore/hashing.py
@@ -1,8 +1,9 @@
 import hashlib
 import json
 from abc import ABC
+from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import Any, Iterable, Iterator, Type
+from typing import Any
 
 import orjson
 
@@ -66,8 +67,7 @@ class AbstractHashStateStore(_BaseStateStore, ABC):
 
     def __iter__(self) -> Iterator[str]:
         with self.lock:
-            for key in self._local_state:
-                yield key
+            yield from self._local_state
 
 
 class RawHashStateStore(AbstractHashStateStore):
@@ -169,7 +169,7 @@ class RawHashStateStore(AbstractHashStateStore):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
@@ -214,7 +214,7 @@ class LocalHashStateStore(AbstractHashStateStore):
 
         with self.lock:
             try:
-                with open(self._file_path, "r") as f:
+                with open(self._file_path) as f:
                     self._local_state = json.load(f, cls=_DecimalDecoder)
             except FileNotFoundError:
                 pass
@@ -243,7 +243,7 @@ class LocalHashStateStore(AbstractHashStateStore):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:

--- a/cognite/extractorutils/threading.py
+++ b/cognite/extractorutils/threading.py
@@ -17,7 +17,7 @@ class CancellationToken:
     def __init__(self, condition: Condition | None = None) -> None:
         self._cv: Condition = condition or Condition()
         self._is_cancelled_int: bool = False
-        self._parent: "CancellationToken" | None = None
+        self._parent: CancellationToken | None = None
 
     def __repr__(self) -> str:
         cls = self.__class__

--- a/cognite/extractorutils/unstable/configuration/exceptions.py
+++ b/cognite/extractorutils/unstable/configuration/exceptions.py
@@ -1,6 +1,3 @@
-from typing import List, Optional
-
-
 class InvalidConfigError(Exception):
     """
     Exception thrown from ``load_yaml`` and ``load_yaml_dict`` if config file is invalid. This can be due to
@@ -10,8 +7,8 @@ class InvalidConfigError(Exception):
       * Unkown fields
     """
 
-    def __init__(self, message: str, details: Optional[List[str]] = None):
-        super(InvalidConfigError, self).__init__()
+    def __init__(self, message: str, details: list[str] | None = None):
+        super().__init__()
         self.message = message
         self.details = details
 

--- a/cognite/extractorutils/unstable/configuration/loaders.py
+++ b/cognite/extractorutils/unstable/configuration/loaders.py
@@ -2,7 +2,7 @@ import json
 from enum import Enum
 from io import StringIO
 from pathlib import Path
-from typing import Dict, Optional, TextIO, Tuple, Type, TypeVar, Union
+from typing import TextIO, TypeVar
 
 from pydantic import ValidationError
 
@@ -23,7 +23,7 @@ class ConfigFormat(Enum):
     YAML = "yaml"
 
 
-def load_file(path: Path, schema: Type[_T]) -> _T:
+def load_file(path: Path, schema: type[_T]) -> _T:
     if path.suffix in [".yaml", ".yml"]:
         format = ConfigFormat.YAML
     elif path.suffix == ".json":
@@ -31,14 +31,14 @@ def load_file(path: Path, schema: Type[_T]) -> _T:
     else:
         raise InvalidConfigError(f"Unknown file type {path.suffix}")
 
-    with open(path, "r") as stream:
+    with open(path) as stream:
         return load_io(stream, format, schema)
 
 
 def load_from_cdf(
-    cognite_client: CogniteClient, external_id: str, schema: Type[_T], revision: Optional[int] = None
-) -> Tuple[_T, int]:
-    params: Dict[str, Union[str, int]] = {"externalId": external_id}
+    cognite_client: CogniteClient, external_id: str, schema: type[_T], revision: int | None = None
+) -> tuple[_T, int]:
+    params: dict[str, str | int] = {"externalId": external_id}
     if revision:
         params["revision"] = revision
     response = cognite_client.get(
@@ -61,7 +61,7 @@ def load_from_cdf(
         raise new_e from e
 
 
-def load_io(stream: TextIO, format: ConfigFormat, schema: Type[_T]) -> _T:
+def load_io(stream: TextIO, format: ConfigFormat, schema: type[_T]) -> _T:
     if format == ConfigFormat.JSON:
         data = json.load(stream)
 
@@ -97,7 +97,7 @@ def _make_loc_str(loc: tuple) -> str:
     return loc_str
 
 
-def load_dict(data: dict, schema: Type[_T]) -> _T:
+def load_dict(data: dict, schema: type[_T]) -> _T:
     try:
         return schema.model_validate(data)
 

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -2,7 +2,7 @@ import re
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Literal
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
@@ -49,21 +49,21 @@ class _ClientCredentialsConfig(ConfigModel):
     client_id: str
     client_secret: str
     token_url: str
-    scopes: List[str]
-    resource: Optional[str] = None
-    audience: Optional[str] = None
+    scopes: list[str]
+    resource: str | None = None
+    audience: str | None = None
 
 
 class _ClientCertificateConfig(ConfigModel):
     type: Literal["client-certificate"]
     client_id: str
     path: Path
-    password: Optional[str] = None
+    password: str | None = None
     authority_url: str
-    scopes: List[str]
+    scopes: list[str]
 
 
-AuthenticationConfig = Annotated[Union[_ClientCredentialsConfig, _ClientCertificateConfig], Field(discriminator="type")]
+AuthenticationConfig = Annotated[_ClientCredentialsConfig | _ClientCertificateConfig, Field(discriminator="type")]
 
 
 class TimeIntervalConfig:
@@ -76,7 +76,7 @@ class TimeIntervalConfig:
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
-        return core_schema.no_info_after_validator_function(cls, handler(Union[str, int]))
+        return core_schema.no_info_after_validator_function(cls, handler(str | int))
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TimeIntervalConfig):
@@ -140,13 +140,13 @@ class TimeIntervalConfig:
 
 class _ConnectionParameters(ConfigModel):
     gzip_compression: bool = False
-    status_forcelist: List[int] = Field(default_factory=lambda: [429, 502, 503, 504])
+    status_forcelist: list[int] = Field(default_factory=lambda: [429, 502, 503, 504])
     max_retries: int = 10
     max_retries_connect: int = 3
     max_retry_backoff: TimeIntervalConfig = Field(default_factory=lambda: TimeIntervalConfig("30s"))
     max_connection_pool_size: int = 50
     ssl_verify: bool = True
-    proxies: Dict[str, str] = Field(default_factory=dict)
+    proxies: dict[str, str] = Field(default_factory=dict)
     timeout: TimeIntervalConfig = Field(default_factory=lambda: TimeIntervalConfig("30s"))
 
 
@@ -253,9 +253,9 @@ LogHandlerConfig = Annotated[LogFileHandlerConfig | LogConsoleHandlerConfig, Fie
 
 
 # Mypy BS
-def _log_handler_default() -> List[LogHandlerConfig]:
+def _log_handler_default() -> list[LogHandlerConfig]:
     return [LogConsoleHandlerConfig(type="console", level=LogLevel.INFO)]
 
 
 class ExtractorConfig(ConfigModel):
-    log_handlers: List[LogHandlerConfig] = Field(default_factory=_log_handler_default)
+    log_handlers: list[LogHandlerConfig] = Field(default_factory=_log_handler_default)

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -8,7 +8,7 @@ from multiprocessing import Queue
 from threading import RLock, Thread
 from traceback import format_exception
 from types import TracebackType
-from typing import Generic, Literal, Type, TypeVar
+from typing import Generic, Literal, TypeVar
 
 from humps import pascalize
 from typing_extensions import Self, assert_never
@@ -59,7 +59,7 @@ class Extractor(Generic[ConfigType]):
     DESCRIPTION: str
     VERSION: str
 
-    CONFIG_TYPE: Type[ConfigType]
+    CONFIG_TYPE: type[ConfigType]
 
     RESTART_POLICY: RestartPolicy = WHEN_CONTINUOUS_TASKS_CRASHES
 
@@ -305,7 +305,7 @@ class Extractor(Generic[ConfigType]):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool:

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -64,7 +64,7 @@ class Error:
 
     def __exit__(
         self,
-        exc_type: typing.Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> bool:

--- a/cognite/extractorutils/unstable/core/restart_policy.py
+++ b/cognite/extractorutils/unstable/core/restart_policy.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from cognite.extractorutils.unstable.core.tasks import ContinuousTask, Task
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -5,7 +5,7 @@ import time
 from argparse import ArgumentParser, Namespace
 from multiprocessing import Process, Queue
 from pathlib import Path
-from typing import Any, Generic, Type, TypeVar
+from typing import Any, Generic, TypeVar
 from uuid import uuid4
 
 from requests.exceptions import ConnectionError
@@ -30,7 +30,7 @@ ExtractorType = TypeVar("ExtractorType", bound=Extractor)
 class Runtime(Generic[ExtractorType]):
     def __init__(
         self,
-        extractor: Type[ExtractorType],
+        extractor: type[ExtractorType],
     ) -> None:
         self._extractor_class = extractor
         self._cancellation_token = CancellationToken()

--- a/cognite/extractorutils/unstable/core/tasks.py
+++ b/cognite/extractorutils/unstable/core/tasks.py
@@ -1,6 +1,6 @@
 from abc import ABC
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from cognite.extractorutils.unstable.configuration.models import ScheduleConfig
 

--- a/cognite/extractorutils/unstable/scheduling/_scheduler.py
+++ b/cognite/extractorutils/unstable/scheduling/_scheduler.py
@@ -1,8 +1,8 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 from logging import getLogger
 from threading import RLock, Thread
 from time import time
-from typing import Callable
 
 import arrow
 from humps import pascalize

--- a/cognite/extractorutils/uploader/_base.py
+++ b/cognite/extractorutils/uploader/_base.py
@@ -15,8 +15,9 @@
 import logging
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from arrow import Arrow
 

--- a/cognite/extractorutils/uploader/assets.py
+++ b/cognite/extractorutils/uploader/assets.py
@@ -12,8 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, Type
+from typing import Any
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.assets import Asset
@@ -147,7 +148,7 @@ class AssetUploadQueue(AbstractUploadQueue):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:

--- a/cognite/extractorutils/uploader/data_modeling.py
+++ b/cognite/extractorutils/uploader/data_modeling.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, Type
+from typing import Any
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes.data_modeling import EdgeApply, NodeApply
@@ -100,7 +101,7 @@ class InstanceUploadQueue(AbstractUploadQueue):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:

--- a/cognite/extractorutils/uploader/events.py
+++ b/cognite/extractorutils/uploader/events.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from collections.abc import Callable
 from types import TracebackType
-from typing import Callable, Type
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Event
@@ -151,7 +151,7 @@ class EventUploadQueue(AbstractUploadQueue):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         """
         Wraps around stop method, for use as context manager

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import threading
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from io import BytesIO, RawIOBase
 from math import ceil
@@ -21,12 +22,6 @@ from types import TracebackType
 from typing import (
     Any,
     BinaryIO,
-    Callable,
-    Iterator,
-    List,
-    Optional,
-    Type,
-    Union,
 )
 from urllib.parse import ParseResult, urlparse
 
@@ -67,7 +62,7 @@ _MAX_FILE_CHUNK_SIZE = 4 * 1024 * 1024 * 1000
 _CDF_ALPHA_VERSION_HEADER = {"cdf-version": "alpha"}
 
 
-FileMetadataOrCogniteExtractorFile = Union[FileMetadata, CogniteExtractorFileApply]
+FileMetadataOrCogniteExtractorFile = FileMetadata | CogniteExtractorFileApply
 
 
 class ChunkedStream(RawIOBase, BinaryIO):
@@ -111,7 +106,7 @@ class ChunkedStream(RawIOBase, BinaryIO):
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,
+        exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
@@ -146,7 +141,7 @@ class ChunkedStream(RawIOBase, BinaryIO):
         if size > 0:
             self._pos += size
             return self._inner.read(size)
-        return bytes()
+        return b""
 
     def next_chunk(self) -> bool:
         """
@@ -209,8 +204,8 @@ class IOFileUploadQueue(AbstractUploadQueue):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         overwrite_existing: bool = False,
-        cancellation_token: Optional[CancellationToken] = None,
-        max_parallelism: Optional[int] = None,
+        cancellation_token: CancellationToken | None = None,
+        max_parallelism: int | None = None,
         failure_logging_path: None | str = None,
         ssl_verify: bool | str = True,
     ):
@@ -231,8 +226,8 @@ class IOFileUploadQueue(AbstractUploadQueue):
         self.failure_logging_path = failure_logging_path or None
         self.initialize_failure_logging()
 
-        self.upload_queue: List[Future] = []
-        self.errors: List[Exception] = []
+        self.upload_queue: list[Future] = []
+        self.errors: list[Exception] = []
 
         self.overwrite_existing = overwrite_existing
 
@@ -429,7 +424,7 @@ class IOFileUploadQueue(AbstractUploadQueue):
         self,
         file_meta: FileMetadataOrCogniteExtractorFile,
         read_file: Callable[[], BinaryIO],
-        extra_retries: tuple[Type[Exception], ...] | dict[Type[Exception], Callable[[Any], bool]] | None = None,
+        extra_retries: tuple[type[Exception], ...] | dict[type[Exception], Callable[[Any], bool]] | None = None,
     ) -> None:
         """
         Add file to upload queue. The file will start uploading immedeately. If the size of the queue is larger than
@@ -584,9 +579,9 @@ class IOFileUploadQueue(AbstractUploadQueue):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         """
         Wraps around stop method, for use as context manager
@@ -649,7 +644,7 @@ class FileUploadQueue(IOFileUploadQueue):
     def add_to_upload_queue(
         self,
         file_meta: FileMetadataOrCogniteExtractorFile,
-        file_name: Union[str, PathLike],
+        file_name: str | PathLike,
     ) -> None:
         """
         Add file to upload queue. The queue will be uploaded if the queue size is larger than the threshold

--- a/cognite/extractorutils/uploader/raw.py
+++ b/cognite/extractorutils/uploader/raw.py
@@ -12,8 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from collections.abc import Callable
 from types import TracebackType
-from typing import Any, Callable, Type
+from typing import Any
 
 import arrow
 from arrow import Arrow
@@ -162,7 +163,7 @@ class RawUploadQueue(AbstractUploadQueue):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> None:
         """
         Wraps around stop method, for use as context manager

--- a/cognite/extractorutils/uploader/upload_failure_handler.py
+++ b/cognite/extractorutils/uploader/upload_failure_handler.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterator
 from datetime import datetime
-from typing import Iterator, List
 
 import jsonlines
 
@@ -9,7 +9,7 @@ class FileErrorMapping:
         self.file_name = file_name
         self.error_reason = error_reason
 
-    def __iter__(self) -> Iterator[List[str]]:
+    def __iter__(self) -> Iterator[list[str]]:
         return iter([[self.file_name, self.error_reason]])
 
 

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -16,9 +16,10 @@
 A module containing a slightly more advanced base extractor class, sorting a generic output into upload queues.
 """
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, Callable, Iterable, Type, TypeVar
+from typing import Any, TypeVar
 
 from more_itertools import peekable
 
@@ -80,7 +81,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         description: str,
         version: str | None = None,
         run_handle: RunHandle | None = None,
-        config_class: Type[UploaderExtractorConfigClass],
+        config_class: type[UploaderExtractorConfigClass],
         metrics: BaseMetrics | None = None,
         use_default_state_store: bool = True,
         cancellation_token: CancellationToken | None = None,
@@ -90,7 +91,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         handle_interrupts: bool = True,
         middleware: list[Callable[[dict], dict]] | None = None,
     ):
-        super(UploaderExtractor, self).__init__(
+        super().__init__(
             name=name,
             description=description,
             version=version,
@@ -144,7 +145,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         return item
 
     def __enter__(self) -> "UploaderExtractor":
-        super(UploaderExtractor, self).__enter__()
+        super().__enter__()
 
         queue_config = self.config.queues if self.config.queues else QueueConfigClass()
         self.event_queue = EventUploadQueue(
@@ -170,9 +171,9 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: TracebackType | None
     ) -> bool:
         self.event_queue.__exit__(exc_type, exc_val, exc_tb)
         self.raw_queue.__exit__(exc_type, exc_val, exc_tb)
         self.time_series_queue.__exit__(exc_type, exc_val, exc_tb)
-        return super(UploaderExtractor, self).__exit__(exc_type, exc_val, exc_tb)
+        return super().__exit__(exc_type, exc_val, exc_tb)

--- a/cognite/extractorutils/uploader_types.py
+++ b/cognite/extractorutils/uploader_types.py
@@ -1,4 +1,5 @@
-from typing import Iterable, TypeAlias
+from collections.abc import Iterable
+from typing import TypeAlias
 
 from cognite.client.data_classes import Event as _Event
 from cognite.client.data_classes import Row as _Row

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -20,12 +20,13 @@ extractors.
 import io
 import logging
 import random
+from collections.abc import Callable, Generator, Iterable
 from datetime import datetime, timezone
 from functools import partial, wraps
 from io import RawIOBase
 from threading import Thread
 from time import time
-from typing import Any, Callable, Generator, Iterable, Type, TypeVar
+from typing import Any, TypeVar
 
 from decorator import decorator
 
@@ -157,7 +158,7 @@ class EitherId:
         Returns:
             A string rep of the EitherId
         """
-        return "{}: {}".format(self.type(), self.content())
+        return f"{self.type()}: {self.content()}"
 
     def __repr__(self) -> str:
         """
@@ -313,7 +314,7 @@ _T2 = TypeVar("_T2")
 def _retry_internal(
     f: Callable[..., _T2],
     cancellation_token: CancellationToken,
-    exceptions: tuple[Type[Exception], ...] | dict[Type[Exception], Callable[[Exception], bool]],
+    exceptions: tuple[type[Exception], ...] | dict[type[Exception], Callable[[Exception], bool]],
     tries: int,
     delay: float,
     max_delay: float | None,
@@ -367,7 +368,7 @@ def _retry_internal(
 
 def retry(
     cancellation_token: CancellationToken | None = None,
-    exceptions: tuple[Type[Exception], ...] | dict[Type[Exception], Callable[[Any], bool]] = (Exception,),
+    exceptions: tuple[type[Exception], ...] | dict[type[Exception], Callable[[Any], bool]] = (Exception,),
     tries: int = 10,
     delay: float = 1,
     max_delay: float | None = 60,
@@ -415,7 +416,7 @@ def retry(
 
 def requests_exceptions(
     status_codes: list[int] | None = None,
-) -> dict[Type[Exception], Callable[[Any], bool]]:
+) -> dict[type[Exception], Callable[[Any], bool]]:
     """
     Retry exceptions from using the ``requests`` library. This will retry all connection and HTTP errors matching
     the given status codes.
@@ -449,7 +450,7 @@ def requests_exceptions(
 
 def httpx_exceptions(
     status_codes: list[int] | None = None,
-) -> dict[Type[Exception], Callable[[Any], bool]]:
+) -> dict[type[Exception], Callable[[Any], bool]]:
     """
     Retry exceptions from using the ``httpx`` library. This will retry all connection and HTTP errors matching
     the given status codes.
@@ -483,7 +484,7 @@ def httpx_exceptions(
 
 def cognite_exceptions(
     status_codes: list[int] | None = None,
-) -> dict[Type[Exception], Callable[[Any], bool]]:
+) -> dict[type[Exception], Callable[[Any], bool]]:
     """
     Retry exceptions from using the Cognite SDK. This will retry all connection and HTTP errors matching
     the given status codes.
@@ -499,7 +500,7 @@ def cognite_exceptions(
     status_codes = status_codes or [408, 425, 429, 500, 502, 503, 504]
 
     def handle_cognite_errors(exception: CogniteException) -> bool:
-        if isinstance(exception, (CogniteAPIError, CogniteFileUploadError)):
+        if isinstance(exception, CogniteAPIError | CogniteFileUploadError):
             return exception.code in status_codes
         return True
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # cognite-package-template documentation build configuration file, created by
 # sphinx-quickstart on Mon Jan  8 14:36:34 2018.
@@ -112,7 +111,7 @@ html_logo = "img/cognite_logo_white.png"
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "{}doc".format(project)
+htmlhelp_basename = f"{project}doc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -135,14 +134,14 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
-latex_documents = [(master_doc, "{}.tex".format(project), "{} Documentation".format(project), "Cognite", "manual")]
+latex_documents = [(master_doc, f"{project}.tex", f"{project} Documentation", "Cognite", "manual")]
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, project, "{} Documentation".format(project), [author], 1)]
+man_pages = [(master_doc, project, f"{project} Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -154,7 +153,7 @@ texinfo_documents = [
     (
         master_doc,
         project,
-        "{} Documentation".format(project),
+        f"{project} Documentation",
         author,
         project,
         "One line description of project.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,30 +12,32 @@ packages = [
 ]
 
 [tool.ruff]
-select = ["E", "F", "I", "T20", "S", "B"]
-ignore = ["S104", "S303", "S311"]
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
-unfixable = []
-
 exclude = [
     ".git",
     ".mypy_cache",
     ".ruff_cache",
 ]
-
 line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "T20", "S", "B", "UP"]
+ignore = ["S104", "S303", "S311"]
+fixable = ["A", "B", "C", "D", "E", "F", "I", "UP"]
+unfixable = []
+
+
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-target-version = "py310"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "T201", "S105", "S106", "S608", "E501", "S113", "F841", "B017"]
 "**/__init__.py" = ["F401"]
 "docs/*" = ["E402"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = ["alembic"]
 
 [tool.pytest.ini_options]
@@ -57,7 +59,7 @@ warn_unused_ignores = true
 exclude = "tests/*"
 
 [tool.poetry.dependencies]
-python = "^3.9.0"
+python = "^3.10.0"
 cognite-sdk = "^7.59.0"
 prometheus-client = ">0.7.0, <=1.0.0"
 arrow = "^1.0.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
+from collections.abc import Generator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Generator
 
 import pytest
 

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -1,6 +1,6 @@
 import os
+from collections.abc import Generator
 from time import sleep, time
-from typing import Generator
 from uuid import uuid4
 
 import pytest

--- a/tests/tests_integration/test_data_modeling_queue.py
+++ b/tests/tests_integration/test_data_modeling_queue.py
@@ -1,6 +1,5 @@
 import random
 from time import sleep
-from typing import Tuple
 
 import pytest
 from faker import Faker
@@ -29,7 +28,7 @@ def set_test_parameters() -> ParamTest:
     )
 
 
-def test_dm_upload_queue(set_upload_test: Tuple[CogniteClient, ParamTest]) -> None:
+def test_dm_upload_queue(set_upload_test: tuple[CogniteClient, ParamTest]) -> None:
     client, test_params = set_upload_test
     queue = InstanceUploadQueue(client)
 

--- a/tests/tests_integration/test_events_integration.py
+++ b/tests/tests_integration/test_events_integration.py
@@ -14,7 +14,6 @@
 
 import os
 import random
-from typing import Tuple
 
 import pytest
 
@@ -37,7 +36,7 @@ def set_test_parameters() -> ParamTest:
 
 
 @pytest.mark.parametrize("functions_runtime", ["true", "false"])
-def test_events_upload_queue_upsert(set_upload_test: Tuple[CogniteClient, ParamTest], functions_runtime: str):
+def test_events_upload_queue_upsert(set_upload_test: tuple[CogniteClient, ParamTest], functions_runtime: str):
     os.environ["COGNITE_FUNCTION_RUNTIME"] = functions_runtime
     client, test_parameter = set_upload_test
     queue = EventUploadQueue(cdf_client=client)

--- a/tests/tests_integration/test_file_integration.py
+++ b/tests/tests_integration/test_file_integration.py
@@ -17,7 +17,8 @@ import os
 import pathlib
 import random
 import time
-from typing import BinaryIO, Callable, Tuple
+from collections.abc import Callable
+from typing import BinaryIO
 
 import jsonlines
 import pytest
@@ -75,7 +76,7 @@ def await_is_uploaded_status(
 
 
 @pytest.mark.parametrize("functions_runtime", ["true"])
-def test_errored_file(set_upload_test: Tuple[CogniteClient, ParamTest], functions_runtime: str) -> None:
+def test_errored_file(set_upload_test: tuple[CogniteClient, ParamTest], functions_runtime: str) -> None:
     LOG_FAILURE_FILE = "integration_test_failure_log.jsonl"
     NO_PERMISSION_FILE = "file_with_no_permission.txt"
     FILE_REASON_MAP_KEY = "file_error_reason_map"

--- a/tests/tests_integration/test_raw_integration.py
+++ b/tests/tests_integration/test_raw_integration.py
@@ -42,7 +42,7 @@ def test_raw_upload_queue(set_upload_test: tuple[CogniteClient, ParamTest], func
     uploaded = []
 
     for i in range(500):
-        r = Row("key{:03}".format(i), {"col": "val{}".format(i)})
+        r = Row(f"key{i:03}", {"col": f"val{i}"})
 
         queue.add_to_upload_queue(test_parameter.database_name, test_parameter.table_name, r)
         uploaded.append(r)

--- a/tests/tests_unit/test_base.py
+++ b/tests/tests_unit/test_base.py
@@ -11,8 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable
 from unittest.mock import patch
 
 import pytest

--- a/tests/tests_unit/test_configtools.py
+++ b/tests/tests_unit/test_configtools.py
@@ -18,7 +18,6 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Union
 
 import pytest
 import yaml
@@ -235,7 +234,7 @@ def test_get_cognite_client_from_aad() -> None:
     config = load_yaml(config_raw, CogniteConfig)
     cdf = config.get_cognite_client("client_name", token_custom_args={"audience": "lol"})
     assert cdf.config.credentials.token_custom_args == {"audience": "lol"}
-    assert type(cdf.config.credentials) == OAuthClientCredentials
+    assert isinstance(cdf.config.credentials, OAuthClientCredentials)
     assert cdf.config.credentials.client_id == "cid"
     assert cdf.config.credentials.client_secret == "scrt"
     assert cdf.config.credentials.scopes == ["scp"]
@@ -439,7 +438,7 @@ def test_dump_and_reload_config() -> None:
 
     with open("test_dump_config.yml", "w") as config_file:
         yaml.dump(dataclasses.asdict(config), config_file)
-    with open("test_dump_config.yml", "r") as config_file:
+    with open("test_dump_config.yml") as config_file:
         load_yaml(config_file, BaseConfig)
 
 
@@ -553,7 +552,7 @@ def test_match_patterns() -> None:
 
 
 def test_compile_patterns() -> None:
-    patterns: list[Union[str, IgnorePattern]] = [
+    patterns: list[str | IgnorePattern] = [
         "a*c",
         IgnorePattern("d*f", flags=[RegExpFlag.IGNORECASE]),
         IgnorePattern("m*o", options=[RegExpFlag.IC]),

--- a/tests/tests_unit/test_statestore.py
+++ b/tests/tests_unit/test_statestore.py
@@ -18,7 +18,6 @@ import os
 import time
 from collections import OrderedDict
 from decimal import Decimal
-from typing import Type
 from unittest.mock import Mock, patch
 
 import pytest
@@ -138,7 +137,7 @@ def test_local_state_interaction() -> None:
 
 
 @patch("cognite.client.CogniteClient")
-def test_upload_queue_integration(MockCogniteClient: Type[CogniteClient]) -> None:
+def test_upload_queue_integration(MockCogniteClient: type[CogniteClient]) -> None:
     state_store = NoStateStore()
 
     upload_queue = TimeSeriesUploadQueue(


### PR DESCRIPTION
Also properly drop 3.9 support. #360 seems to have forgotten to edit the restriction in pyproject, just dropping testing for 3.9 (which will not work currently because of match statements).