### PR TITLE
Rename local_override to force_local_config

### DIFF
--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -176,12 +176,12 @@ class Runtime(Generic[ExtractorType]):
     ) -> tuple[ExtractorConfig, ConfigRevision]:
         current_config_revision: ConfigRevision
 
-        if args.local_override:
+        if args.force_local_config:
             self.logger.info("Loading local application config")
 
             current_config_revision = "local"
             try:
-                application_config = load_file(args.local_override[0], self._extractor_class.CONFIG_TYPE)
+                application_config = load_file(args.force_local_config[0], self._extractor_class.CONFIG_TYPE)
             except InvalidConfigError as e:
                 self.logger.critical(str(e))
                 raise e

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -32,7 +32,7 @@ def test_load_local_config(connection_config: ConnectionConfig, local_config_fil
 
     config: TestConfig
     config, revision = runtime._try_get_application_config(
-        args=Namespace(local_override=[local_config_file]),
+        args=Namespace(force_local_config=[local_config_file]),
         connection_config=connection_config,
     )
 
@@ -57,7 +57,7 @@ def test_load_cdf_config(connection_config: ConnectionConfig) -> None:
 
     config: TestConfig
     config, revision = runtime._try_get_application_config(
-        args=Namespace(local_override=None),
+        args=Namespace(force_local_config=None),
         connection_config=connection_config,
     )
 
@@ -96,7 +96,7 @@ def test_load_cdf_config_initial_empty(connection_config: ConnectionConfig) -> N
 
     start_time = time.time()
     result: tuple[TestConfig, ConfigRevision] | None = runtime._safe_get_application_config(
-        args=Namespace(local_override=None),
+        args=Namespace(force_local_config=None),
         connection_config=connection_config,
     )
     duration = time.time() - start_time


### PR DESCRIPTION
This PR refactor the cli arg rename change from `local_override` to `force_local_config` in the `_try_get_application_config`