### PR TITLE
Fix thread pickle error in unstable runtime

### DIFF
--- a/cognite/examples/unstable/extractors/simple_extractor/config/connection_config.yaml
+++ b/cognite/examples/unstable/extractors/simple_extractor/config/connection_config.yaml
@@ -1,5 +1,5 @@
 project: ${COGNITE_PROJECT}
-base-url: ${COGNITE_BASE_URL}
+base_url: ${COGNITE_BASE_URL}
 integration:
   external_id: "utils-test-keyvault-remote"
 authentication:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -109,13 +109,11 @@ class FullConfig(Generic[_T]):
         application_config: _T,
         current_config_revision: ConfigRevision,
         log_level_override: str | None = None,
-        cancel_event: MpEvent | None = None,
     ) -> None:
         self.connection_config = connection_config
         self.application_config = application_config
         self.current_config_revision: ConfigRevision = current_config_revision
         self.log_level_override = log_level_override
-        self.cancel_event = cancel_event
 
 
 class Extractor(Generic[ConfigType], CogniteLogger):
@@ -143,9 +141,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         self.cancellation_token = CancellationToken()
         self.cancellation_token.cancel_on_interrupt()
-
-        if config.cancel_event:
-            self._setup_cancellation_watcher(config.cancel_event)
 
         self.connection_config = config.connection_config
         self.application_config = config.application_config
@@ -247,6 +242,10 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
     def _set_runtime_message_queue(self, queue: Queue) -> None:
         self._runtime_messages = queue
+
+    def _attach_runtime_controls(self, *, cancel_event: MpEvent, message_queue: Queue) -> None:
+        self._set_runtime_message_queue(message_queue)
+        self._setup_cancellation_watcher(cancel_event)
 
     def _checkin(self) -> None:
         with self._checkin_lock:

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -61,7 +61,7 @@ class MockFunction:
 @pytest.fixture
 def extraction_pipeline(set_client: CogniteClient) -> Generator[str, None, None]:
     external_id = f"utils-test-{uuid4().hex}"
-    set_client.post(
+    response = set_client.post(
         url=f"/api/v1/projects/{set_client.config.project}/odin",
         json={
             "items": [
@@ -70,6 +70,10 @@ def extraction_pipeline(set_client: CogniteClient) -> Generator[str, None, None]
         },
         headers={"cdf-version": "alpha"},
     )
+
+    print(f"Created extraction pipeline with external ID: {external_id}")
+    print(f"Response from odin: {response.json()}")
+    assert response.status_code == 201, f"Failed to create extraction pipeline: {response.text}"
 
     yield external_id
 

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -61,7 +61,7 @@ class MockFunction:
 @pytest.fixture
 def extraction_pipeline(set_client: CogniteClient) -> Generator[str, None, None]:
     external_id = f"utils-test-{uuid4().hex}"
-    response = set_client.post(
+    set_client.post(
         url=f"/api/v1/projects/{set_client.config.project}/odin",
         json={
             "items": [
@@ -70,10 +70,6 @@ def extraction_pipeline(set_client: CogniteClient) -> Generator[str, None, None]
         },
         headers={"cdf-version": "alpha"},
     )
-
-    print(f"Created extraction pipeline with external ID: {external_id}")
-    print(f"Response from odin: {response.json()}")
-    assert response.status_code == 201, f"Failed to create extraction pipeline: {response.text}"
 
     yield external_id
 

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -99,6 +99,7 @@ def connection_config(extraction_pipeline: str) -> ConnectionConfig:
 
 
 class TestConfig(ExtractorConfig):
+    __test__ = False
     parameter_one: int
     parameter_two: str
 
@@ -109,6 +110,7 @@ def application_config() -> TestConfig:
 
 
 class TestExtractor(Extractor[TestConfig]):
+    __test__ = False
     NAME = "Test extractor"
     EXTERNAL_ID = "test-extractor"
     DESCRIPTION = "Test of the new runtime"

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -142,9 +142,7 @@ def test_changing_cwd() -> None:
     assert os.getcwd() != original_cwd
 
 
-def _write_conn_from_fixture(
-    base_yaml_path: Path, out_path: Path, cfg: ConnectionConfig
-) -> None:
+def _write_conn_from_fixture(base_yaml_path: Path, out_path: Path, cfg: ConnectionConfig) -> None:
     """Start from the repo YAML and overwrite with plain strings from the fixture."""
     data = yaml.safe_load(base_yaml_path.read_text())
 
@@ -192,16 +190,21 @@ def test_runtime_cancellation_propagates_to_extractor(
 
     argv = [
         "simple-extractor",
-        "--cwd", str(tmp_path),           
-        "-c", conn_file.name,
-        "-f", app_file.name,
+        "--cwd",
+        str(tmp_path),
+        "-c",
+        conn_file.name,
+        "-f",
+        app_file.name,
         "--skip-init-checks",
-        "-l", "info",
+        "-l",
+        "info",
     ]
 
     monkeypatch.setattr(sys, "argv", argv)
 
     from cognite.extractorutils.unstable.core.base import Extractor
+
     monkeypatch.setattr(Extractor, "_report_extractor_info", lambda self: None)
     monkeypatch.setattr(Extractor, "_checkin", lambda self: None)
 

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -9,6 +9,7 @@ from random import randint
 from threading import Thread
 
 import pytest
+import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from typing_extensions import Self
 
@@ -142,7 +143,7 @@ def test_changing_cwd() -> None:
 
 
 def test_runtime_cancellation_propagates_to_extractor(
-    monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]
+    extraction_pipeline: str, tmp_path: Path, monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]
 ) -> None:
     """
     Start the runtime, then cancel its token. Verify that:
@@ -158,25 +159,27 @@ def test_runtime_cancellation_propagates_to_extractor(
     cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config").resolve()
     assert cfg_dir.exists(), f"Config directory not found: {cfg_dir}"
 
-    conn_cfg = cfg_dir / "connection_config.yaml"
-    app_cfg = cfg_dir / "config.yaml"
-    assert conn_cfg.exists(), f"Missing connection_config.yaml at {conn_cfg}"
-    assert app_cfg.exists(), f"Missing config.yaml at {app_cfg}"
+    cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config")
+    base_cfg = yaml.safe_load((cfg_dir / "connection_config.yaml").read_text())
+    # Update the integration external ID to match the extraction pipeline
+    base_cfg["integration"]["external_id"] = extraction_pipeline
+
+    conn_file = tmp_path / "connection_config.yaml"
+    conn_file.write_text(yaml.safe_dump(base_cfg))
 
     argv = [
         "simple-extractor",
         "--cwd",
         str(cfg_dir),
         "-c",
-        str(conn_cfg.name),
+        str(conn_file),
         "-f",
-        str(app_cfg.name),
+        "config.yaml",
         "--skip-init-checks",
         "-l",
         "info",
     ]
     monkeypatch.setattr(sys, "argv", argv)
-    monkeypatch.setenv("PYTHONUNBUFFERED", "1")
 
     runtime = Runtime(SimpleExtractor)
 

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -155,7 +155,7 @@ def test_runtime_cancellation_propagates_to_extractor(
       uv run simple-extractor --cwd cognite/examples/unstable/extractors/simple_extractor/config \
          -c connection_config.yaml -f config.yaml --skip-init-checks
     """
-
+    print(f"external id for integration is: {extraction_pipeline}")
     cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config")
     base_cfg = yaml.safe_load((cfg_dir / "connection_config.yaml").read_text())
     # Update the integration external ID to match the extraction pipeline

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -143,7 +143,7 @@ def test_changing_cwd() -> None:
 
 
 def test_runtime_cancellation_propagates_to_extractor(
-    extraction_pipeline: str, tmp_path: Path, monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]
+    extraction_pipeline: str, tmp_path: Path, monkeypatch: MonkeyPatch
 ) -> None:
     """
     Start the runtime, then cancel its token. Verify that:
@@ -155,32 +155,39 @@ def test_runtime_cancellation_propagates_to_extractor(
       uv run simple-extractor --cwd cognite/examples/unstable/extractors/simple_extractor/config \
          -c connection_config.yaml -f config.yaml --skip-init-checks
     """
-    print(f"external id for integration is: {extraction_pipeline}")
+    log_file = tmp_path / "test_run.log"
+    temp_app_config_file = tmp_path / "config.yaml"
+    temp_conn_config_file = tmp_path / "connection_config.yaml"
+
     cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config")
-    base_cfg = yaml.safe_load((cfg_dir / "connection_config.yaml").read_text())
-    # Update the integration external ID to match the extraction pipeline
-    base_cfg["integration"]["external_id"] = extraction_pipeline
+    conn_cfg_data = yaml.safe_load((cfg_dir / "connection_config.yaml").read_text())
+    conn_cfg_data["integration"]["external_id"] = extraction_pipeline
+    temp_conn_config_file.write_text(yaml.dump(conn_cfg_data))
 
-    conn_file = tmp_path / f"test-{randint(0, 1000000)}-connection_config.yaml"
+    app_cfg_data = yaml.safe_load((cfg_dir / "config.yaml").read_text())
 
-    conn_file.write_text(yaml.safe_dump(base_cfg))
+    app_cfg_data["log-handlers"] = [
+        {
+            "type": "file",
+            "path": str(log_file),
+            "level": "INFO",
+        }
+    ]
+    temp_app_config_file.write_text(yaml.dump(app_cfg_data))
 
     argv = [
         "simple-extractor",
         "--cwd",
-        str(cfg_dir),
+        str(tmp_path),
         "-c",
-        str(conn_file),
+        temp_conn_config_file.name,
         "-f",
-        "config.yaml",
+        temp_app_config_file.name,
         "--skip-init-checks",
-        "-l",
-        "info",
     ]
     monkeypatch.setattr(sys, "argv", argv)
 
     runtime = Runtime(SimpleExtractor)
-
     child_holder = {}
     original_spawn = Runtime._spawn_extractor
 
@@ -195,24 +202,22 @@ def test_runtime_cancellation_propagates_to_extractor(
     t.start()
 
     start = time.time()
-    while "proc" not in child_holder and time.time() - start < 10:
+    while "proc" not in child_holder and time.time() - start < 15:
         time.sleep(0.05)
 
     assert "proc" in child_holder, "Extractor process was not spawned in time."
     proc = child_holder["proc"]
 
-    time.sleep(0.5)
-
+    time.sleep(1.0)
     runtime._cancellation_token.cancel()
 
     t.join(timeout=30)
     assert not t.is_alive(), "Runtime did not shut down within timeout after cancellation."
 
-    proc.join(timeout=0)
+    proc.join(timeout=5)
     assert not proc.is_alive(), "Extractor process is still alive"
 
-    out, err = capfd.readouterr()
-    combined = (out or "") + (err or "")
-    assert "Cancellation signal received from runtime. Shutting down gracefully." in combined, (
-        f"Expected cancellation log line not found in output.\nCaptured output:\n{combined}"
+    log_content = log_file.read_text()
+    assert "Cancellation signal received from runtime. Shutting down gracefully." in log_content, (
+        f"Expected cancellation log line not found in output.\nCaptured output:\n{log_content}"
     )

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -191,7 +191,7 @@ def test_runtime_cancellation_propagates_to_extractor(
 
     monkeypatch.setattr(Runtime, "_spawn_extractor", spy_spawn, raising=True)
 
-    t = Thread(target=runtime.run, name="RuntimeMain")
+    t = Thread(target=runtime.run, name=f"RuntimeMain-{randint(0, 1000000)}")
     t.start()
 
     start = time.time()

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -7,10 +7,10 @@ from multiprocessing import Process
 from pathlib import Path
 from random import randint
 from threading import Thread
-from typing import Self
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from typing_extensions import Self
 
 from cognite.examples.unstable.extractors.simple_extractor.main import SimpleExtractor
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -9,10 +9,10 @@ from random import randint
 from threading import Thread
 
 import pytest
+import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from typing_extensions import Self
 
-from cognite.client import CogniteClient
 from cognite.examples.unstable.extractors.simple_extractor.main import SimpleExtractor
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
 from cognite.extractorutils.unstable.core.base import ConfigRevision, FullConfig
@@ -142,30 +142,8 @@ def test_changing_cwd() -> None:
     assert os.getcwd() != original_cwd
 
 
-@pytest.fixture
-def integration_external_id(set_client: CogniteClient) -> Generator[str, None, None]:
-    external_id = "utils-test-keyvault-remote"
-    set_client.post(
-        url=f"/api/v1/projects/{set_client.config.project}/odin",
-        json={
-            "items": [
-                {"externalId": external_id, "extractor": {"externalId": "test-extractor"}},
-            ]
-        },
-        headers={"cdf-version": "alpha"},
-    )
-
-    yield external_id
-
-    set_client.post(
-        url=f"/api/v1/projects/{set_client.config.project}/odin/delete",
-        json={"items": [{"externalId": external_id}]},
-        headers={"cdf-version": "alpha"},
-    )
-
-
 def test_runtime_cancellation_propagates_to_extractor(
-    integration_external_id: str, monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]
+    extraction_pipeline: str, tmp_path: Path, monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]
 ) -> None:
     """
     Start the runtime, then cancel its token. Verify that:
@@ -178,15 +156,21 @@ def test_runtime_cancellation_propagates_to_extractor(
          -c connection_config.yaml -f config.yaml --skip-init-checks
     """
 
-    cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config").resolve()
-    assert cfg_dir.exists(), f"Config directory not found: {cfg_dir}"
+    cfg_dir = Path("cognite/examples/unstable/extractors/simple_extractor/config")
+    base_cfg = yaml.safe_load((cfg_dir / "connection_config.yaml").read_text())
+    # Update the integration external ID to match the extraction pipeline
+    base_cfg["integration"]["external_id"] = extraction_pipeline
+
+    conn_file = tmp_path / f"test-{randint(0, 1000000)}-connection_config.yaml"
+
+    conn_file.write_text(yaml.safe_dump(base_cfg))
 
     argv = [
         "simple-extractor",
         "--cwd",
         str(cfg_dir),
         "-c",
-        "connection_config.yaml",
+        str(conn_file),
         "-f",
         "config.yaml",
         "--skip-init-checks",

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -9,10 +9,10 @@ from random import randint
 from threading import Thread
 
 import pytest
-import yaml
 from _pytest.monkeypatch import MonkeyPatch
 from typing_extensions import Self
 
+from cognite.client import CogniteClient
 from cognite.examples.unstable.extractors.simple_extractor.main import SimpleExtractor
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
 from cognite.extractorutils.unstable.core.base import ConfigRevision, FullConfig
@@ -141,7 +141,6 @@ def test_changing_cwd() -> None:
     assert os.getcwd() == str(Path(__file__).parent)
     assert os.getcwd() != original_cwd
 
-from cognite.client import CogniteClient
 
 @pytest.fixture
 def integration_external_id(set_client: CogniteClient) -> Generator[str, None, None]:
@@ -163,6 +162,7 @@ def integration_external_id(set_client: CogniteClient) -> Generator[str, None, N
         json={"items": [{"externalId": external_id}]},
         headers={"cdf-version": "alpha"},
     )
+
 
 def test_runtime_cancellation_propagates_to_extractor(
     integration_external_id: str, monkeypatch: MonkeyPatch, capfd: pytest.CaptureFixture[str]

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -203,11 +203,6 @@ def test_runtime_cancellation_propagates_to_extractor(
 
     monkeypatch.setattr(sys, "argv", argv)
 
-    from cognite.extractorutils.unstable.core.base import Extractor
-
-    monkeypatch.setattr(Extractor, "_report_extractor_info", lambda self: None)
-    monkeypatch.setattr(Extractor, "_checkin", lambda self: None)
-
     runtime = Runtime(SimpleExtractor)
 
     child_holder = {}


### PR DESCRIPTION
This PR fixes the `cannot pickle '_thread.RLock' object` error arising in the `Runtime` class arising due to the non‑picklable CancellationToken object being directly passed in spawning the extractor process. 

**Why:**
The child target captured Runtime (via CancellationToken), which holds non‑picklable thread locks.

**Solution:**
- Moved the extractor entrypoint to a module‑level function (picklable).
- Pass a picklable multiprocessing.Event to the child.
- Small watcher threads bridge cancellation: parent CancellationToken → Event, and Event → child CancellationToken.

**Test:**
Cancelling the runtime triggers child log (“Cancellation signal received…”) and clean exit; no pickling error.