### PR TITLE
Ability to change working directory in unstable module.

### DIFF
--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -216,8 +216,8 @@ class Runtime(Generic[ExtractorType]):
             except OSError as e:
                 self.logger.critical(f"Could not change working directory to {cwd}: {e}")
                 raise InvalidConfigError(f"Could not change working directory to {cwd}") from e
-        else:
-            self.logger.info(f"No working directory specified, using current directory: {os.getcwd()}")
+
+        self.logger.info(f"Using {os.getcwd()} as working directory")
 
     def _safe_get_application_config(
         self,

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -1,3 +1,4 @@
+import os
 import time
 from argparse import Namespace
 from collections.abc import Generator
@@ -119,3 +120,12 @@ def test_load_cdf_config_initial_empty(connection_config: ConnectionConfig) -> N
 
     assert len(errors["items"]) == 1
     assert "No configuration found for the given integration" in errors["items"][0]["description"]
+
+
+def test_changing_cwd() -> None:
+    runtime = Runtime(TestExtractor)
+    original_cwd = os.getcwd()
+    runtime._try_change_cwd(Path(__file__).parent)
+
+    assert os.getcwd() == str(Path(__file__).parent)
+    assert os.getcwd() != original_cwd


### PR DESCRIPTION
This is a simple CLI option that allows users to set/change the working directory of extractors. Users will be able to use `-c` or `--cwd` flags to change/set working directory.