### PR TITLE
Remove escape in docstring

### DIFF
--- a/cognite/extractorutils/configtools/__init__.py
+++ b/cognite/extractorutils/configtools/__init__.py
@@ -16,7 +16,7 @@
 Module containing tools for loading and verifying config files, and a YAML loader to automatically serialize these
 dataclasses from a config file.
 
-Configs are described as ``dataclass``\es, and use the ``BaseConfig`` class as a superclass to get a few things
+Configs are described as ``dataclass`` es, and use the ``BaseConfig`` class as a superclass to get a few things
 built-in: config version, Cognite project and logging. Use type hints to specify types, use the ``Optional`` type to
 specify that a config parameter is optional, and give the attribute a value to give it a default.
 


### PR DESCRIPTION
It's valid restructured text, but not valid python so the importer
complains all the time about it. Just accept that the docs is going to
look slightly weird...
