### PR TITLE
Add example extractor to run unstable

### DIFF
--- a/cognite/examples/unstable/extractors/simple_extractor/config/config.yaml
+++ b/cognite/examples/unstable/extractors/simple_extractor/config/config.yaml
@@ -1,0 +1,3 @@
+log-handlers:
+  - type: console
+    level: INFO

--- a/cognite/examples/unstable/extractors/simple_extractor/config/connection_config.yaml
+++ b/cognite/examples/unstable/extractors/simple_extractor/config/connection_config.yaml
@@ -1,0 +1,10 @@
+project: ${COGNITE_PROJECT}
+base-url: ${COGNITE_BASE_URL}
+integration:
+  external_id: "utils-test-keyvault-remote"
+authentication:
+  type: "client-credentials"
+  client_id: ${COGNITE_CLIENT_ID}
+  client_secret: ${COGNITE_CLIENT_SECRET}
+  token_url: ${COGNITE_TOKEN_URL}
+  scopes: ${COGNITE_BASE_URL}/.default

--- a/cognite/examples/unstable/extractors/simple_extractor/main.py
+++ b/cognite/examples/unstable/extractors/simple_extractor/main.py
@@ -1,0 +1,54 @@
+"""
+An example extractor that logs messages at various levels.
+"""
+
+from cognite.extractorutils.unstable.configuration.models import ExtractorConfig
+from cognite.extractorutils.unstable.core.base import Extractor, StartupTask, TaskContext
+from cognite.extractorutils.unstable.core.runtime import Runtime
+
+
+class SimpleConfig(ExtractorConfig):
+    """
+    Defines the configuration for the SimpleExtractor.
+    """
+
+    pass
+
+
+class SimpleExtractor(Extractor[SimpleConfig]):
+    """
+    An example extractor that logs messages at various levels.
+    """
+
+    NAME = "SimpleTestExtractor"
+    EXTERNAL_ID = "test-extractor"
+    DESCRIPTION = "An extractor for testing log levels"
+    VERSION = "1.0.0"
+    CONFIG_TYPE = SimpleConfig
+    SUPPORTS_DRY_RUN = True
+
+    def __init_tasks__(self) -> None:
+        """
+        Initializes and adds tasks to the extractor.
+        """
+        self.add_task(StartupTask(name="main_task", target=self.run_my_task))
+
+    # example task that logs messages at different levels
+    def run_my_task(self, ctx: TaskContext) -> None:
+        """
+        An example task that logs messages at different levels.
+
+        Args:
+            ctx: The context for the task execution, used for logging.
+        """
+        ctx.debug("This is a detailed debug message.")
+        ctx.info("This is an informational message.")
+        ctx.warning("This is a warning message.")
+        ctx.info("Test finished.")
+
+    # add more tasks as needed
+
+
+if __name__ == "__main__":
+    runtime = Runtime(SimpleExtractor)
+    runtime.run()

--- a/cognite/examples/unstable/extractors/simple_extractor/main.py
+++ b/cognite/examples/unstable/extractors/simple_extractor/main.py
@@ -48,7 +48,9 @@ class SimpleExtractor(Extractor[SimpleConfig]):
 
     # add more tasks as needed
 
-
-if __name__ == "__main__":
+def main() -> None:
     runtime = Runtime(SimpleExtractor)
     runtime.run()
+
+if __name__ == "__main__":
+    main()

--- a/cognite/examples/unstable/extractors/simple_extractor/main.py
+++ b/cognite/examples/unstable/extractors/simple_extractor/main.py
@@ -48,9 +48,11 @@ class SimpleExtractor(Extractor[SimpleConfig]):
 
     # add more tasks as needed
 
+
 def main() -> None:
     runtime = Runtime(SimpleExtractor)
     runtime.run()
+
 
 if __name__ == "__main__":
     main()

--- a/cognite/examples/unstable/extractors/simple_extractor/main.py
+++ b/cognite/examples/unstable/extractors/simple_extractor/main.py
@@ -50,6 +50,9 @@ class SimpleExtractor(Extractor[SimpleConfig]):
 
 
 def main() -> None:
+    """
+    Main function to run the SimpleExtractor.
+    """
     runtime = Runtime(SimpleExtractor)
     runtime.run()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,6 @@ only-include = ["cognite"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.scripts]
+simple-extractor = "cognite.examples.unstable.extractors.simple_extractor.main:main"


### PR DESCRIPTION
This PR adds a simple extractor example that logs messages at different levels and helps to run the unstable extractor for easy development. 