### PR TITLE
Attempt to make scheduler tests less flaky

### DIFF
--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import Generator
+from threading import RLock
 from time import sleep, time
 from uuid import uuid4
 
@@ -38,11 +39,12 @@ def set_client() -> CogniteClient:
 class MockFunction:
     def __init__(self, sleep_time: int) -> None:
         self.called_times: list[float] = []
-
         self.sleep_time = sleep_time
+        self.lock = RLock()
 
     def __call__(self) -> None:
-        self.called_times.append(time())
+        with self.lock:
+            self.called_times.append(time())
         sleep(self.sleep_time)
 
 

--- a/tests/test_unstable/test_scheduler.py
+++ b/tests/test_unstable/test_scheduler.py
@@ -78,6 +78,7 @@ def test_manual() -> None:
 
     Thread(target=scheduler.run).start()
 
+    sleep(0.1)
     scheduler.trigger("test")
     sleep(0.1)
     scheduler.trigger("test")


### PR DESCRIPTION
Give the first run of the trigger test some time to finish, since the
scheduler doesn't allow multiple runs of the same task at the same time