### PR TITLE
In `unstable`: Rename the local file override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Next
+
+### Changed
+
+* In the `unstable` package: `-l` / `--local-override` is renamed to `-f` / `--force-local-config`
+
 ## 7.5.14
 
 ### Added

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -73,8 +73,8 @@ class Runtime(Generic[ExtractorType]):
             help="Connection parameters",
         )
         argparser.add_argument(
-            "-l",
-            "--local-override",
+            "-f",
+            "--force-local-config",
             nargs=1,
             type=Path,
             required=False,


### PR DESCRIPTION
`-l` / `--local-override` is renamed to `-f` / `--force-local-config` to
align with the dotnet version

Breaking changes are accepted in the `unstable` package.
