### PR TITLE
Add ANN rule for ruff

### DIFF
--- a/cognite/extractorutils/_inner_util.py
+++ b/cognite/extractorutils/_inner_util.py
@@ -37,14 +37,14 @@ def resolve_log_level_for_httpx(level: str) -> str:
 
 
 class _DecimalEncoder(json.JSONEncoder):
-    def default(self, obj: Any) -> dict[str, str]:
+    def default(self, obj: Any) -> dict[str, str]:  # noqa: ANN401
         if isinstance(obj, Decimal):
             return {"type": "decimal_encoded", "value": str(obj)}
         return super().default(obj)
 
 
 class _DecimalDecoder(json.JSONDecoder):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
         json.JSONDecoder.__init__(self, *args, object_hook=self.object_hook, **kwargs)
 
     def object_hook(self, obj_dict: dict[str, str]) -> dict[str, str] | Decimal:

--- a/cognite/extractorutils/base.py
+++ b/cognite/extractorutils/base.py
@@ -99,7 +99,7 @@ class Extractor(Generic[CustomConfigClass]):
         reload_config_interval: int | None = 300,
         reload_config_action: ReloadConfigAction = ReloadConfigAction.DO_NOTHING,
         success_message: str = "Successful shutdown",
-    ):
+    ) -> None:
         self.name = name
         self.description = description
         self.run_handle = run_handle

--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -29,6 +29,7 @@ from urllib.parse import urljoin, urlparse
 
 import yaml
 from prometheus_client import REGISTRY, start_http_server
+from typing_extensions import Self
 
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client.credentials import (
@@ -926,7 +927,7 @@ class CastableInt(int):
     file.
     """
 
-    def __new__(cls, value: Any) -> "CastableInt":
+    def __new__(cls, value: int | str | bytes) -> Self:
         """
         Returns value as is if it's int.
 
@@ -955,7 +956,7 @@ class PortNumber(CastableInt):
     not a valid port number raises a ValueError at instantiation.
     """
 
-    def __new__(cls, value: Any) -> "PortNumber":
+    def __new__(cls, value: int | str | bytes) -> Self:
         """
         Try to cast the value to an integer and validate it as a port number.
 

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -72,7 +72,7 @@ class KeyVaultLoader:
         config: A dictionary containing the configuration for the keyvault.
     """
 
-    def __init__(self, config: dict | None):
+    def __init__(self, config: dict | None) -> None:
         self.config = config
 
         self.client: SecretClient | None = None
@@ -374,7 +374,7 @@ class ConfigResolver(Generic[CustomConfigClass]):
     Automatically reloads the configuration file if it has changed
     """
 
-    def __init__(self, config_path: str, config_type: type[CustomConfigClass]):
+    def __init__(self, config_path: str, config_type: type[CustomConfigClass]) -> None:
         self.config_path = config_path
         self.config_type = config_type
 

--- a/cognite/extractorutils/exceptions.py
+++ b/cognite/extractorutils/exceptions.py
@@ -25,7 +25,7 @@ class InvalidConfigError(Exception):
       * Unknown fields
     """
 
-    def __init__(self, message: str, details: list[str] | None = None):
+    def __init__(self, message: str, details: list[str] | None = None) -> None:
         super().__init__()
         self.message = message
         self.details = details

--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -66,7 +66,7 @@ _metrics_singularities = {}
 T = TypeVar("T")
 
 
-def safe_get(cls: type[T], *args: Any, **kwargs: Any) -> T:
+def safe_get(cls: type[T], *args: Any, **kwargs: Any) -> T:  # noqa: ANN401
     """
     A factory for instances of metrics collections.
 
@@ -121,7 +121,7 @@ class BaseMetrics:
         process_scrape_interval: Interval (in seconds) between each fetch of data for the ``process_*`` gauges
     """
 
-    def __init__(self, extractor_name: str, extractor_version: str, process_scrape_interval: float = 15):
+    def __init__(self, extractor_name: str, extractor_version: str, process_scrape_interval: float = 15) -> None:
         extractor_name = extractor_name.strip().replace(" ", "_")
 
         self.startup = Gauge(f"{extractor_name}_start_time", "Timestamp (seconds) of when the extractor last started")
@@ -186,7 +186,7 @@ class AbstractMetricsPusher(ABC):
         push_interval: int | None = None,
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         self.push_interval = push_interval
         self.thread_name = thread_name
 
@@ -273,7 +273,7 @@ class PrometheusPusher(AbstractMetricsPusher):
         password: str | None = None,
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(push_interval, thread_name, cancellation_token)
 
         self.username = username
@@ -282,7 +282,9 @@ class PrometheusPusher(AbstractMetricsPusher):
 
         self.url = url
 
-    def _auth_handler(self, url: str, method: str, timeout: int, headers: list[tuple[str, str]], data: Any) -> Callable:
+    def _auth_handler(
+        self, url: str, method: str, timeout: int, headers: list[tuple[str, str]], data: bytes
+    ) -> Callable[[], None]:
         """
         Returns a authentication handler against the Prometheus Pushgateway to use in the pushadd_to_gateway method.
 
@@ -349,7 +351,7 @@ class CognitePusher(AbstractMetricsPusher):
         data_set: EitherId | None = None,
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(push_interval, thread_name, cancellation_token)
 
         self.cdf_client = cdf_client

--- a/cognite/extractorutils/statestore/watermark.py
+++ b/cognite/extractorutils/statestore/watermark.py
@@ -1,3 +1,6 @@
+# ruff: noqa: ANN401
+# TODO: the state stores should be generic over the type of state, not just Any.
+
 #  Copyright 2020 Cognite AS
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,7 +69,7 @@ class AbstractStateStore(_BaseStateStore, ABC):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(
             save_interval=save_interval,
             trigger_log_level=trigger_log_level,
@@ -249,7 +252,7 @@ class RawStateStore(AbstractStateStore):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(save_interval, trigger_log_level, thread_name, cancellation_token)
 
         self._cdf_client = cdf_client
@@ -395,7 +398,7 @@ class LocalStateStore(AbstractStateStore):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(save_interval, trigger_log_level, thread_name, cancellation_token)
 
         self._file_path = file_path

--- a/cognite/extractorutils/threading.py
+++ b/cognite/extractorutils/threading.py
@@ -6,7 +6,7 @@ import logging
 import signal
 from threading import Condition
 from time import time
-from typing import Any
+from types import FrameType
 
 
 class CancellationToken:
@@ -114,7 +114,7 @@ class CancellationToken:
         This will set the cancellation token instead of throwing a KeyboardInterrupt exception.
         """
 
-        def sigint_handler(sig_num: int, frame: Any) -> None:
+        def sigint_handler(sig_num: int, frame: FrameType | None) -> None:
             logger = logging.getLogger(__name__)
             logger.warning("Interrupt signal received, stopping extractor gracefully")
             self.cancel()

--- a/cognite/extractorutils/unstable/configuration/exceptions.py
+++ b/cognite/extractorutils/unstable/configuration/exceptions.py
@@ -12,7 +12,7 @@ class InvalidConfigError(Exception):
       * Unknown fields
     """
 
-    def __init__(self, message: str, details: list[str] | None = None):
+    def __init__(self, message: str, details: list[str] | None = None) -> None:
         super().__init__()
         self.message = message
         self.details = details

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -84,7 +84,7 @@ class TimeIntervalConfig:
         self._interval, self._expression = TimeIntervalConfig._parse_expression(expression)
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:  # noqa: ANN401
         """
         Pydantic hook to define how this class should be serialized/deserialized.
 

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -17,14 +17,14 @@ class CogniteModel(BaseModel):
       * exclude Nones from serialized JSON instead of having nulls in the response text.
     """
 
-    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
         if kwargs:
             kwargs["exclude_none"] = True
         else:
             kwargs = {"exclude_none": True}
         return BaseModel.model_dump(self, *args, **kwargs)
 
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ANN401
         return self.model_dump(*args, **kwargs)
 
     model_config = ConfigDict(alias_generator=camelize, populate_by_name=True, extra="forbid")

--- a/cognite/extractorutils/unstable/core/tasks.py
+++ b/cognite/extractorutils/unstable/core/tasks.py
@@ -28,7 +28,7 @@ class TaskContext(CogniteLogger):
     This class is used to log errors and messages related to the task execution.
     """
 
-    def __init__(self, task: "Task", extractor: "Extractor"):
+    def __init__(self, task: "Task", extractor: "Extractor") -> None:
         super().__init__()
         self._task = task
         self._extractor = extractor
@@ -87,7 +87,7 @@ class ScheduledTask(_Task):
         target: TaskTarget,
         description: str | None = None,
         schedule: ScheduleConfig,
-    ):
+    ) -> None:
         super().__init__(name=name, target=target, description=description)
         self.schedule = schedule
 

--- a/cognite/extractorutils/uploader/_base.py
+++ b/cognite/extractorutils/uploader/_base.py
@@ -50,7 +50,7 @@ class AbstractUploadQueue(ABC):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         self.cdf_client = cdf_client
 
         self.threshold = max_queue_size if max_queue_size is not None else -1

--- a/cognite/extractorutils/uploader/assets.py
+++ b/cognite/extractorutils/uploader/assets.py
@@ -64,7 +64,7 @@ class AssetUploadQueue(AbstractUploadQueue):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         super().__init__(
             cdf_client,
             post_upload_function,

--- a/cognite/extractorutils/uploader/data_modeling.py
+++ b/cognite/extractorutils/uploader/data_modeling.py
@@ -50,7 +50,7 @@ class InstanceUploadQueue(AbstractUploadQueue):
         auto_create_start_nodes: bool = True,
         auto_create_end_nodes: bool = True,
         auto_create_direct_relations: bool = True,
-    ):
+    ) -> None:
         super().__init__(
             cdf_client,
             post_upload_function,

--- a/cognite/extractorutils/uploader/events.py
+++ b/cognite/extractorutils/uploader/events.py
@@ -62,7 +62,7 @@ class EventUploadQueue(AbstractUploadQueue):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         # Super sets post_upload and threshold
         super().__init__(
             cdf_client,

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -103,13 +103,13 @@ class ChunkedStream(RawIOBase, BinaryIO):
     # resolve the same way. These four useless methods with liberal use of Any are
     # required to satisfy mypy.
     # This may be solvable by changing the typing in the python SDK to use typing.Protocol.
-    def writelines(self, __lines: Any) -> None:
+    def writelines(self, __lines: Any) -> None:  # noqa: ANN401
         """
         Not supported for ChunkedStream.
         """
         raise NotImplementedError()
 
-    def write(self, __b: Any) -> int:
+    def write(self, __b: Any) -> int:  # noqa: ANN401
         """
         Not supported for ChunkedStream.
         """
@@ -250,7 +250,7 @@ class IOFileUploadQueue(AbstractUploadQueue):
         max_parallelism: int | None = None,
         failure_logging_path: None | str = None,
         ssl_verify: bool | str = True,
-    ):
+    ) -> None:
         # Super sets post_upload and threshold
         super().__init__(
             cdf_client,
@@ -696,7 +696,7 @@ class FileUploadQueue(IOFileUploadQueue):
         overwrite_existing: bool = False,
         cancellation_token: CancellationToken | None = None,
         ssl_verify: bool | str = True,
-    ):
+    ) -> None:
         # Super sets post_upload and threshold
         super().__init__(
             cdf_client=cdf_client,

--- a/cognite/extractorutils/uploader/raw.py
+++ b/cognite/extractorutils/uploader/raw.py
@@ -67,7 +67,7 @@ class RawUploadQueue(AbstractUploadQueue):
         trigger_log_level: str = "DEBUG",
         thread_name: str | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         # Super sets post_upload and thresholds
         super().__init__(
             cdf_client,

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -115,7 +115,7 @@ class TimeSeriesUploadQueue(AbstractUploadQueue):
         create_missing: Callable[[str, DataPointList], TimeSeries] | bool = False,
         data_set_id: int | None = None,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         # Super sets post_upload and threshold
         super().__init__(
             cdf_client,
@@ -369,7 +369,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
         thread_name: str | None = None,
         create_missing: bool = False,
         cancellation_token: CancellationToken | None = None,
-    ):
+    ) -> None:
         # Super sets post_upload and threshold
         super().__init__(
             cdf_client,

--- a/cognite/extractorutils/uploader_extractor.py
+++ b/cognite/extractorutils/uploader_extractor.py
@@ -100,7 +100,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         heartbeat_waiting_time: int = 600,
         handle_interrupts: bool = True,
         middleware: list[Callable[[dict], dict]] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             name=name,
             description=description,
@@ -156,7 +156,7 @@ class UploaderExtractor(Extractor[UploaderExtractorConfigClass]):
         else:
             raise ValueError(f"Unexpected type: {type(peek)}")
 
-    def _apply_middleware(self, item: Any) -> Any:
+    def _apply_middleware(self, item: Any) -> Any:  # noqa: ANN401
         for mw in self.middleware:
             item = mw(item)
         return item

--- a/cognite/extractorutils/uploader_types.py
+++ b/cognite/extractorutils/uploader_types.py
@@ -17,7 +17,7 @@ class InsertDatapoints:
     A class representing a batch of datapoints to be inserted into a time series.
     """
 
-    def __init__(self, *, id: int | None = None, external_id: str | None = None, datapoints: list[DataPoint]):  # noqa: A002
+    def __init__(self, *, id: int | None = None, external_id: str | None = None, datapoints: list[DataPoint]) -> None:  # noqa: A002
         self.id = id
         self.external_id = external_id
         self.datapoints = datapoints
@@ -28,7 +28,7 @@ class RawRow:
     A class representing a row of data to be inserted into a RAW table.
     """
 
-    def __init__(self, db_name: str, table_name: str, row: _Row | Iterable[_Row]):
+    def __init__(self, db_name: str, table_name: str, row: _Row | Iterable[_Row]) -> None:
         self.db_name = db_name
         self.table_name = table_name
         if isinstance(row, Iterable):

--- a/cognite/extractorutils/util.py
+++ b/cognite/extractorutils/util.py
@@ -30,12 +30,14 @@ from typing import Any, TypeVar
 from decorator import decorator
 
 from cognite.client import CogniteClient
+from cognite.client._api.assets import AssetsAPI
+from cognite.client._api.time_series import TimeSeriesAPI
 from cognite.client.data_classes import Asset, ExtractionPipelineRun, TimeSeries
 from cognite.client.exceptions import CogniteAPIError, CogniteException, CogniteFileUploadError, CogniteNotFoundError
 from cognite.extractorutils.threading import CancellationToken
 
 
-def _ensure(endpoint: Any, items: Iterable[Any]) -> None:
+def _ensure(endpoint: TimeSeriesAPI | AssetsAPI, items: Iterable[Any]) -> None:
     try:
         external_ids = [ts.external_id for ts in items]
 
@@ -90,7 +92,7 @@ class EitherId:
         TypeError: If none of both of id types are set.
     """
 
-    def __init__(self, **kwargs: int | str | None):
+    def __init__(self, **kwargs: int | str | None) -> None:
         internal_id = kwargs.get("id")
         external_id = kwargs.get("externalId") or kwargs.get("external_id")
 
@@ -127,7 +129,7 @@ class EitherId:
         """
         return self.internal_id or self.external_id  # type: ignore  # checked to be not None in init
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """
         Compare with another object. Only returns true if other is an EitherId with the same type and content.
 
@@ -210,7 +212,7 @@ def add_extraction_pipeline(
 
     def decorator_ext_pip(input_function: Callable[..., _T1]) -> Callable[..., _T1]:
         @wraps(input_function)
-        def wrapper_ext_pip(*args: Any, **kwargs: Any) -> _T1:
+        def wrapper_ext_pip(*args: Any, **kwargs: Any) -> _T1:  # noqa: ANN401
             ##############################
             # Setup Extraction Pipelines #
             ##############################
@@ -397,7 +399,7 @@ def retry(
     """
 
     @decorator
-    def retry_decorator(f: Callable[..., _T2], *fargs: Any, **fkwargs: Any) -> _T2:
+    def retry_decorator(f: Callable[..., _T2], *fargs: Any, **fkwargs: Any) -> _T2:  # noqa: ANN401
         args = fargs if fargs else []
         kwargs = fkwargs if fkwargs else {}
 
@@ -657,7 +659,7 @@ def iterable_to_stream(
         def readable(self) -> bool:
             return True
 
-        def readinto(self, buffer: Any) -> int | None:
+        def readinto(self, buffer: "WritableBuffer") -> int | None:  # type: ignore[name-defined]  # noqa: F821
             try:
                 # Bytes to return
                 ln = len(buffer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,8 @@ target-version = "py310"
 
 [tool.ruff.lint]
 # TODO: Add these rules, which are likely to require larger changes to the codebase:
-# D, DOC - Docstrings
-# ANN - Type annotations everywhere, disallow Any, bare dict, bare list, etc.
-select = ["A", "E", "F", "I", "T20", "S", "B", "UP", "DTZ", "W", "LOG", "RUF", "SIM", "C4", "PERF", "FURB", "D", "D213"]
+# DOC - More docstring lints
+select = ["A", "E", "F", "I", "T20", "S", "B", "UP", "DTZ", "W", "LOG", "RUF", "SIM", "C4", "PERF", "FURB", "D", "D213", "ANN"]
 ignore = ["S104", "S303", "S311", "PERF203", "D212", "D200", "D107"]
 
 # Allow unused variables when underscore-prefixed.
@@ -84,7 +83,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "T201", "S105", "S106", "S608", "E501", "S113", "F841", "B017", "D"]
+"tests/*" = ["S101", "T201", "S105", "S106", "S608", "E501", "S113", "F841", "B017", "D", "ANN401"] # TODO: turn off ANN401 ignore (ie don't allow Any)
 "**/__init__.py" = ["F401"]
 "docs/*" = ["E402"]
 

--- a/tests/tests_integration/test_events_integration.py
+++ b/tests/tests_integration/test_events_integration.py
@@ -36,7 +36,7 @@ def set_test_parameters() -> ParamTest:
 
 
 @pytest.mark.parametrize("functions_runtime", ["true", "false"])
-def test_events_upload_queue_upsert(set_upload_test: tuple[CogniteClient, ParamTest], functions_runtime: str):
+def test_events_upload_queue_upsert(set_upload_test: tuple[CogniteClient, ParamTest], functions_runtime: str) -> None:
     os.environ["COGNITE_FUNCTION_RUNTIME"] = functions_runtime
     client, test_parameter = set_upload_test
     queue = EventUploadQueue(cdf_client=client)


### PR DESCRIPTION
Adding the annotation rule, which requires type annotations everywhere, and disallows certain shortcuts, like using `Any` to get around typing.

I had to be quite liberal with the exemptions, some of the fixes would be quite large and potentially breaking. Such as making the state stores generic over the type of state instead of just using `Any` everywhere.