### PR TITLE
Loosen dependency restriction on httpx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
+## 7.6.7
+
+### Changed
+
+* Loosened dependency restrictions on `0.*` packages
+
 ## 7.5.6
 
 ### Added

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.5.6"
+__version__ = "7.5.7"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils"
-version = "7.5.6"
+version = "7.5.7"
 description = "Utilities for easier development of extractors for CDF"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"
@@ -71,7 +71,7 @@ python-dotenv = "^1.0.0"
 azure-identity = "^1.14.0"
 azure-keyvault-secrets = "^4.7.0"
 orjson = "^3.10.3"
-httpx = "^0.27.0"
+httpx = ">=0.27.0, <1"
 pydantic = "^2.8.2"
 pyhumps = "^3.8.0"
 croniter = "^6.0.0"
@@ -94,7 +94,6 @@ pytest-order = "^1.0.1"
 parameterized = "*"
 requests = "^2.31.0"
 types-requests = "^2.31.0.20240125"
-httpx = "^0.27.0"
 faker = "^33.0.0"
 
 [build-system]

--- a/tests/tests_unit/test_cdf_upload_queues.py
+++ b/tests/tests_unit/test_cdf_upload_queues.py
@@ -284,6 +284,7 @@ def test_mock_private_link_upload(MockCogniteClient: Mock) -> None:
     base_url = URL(base_url_str)
 
     client.config.base_url = "https://qweasd-666.gremiocampeao.cognitedata.com"
+    client._config.client_name = "extutil-unit-test"
 
     queue = IOFileUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1, max_parallelism=1)
 


### PR DESCRIPTION
Using `^0.x.y` in poetry is quite problematic, since it locks it to _minor_ version and only allows patch updates. This makes it very hard to depend on this package since it both makes it hard to update packages _and_ makes the likelihood of unresolvable requirements much higher.

The same is really true for upper bounds in general, but to a lesser extent. There's a quite good blog post on it from one of the big guys in scientific python:

https://iscinumpy.dev/post/bound-version-constraints/