### PR TITLE
Changes to prevent the use of method find_dotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## 7.6.0
+## 7.5.12
 
 ### Security
 
-* Removed reliance on `dotenv.find_dotenv` to prevent unintentional loading of environment files. Environment variable management is now more explicit to enhance security and reduce potential misconfigurations.
+* Disabled recursive search for .env file. The change will prevent loading environment variables hosted in directories other than the current working directory. Environment variable management is now more explicit to enhance security, and reduce potential misconfigurations.
 
 ## 7.5.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.6.0
+
+### Security
+
+* Removed reliance on `dotenv.find_dotenv` to prevent unintentional loading of environment files. Environment variable management is now more explicit to enhance security and reduce potential misconfigurations.
+
 ## 7.5.11
 
 ### Added

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.6.0"
+__version__ = "7.5.12"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.5.11"
+__version__ = "7.6.0"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -22,7 +22,7 @@ from threading import Thread
 from types import TracebackType
 from typing import Any, Generic, TypeVar
 
-from dotenv import find_dotenv, load_dotenv
+from dotenv import load_dotenv
 
 from cognite.client import CogniteClient
 from cognite.client.data_classes import ExtractionPipeline, ExtractionPipelineRun
@@ -250,12 +250,11 @@ class Extractor(Generic[CustomConfigClass]):
 
         if str(os.getenv("COGNITE_FUNCTION_RUNTIME", False)).lower() != "true":
             # Environment Variables
-            env_file_path = find_dotenv(usecwd=True)
-            if env_file_path:
-                load_dotenv(dotenv_path=env_file_path, override=True)
-                dotenv_message = f"Successfully ingested environment variables from {env_file_path}"
+            env_file_found = load_dotenv(dotenv_path="./.env", override=True)
+            if env_file_found:
+                dotenv_message = "Successfully ingested environment variables from './.env'"
             else:
-                dotenv_message = "No .env file found"
+                dotenv_message = "No .env file found at {Path.cwd() / '.env'}"
         else:
             dotenv_message = "No .env file imported when using Cognite Functions"
 

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -69,7 +69,7 @@ class KeyVaultLoader:
         self.client: SecretClient | None = None
 
     def _init_client(self) -> None:
-        from dotenv import find_dotenv, load_dotenv
+        from dotenv import load_dotenv
 
         if not self.config:
             raise InvalidConfigError(
@@ -98,8 +98,10 @@ class KeyVaultLoader:
 
             _logger.info("Using Azure ClientSecret credentials to access KeyVault")
 
-            dotenv_path = find_dotenv(usecwd=True)
-            load_dotenv(dotenv_path=dotenv_path, override=True)
+            env_file_found = load_dotenv("./.env", override=True)
+
+            if not env_file_found:
+                _logger.info(f"Local environment file not found at {Path.cwd() / '.env'}")
 
             if all(param in self.config for param in auth_parameters):
                 tenant_id = os.path.expandvars(self.config.get("tenant-id", None))

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -72,7 +72,7 @@ def default_time_series_factory(external_id: str, datapoints: DataPointList) -> 
         A TimeSeries object with external_id set, and the is_string automatically detected
     """
     is_string = (
-        isinstance(datapoints[0].get("value"), str)  # type: ignore  # input might be dict to keep compatibility
+        isinstance(datapoints[0].get("value"), str)
         if isinstance(datapoints[0], dict)
         else isinstance(datapoints[0][1], str)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.6.0"
+version = "7.5.12"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.5.11"
+version = "7.6.0"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}


### PR DESCRIPTION
I have added information as part of the Jira ticket itself. 

Primarily we want to avoid the usage of `find_dotenv` since it recursively traverses to root in search of .env file. There is no way for us to limit this search. It is safer measure to stop looking if we don't find anything in the current directory. 

This will involve a major version bump primarily because I think this is a breaking change and needs to be communicated accordingly to customers as well.