### PR TITLE
Move and update dtos

### DIFF
--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypeVar
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
@@ -433,3 +433,7 @@ class ExtractorConfig(ConfigModel):
     """
 
     log_handlers: list[LogHandlerConfig] = Field(default_factory=_log_handler_default)
+
+
+ConfigType = TypeVar("ConfigType", bound=ExtractorConfig)
+ConfigRevision = Literal["local"] | int

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -107,4 +107,4 @@ class CheckinRequest(HasExternalId):
 
 
 class CheckinResponse(HasExternalId):
-    last_config_revision: int | None
+    last_config_revision: int | None = None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -105,5 +105,5 @@ class CheckinRequest(WithExternalId):
     errors: ErrorList | None = None
 
 
-class CheckinResponse(HasExternalId):
+class CheckinResponse(WithExternalId):
     last_config_revision: int | None = None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -37,10 +37,14 @@ class HasExternalId(CogniteModel):
     external_id: str
 
 
+MessageType = Annotated[str, StringConstraints(min_length=0, max_length=1000)]
+
+
 class TaskUpdate(CogniteModel):
     type: Literal["started"] | Literal["ended"]
     name: str
     timestamp: int
+    message: MessageType | None = None
 
 
 class Error(HasExternalId):

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -33,7 +33,7 @@ class CogniteModel(BaseModel):
     model_config = ConfigDict(alias_generator=camelize, populate_by_name=True, extra="forbid")
 
 
-class HasExternalId(CogniteModel):
+class WithExternalId(CogniteModel):
     external_id: str
 
 
@@ -47,8 +47,7 @@ class TaskUpdate(CogniteModel):
     message: MessageType | None = None
 
 
-class Error(HasExternalId):
-    external_id: str
+class Error(WithExternalId):
     level: str
     description: str
     details: str | None
@@ -74,11 +73,11 @@ JSONType = TypeAliasType(  # type: ignore
 )
 
 
-class HasVersion(CogniteModel):
+class WithVersion(CogniteModel):
     version: VersionType | None = None
 
 
-class ExtractorInfo(HasExternalId, HasVersion):
+class ExtractorInfo(WithExternalId, WithVersion):
     pass
 
 
@@ -94,14 +93,14 @@ class Task(CogniteModel):
     description: DescriptionType | None = None
 
 
-class StartupRequest(HasExternalId):
+class StartupRequest(WithExternalId):
     extractor: ExtractorInfo
     tasks: TaskList | None = None
     active_config_revision: int | Literal["local"] | None = None
     timestamp: int | None = None
 
 
-class CheckinRequest(HasExternalId):
+class CheckinRequest(WithExternalId):
     task_events: TaskUpdateList | None = None
     errors: ErrorList | None = None
 

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -3,11 +3,12 @@ Temporary holding place for DTOs against Extraction Pipelines 2.0 until it's in 
 """
 
 from enum import Enum
-from typing import Annotated, Any, Literal, Optional, TypeAliasType
+from typing import Annotated, Any, Literal, Optional
 
 from annotated_types import Len
 from humps import camelize
 from pydantic import BaseModel, ConfigDict, StringConstraints
+from typing_extensions import TypeAliasType
 
 
 class CogniteModel(BaseModel):

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -10,6 +10,9 @@ from humps import camelize
 from pydantic import BaseModel, ConfigDict, StringConstraints
 from typing_extensions import TypeAliasType
 
+from cognite.extractorutils.unstable.core.errors import Error as InternalError
+from cognite.extractorutils.unstable.core.errors import ErrorLevel
+
 
 class CogniteModel(BaseModel):
     """
@@ -48,12 +51,25 @@ class TaskUpdate(CogniteModel):
 
 
 class Error(WithExternalId):
-    level: str
+    level: ErrorLevel
     description: str
     details: str | None
     start_time: int
     end_time: int | None
     task: str | None
+
+    @classmethod
+    def from_internal(cls, error: InternalError) -> "Error":
+        """Convert the error into a DTO (Data Transfer Object) for reporting."""
+        return Error(
+            external_id=error.external_id,
+            level=error.level,
+            description=error.description,
+            details=error.details,
+            start_time=error.start_time,
+            end_time=error.end_time,
+            task=error._task_name,
+        )
 
 
 TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -2,10 +2,12 @@
 Temporary holding place for DTOs against Extraction Pipelines 2.0 until it's in the SDK.
 """
 
-from typing import Any, Literal
+from enum import Enum
+from typing import Annotated, Any, Literal, Optional, TypeAliasType
 
+from annotated_types import Len
 from humps import camelize
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
 
 class CogniteModel(BaseModel):
@@ -30,13 +32,17 @@ class CogniteModel(BaseModel):
     model_config = ConfigDict(alias_generator=camelize, populate_by_name=True, extra="forbid")
 
 
+class HasExternalId(CogniteModel):
+    external_id: str
+
+
 class TaskUpdate(CogniteModel):
     type: Literal["started"] | Literal["ended"]
     name: str
     timestamp: int
 
 
-class Error(CogniteModel):
+class Error(HasExternalId):
     external_id: str
     level: str
     description: str
@@ -44,3 +50,56 @@ class Error(CogniteModel):
     start_time: int
     end_time: int | None
     task: str | None
+
+
+TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]
+ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
+VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
+DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
+TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
+JSONType = TypeAliasType(  # type: ignore
+    "JSONType",
+    bool
+    | int
+    | float
+    | str
+    | None
+    | list[Optional["JSONType"]]  # type: ignore
+    | dict[str, Optional["JSONType"]],  # type: ignore  # type: ignore
+)
+
+
+class HasVersion(CogniteModel):
+    version: VersionType | None = None
+
+
+class ExtractorInfo(HasExternalId, HasVersion):
+    pass
+
+
+class TaskType(Enum):
+    continuous = "continuous"
+    batch = "batch"
+
+
+class Task(CogniteModel):
+    type: TaskType
+    name: str
+    action: bool = False
+    description: DescriptionType | None = None
+
+
+class StartupRequest(HasExternalId):
+    extractor: ExtractorInfo
+    tasks: TaskList | None = None
+    active_config_revision: int | Literal["local"] | None = None
+    timestamp: int | None = None
+
+
+class CheckinRequest(HasExternalId):
+    task_events: TaskUpdateList | None = None
+    errors: ErrorList | None = None
+
+
+class CheckinResponse(HasExternalId):
+    last_config_revision: int | None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -77,15 +77,9 @@ ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
-JSONType = TypeAliasType(  # type: ignore
+JSONType = TypeAliasType(  # type: ignore[misc]
     "JSONType",
-    bool
-    | int
-    | float
-    | str
-    | None
-    | list[Optional["JSONType"]]  # type: ignore
-    | dict[str, Optional["JSONType"]],  # type: ignore  # type: ignore
+    bool | int | float | str | None | list[Optional["JSONType"]] | dict[str, Optional["JSONType"]],  # type: ignore[misc]
 )
 
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -53,7 +53,7 @@ from logging.handlers import TimedRotatingFileHandler
 from multiprocessing import Queue
 from threading import RLock, Thread
 from types import TracebackType
-from typing import Generic, Literal, TypeVar
+from typing import Generic, TypeVar
 
 from humps import pascalize
 from typing_extensions import Self, assert_never
@@ -61,13 +61,25 @@ from typing_extensions import Self, assert_never
 from cognite.extractorutils._inner_util import _resolve_log_level
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import (
+    ConfigRevision,
+    ConfigType,
     ConnectionConfig,
     ExtractorConfig,
     LogConsoleHandlerConfig,
     LogFileHandlerConfig,
 )
-from cognite.extractorutils.unstable.core._dto import Error as DtoError
-from cognite.extractorutils.unstable.core._dto import TaskUpdate
+from cognite.extractorutils.unstable.core._dto import (
+    Error as DtoError,
+)
+from cognite.extractorutils.unstable.core._dto import (
+    ExtractorInfo,
+    StartupRequest,
+    TaskType,
+    TaskUpdate,
+)
+from cognite.extractorutils.unstable.core._dto import (
+    Task as DtoTask,
+)
 from cognite.extractorutils.unstable.core._messaging import RuntimeMessage
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.logger import CogniteLogger
@@ -77,9 +89,6 @@ from cognite.extractorutils.unstable.scheduling import TaskScheduler
 from cognite.extractorutils.util import now
 
 __all__ = ["ConfigRevision", "ConfigType", "Extractor"]
-
-ConfigType = TypeVar("ConfigType", bound=ExtractorConfig)
-ConfigRevision = Literal["local"] | int
 
 
 _T = TypeVar("_T", bound=ExtractorConfig)
@@ -102,7 +111,7 @@ class FullConfig(Generic[_T]):
     ) -> None:
         self.connection_config = connection_config
         self.application_config = application_config
-        self.current_config_revision = current_config_revision
+        self.current_config_revision: ConfigRevision = current_config_revision
         self.log_level_override = log_level_override
 
 
@@ -134,7 +143,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         self.connection_config = config.connection_config
         self.application_config = config.application_config
-        self.current_config_revision = config.current_config_revision
+        self.current_config_revision: ConfigRevision = config.current_config_revision
         self.log_level_override = config.log_level_override
 
         self.cognite_client = self.connection_config.get_cognite_client(f"{self.EXTERNAL_ID}-{self.VERSION}")
@@ -257,6 +266,25 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         ):
             self.restart()
 
+    def _get_startup_request(self) -> StartupRequest:
+        return StartupRequest(
+            external_id=self.connection_config.integration.external_id,
+            active_config_revision=self.current_config_revision,
+            extractor=ExtractorInfo(version=self.VERSION, external_id=self.EXTERNAL_ID),
+            tasks=[
+                DtoTask(
+                    type=TaskType.continuous if isinstance(t, ContinuousTask) else TaskType.batch,
+                    action=isinstance(t, ScheduledTask),
+                    description=t.description,
+                    name=t.name,
+                )
+                for t in self._tasks
+            ]
+            if len(self._tasks) > 0
+            else None,
+            timestamp=int(self._start_time.timestamp() * 1000),
+        )
+
     def _run_checkin(self) -> None:
         while not self.cancellation_token.is_cancelled:
             try:
@@ -362,23 +390,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
     def _report_extractor_info(self) -> None:
         self.cognite_client.post(
             f"/api/v1/projects/{self.cognite_client.config.project}/integrations/extractorinfo",
-            json={
-                "externalId": self.connection_config.integration.external_id,
-                "activeConfigRevision": self.current_config_revision,
-                "extractor": {
-                    "version": self.VERSION,
-                    "externalId": self.EXTERNAL_ID,
-                },
-                "tasks": [
-                    {
-                        "name": t.name,
-                        "type": "continuous" if isinstance(t, ContinuousTask) else "batch",
-                        "action": bool(isinstance(t, ScheduledTask)),
-                        "description": t.description,
-                    }
-                    for t in self._tasks
-                ],
-            },
+            json=self._get_startup_request().model_dump(mode="json"),
             headers={"cdf-version": "alpha"},
         )
 
@@ -390,6 +402,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         ``with`` statement, which ensures proper cleanup on exit.
         """
         self._setup_logging()
+        self._start_time = datetime.now(tz=timezone.utc)
         self._report_extractor_info()
         Thread(target=self._run_checkin, name="ExtractorCheckin", daemon=True).start()
 
@@ -437,7 +450,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             with extractor:
                 extractor.run()
         """
-        self._start_time = datetime.now(tz=timezone.utc)
         has_scheduled = False
 
         startup: list[StartupTask] = []

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -231,19 +231,19 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
     def _checkin(self) -> None:
         with self._checkin_lock:
-            task_updates = [t.model_dump() for t in self._task_updates]
+            task_updates = [t.model_dump(mode="json") for t in self._task_updates]
             self._task_updates.clear()
 
             error_updates = [
                 DtoError(
                     external_id=e.external_id,
-                    level=e.level.value,
+                    level=e.level,
                     description=e.description,
                     details=e.details,
                     start_time=e.start_time,
                     end_time=e.end_time,
                     task=e._task_name if e._task_name is not None else None,
-                ).model_dump()
+                ).model_dump(mode="json")
                 for e in self._errors.values()
             ]
             self._errors.clear()

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from typing_extensions import assert_never
 
+from cognite.extractorutils.unstable.core._dto import Error as DtoError
 from cognite.extractorutils.util import now
 
 if TYPE_CHECKING:
@@ -126,3 +127,15 @@ class Error:
         """
         self.finish()
         return exc_val is None
+
+    def into_dto(self) -> DtoError:
+        """Convert the error into a DTO (Data Transfer Object) for reporting."""
+        return DtoError(
+            external_id=self.external_id,
+            level=self.level.value,
+            description=self.description,
+            details=self.details,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            task=self._task_name,
+        )

--- a/cognite/extractorutils/unstable/core/errors.py
+++ b/cognite/extractorutils/unstable/core/errors.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 
 from typing_extensions import assert_never
 
-from cognite.extractorutils.unstable.core._dto import Error as DtoError
 from cognite.extractorutils.util import now
 
 if TYPE_CHECKING:
@@ -127,15 +126,3 @@ class Error:
         """
         self.finish()
         return exc_val is None
-
-    def into_dto(self) -> DtoError:
-        """Convert the error into a DTO (Data Transfer Object) for reporting."""
-        return DtoError(
-            external_id=self.external_id,
-            level=self.level.value,
-            description=self.description,
-            details=self.details,
-            start_time=self.start_time,
-            end_time=self.end_time,
-            task=self._task_name,
-        )

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -249,7 +249,7 @@ class Runtime(Generic[ExtractorType]):
                 ts = now()
                 error = Error(
                     external_id=str(uuid4()),
-                    level=ErrorLevel.fatal.value,
+                    level=ErrorLevel.fatal,
                     start_time=ts,
                     end_time=ts,
                     description=error_message,
@@ -261,7 +261,7 @@ class Runtime(Generic[ExtractorType]):
                     f"/api/v1/projects/{self._cognite_client.config.project}/odin/checkin",
                     json={
                         "externalId": connection_config.integration.external_id,
-                        "errors": [error.model_dump()],
+                        "errors": [error.model_dump(mode="json")],
                     },
                     headers={"cdf-version": "alpha"},
                 )

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from time import sleep
 
 import pytest
@@ -174,7 +174,7 @@ def test_report_extractor_info(
             current_config_revision=1,
         )
     )
-    extractor._start_time = datetime.fromtimestamp(now() / 1000, UTC)
+    extractor._start_time = datetime.fromtimestamp(now() / 1000, timezone.utc)
     startup_request = extractor._get_startup_request()
 
     extractor._report_extractor_info()

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -33,6 +33,7 @@ def test_simple_task_report(
             current_config_revision=1,
         )
     )
+    extractor._start_time = datetime.fromtimestamp(now() / 1000, timezone.utc)
 
     extractor.add_task(
         ScheduledTask(

--- a/tests/test_unstable/test_errors.py
+++ b/tests/test_unstable/test_errors.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from time import sleep
 
 import pytest
@@ -6,6 +7,7 @@ from cognite.extractorutils.unstable.configuration.models import ConnectionConfi
 from cognite.extractorutils.unstable.core.base import FullConfig
 from cognite.extractorutils.unstable.core.errors import ErrorLevel
 from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
+from cognite.extractorutils.util import now
 from test_unstable.conftest import TestConfig, TestExtractor
 
 
@@ -77,6 +79,7 @@ def test_task_error(
             current_config_revision=1,
         )
     )
+    extractor._start_time = datetime.fromtimestamp(now() / 1000, timezone.utc)
 
     def task(tc: TaskContext) -> None:
         sleep(0.05)
@@ -130,6 +133,7 @@ def test_crashing_task(
             target=task,
         )
     )
+    extractor._start_time = datetime.fromtimestamp(now() / 1000, timezone.utc)
 
     extractor._report_extractor_info()
     extractor._scheduler.trigger("TestTask")

--- a/tests/test_unstable/test_errors.py
+++ b/tests/test_unstable/test_errors.py
@@ -4,8 +4,9 @@ from time import sleep
 import pytest
 
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
+from cognite.extractorutils.unstable.core._dto import Error as DtoError
 from cognite.extractorutils.unstable.core.base import FullConfig
-from cognite.extractorutils.unstable.core.errors import ErrorLevel
+from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
 from cognite.extractorutils.util import now
 from test_unstable.conftest import TestConfig, TestExtractor
@@ -199,3 +200,22 @@ def test_reporting_errors(
     assert res[0]["startTime"] == err.start_time
     assert res[0]["endTime"] == err.end_time
     assert res[0]["description"] == err.description
+
+
+def test_conversion_to_external(connection_config: ConnectionConfig, application_config: TestConfig) -> None:
+    extractor = TestExtractor(
+        FullConfig(
+            connection_config=connection_config,
+            application_config=application_config,
+            current_config_revision=1,
+        )
+    )
+    error = Error(
+        ErrorLevel.error, "Test error", details="This is a test error", task_name="TestTask", extractor=extractor
+    )
+    dto_error = DtoError.from_internal(error)
+
+    assert dto_error.external_id == error.external_id
+    assert dto_error.level == error.level
+    assert dto_error.description == error.description
+    assert dto_error.details == error.details


### PR DESCRIPTION
This is a preliminary work to properly managing how check-ins are reported for extractors. It involves moving some model objects as well as creating some new DTOs which do nothing for now but will be used in later PR(s).
This also moves when and where we set the start time for extractor to the `start` method as should be.