### PR TITLE
Set start time of extractors.

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -47,6 +47,7 @@ The subclass should also define several class attributes:
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
 from functools import partial
 from logging.handlers import TimedRotatingFileHandler
 from multiprocessing import Queue
@@ -146,6 +147,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._tasks: list[Task] = []
         self._task_updates: list[TaskUpdate] = []
         self._errors: dict[str, Error] = {}
+        self._start_time: datetime = datetime.now(tz=UTC)
 
         self.__init_tasks__()
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -147,7 +147,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._tasks: list[Task] = []
         self._task_updates: list[TaskUpdate] = []
         self._errors: dict[str, Error] = {}
-        self._start_time: datetime = datetime.now(tz=UTC)
+        self._start_time: datetime
 
         self.__init_tasks__()
 
@@ -437,6 +437,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             with extractor:
                 extractor.run()
         """
+        self._start_time = datetime.now(tz=UTC)
         has_scheduled = False
 
         startup: list[StartupTask] = []


### PR DESCRIPTION
This simply does nothing right now but just set the start time of the extractor. This will be used for one, when we report the startup.