### PR TITLE
Switch build system to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ ignore = ["S104", "S303", "S311"]
 fixable = ["A", "B", "C", "D", "E", "F", "I", "UP"]
 unfixable = []
 
-
-
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
@@ -110,13 +108,12 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 exclude = "tests/*"
 
-[tool.setuptools.packages.find]
-where = ["."]
-exclude = ["tests*", "docs*"]
+[tool.hatch.build.targets.wheel]
+packages = ["cognite"]
 
-[tool.setuptools]
-py-modules = ["cognite"]
+[tool.hatch.build.targets.sdist]
+only-include = ["cognite"]
 
 [build-system]
-requires = ["setuptools >= 61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
setuptools produces straight-up invalid wheel files. From PyPI when trying to publish:

```
Upload failed with status code 400 Bad Request. Server says: 400
license-file introduced in metadata version 2.4, not 2.2. See
https://packaging.python.org/specifications/core-metadata for more
information.
```

I tried rebuilding the packages locally, and saw the same discrepancy in the wheel file. Hatchling gets it right, it's also much nicer to configure.