### PR TITLE
Handle case where input is a directory better

### DIFF
--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 from time import sleep
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -649,7 +650,7 @@ class LocalStateStoreConfig:
     Configuration of a state store using a local JSON file
     """
 
-    path: str
+    path: Path
     save_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
@@ -695,8 +696,11 @@ class StateStoreConfig:
             )
 
         if self.local:
+            if self.local.path.is_dir():
+                raise ValueError(f"{self.local.path} is a directory, and not a file")
+
             return LocalStateStore(
-                file_path=self.local.path,
+                file_path=str(self.local.path),
                 save_interval=self.local.save_interval.seconds,
                 cancellation_token=cancellation_token,
             )


### PR DESCRIPTION
If a user configures a directory and not a simple file as the state store location, the error message produced is not very easy to understand. On windows in particular, it results in a "permission denied" error.

This adds a more descriptive error message