### PR TITLE
Fix loading of prometheus server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## Next
+## 7.5.14
 
 ### Added
 
 * In the `unstable` package: Proper retries when fetching configs from CDF
+
+### Fixed
+
+* Fixed loading of prometheus server config
 
 ## 7.5.13
 

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.5.13"
+__version__ = "7.5.14"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -513,6 +513,7 @@ class _PushGatewayConfig:
     push_interval: TimeIntervalConfig = TimeIntervalConfig("30s")
 
 
+@dataclass
 class _PromServerConfig:
     port: int = 9000
     host: str = "0.0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.5.13"
+version = "7.5.14"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}


### PR DESCRIPTION
Loading the _PromServerConfig configuration object failed as it was not annotated as a dataclass, so it had no default conversion from a dict, which caused the YAML deserialization to fail.

Turns out this has _never_ been used.