### PR TITLE
[unstable] Handle logging for extractor-utils

### DIFF
--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -419,7 +419,18 @@ class LogConsoleHandlerConfig(ConfigModel):
     level: LogLevel
 
 
-LogHandlerConfig = Annotated[LogFileHandlerConfig | LogConsoleHandlerConfig, Field(discriminator="type")]
+class LogWindowsEventHandlerConfig(ConfigModel):
+    """
+    Configuration for a log handler that writes to the Windows Event Log.
+    """
+
+    type: Literal["windows-event-log"]
+    level: LogLevel
+
+
+LogHandlerConfig = Annotated[
+    LogFileHandlerConfig | LogConsoleHandlerConfig | LogWindowsEventHandlerConfig, Field(discriminator="type")
+]
 
 
 # Mypy BS

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -419,18 +419,7 @@ class LogConsoleHandlerConfig(ConfigModel):
     level: LogLevel
 
 
-class LogWindowsEventHandlerConfig(ConfigModel):
-    """
-    Configuration for a log handler that writes to the Windows Event Log.
-    """
-
-    type: Literal["windows-event-log"]
-    level: LogLevel
-
-
-LogHandlerConfig = Annotated[
-    LogFileHandlerConfig | LogConsoleHandlerConfig | LogWindowsEventHandlerConfig, Field(discriminator="type")
-]
+LogHandlerConfig = Annotated[LogFileHandlerConfig | LogConsoleHandlerConfig, Field(discriminator="type")]
 
 
 # Mypy BS

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -263,7 +263,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                             root.addHandler(wh)
                         except ImportError:
                             self._logger.warning(
-                                "To use the Windows Event Log handler, the 'pywin32' package must be installed."
+                                "Failed to import the 'pywin32' package. This should install automatically on windows."
+                                "Please try reinstalling to resolve this issue."
                             )
                     else:
                         self._logger.warning("Windows Event Log handler is only available on Windows.")

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -45,12 +45,10 @@ The subclass should also define several class attributes:
 """
 
 import logging
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from functools import partial
-from logging.handlers import NTEventLogHandler as WindowsEventHandler
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event as MpEvent
 from threading import RLock, Thread
@@ -69,7 +67,6 @@ from cognite.extractorutils.unstable.configuration.models import (
     ExtractorConfig,
     LogConsoleHandlerConfig,
     LogFileHandlerConfig,
-    LogWindowsEventHandlerConfig,
 )
 from cognite.extractorutils.unstable.core._dto import (
     CogniteModel,
@@ -247,27 +244,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                             sh.setFormatter(fmt)
                             sh.setLevel(level_for_handler)
                             root.addHandler(sh)
-
-                case LogWindowsEventHandlerConfig() as windows_event_log_handler:
-                    if sys.platform == "win32":
-                        try:
-                            wh = WindowsEventHandler(self.NAME)
-                            level_for_handler = _resolve_log_level(
-                                self.log_level_override
-                                if self.log_level_override
-                                else windows_event_log_handler.level.value
-                            )
-                            wh.setLevel(level_for_handler)
-                            wh.setFormatter(fmt)
-
-                            root.addHandler(wh)
-                        except ImportError:
-                            self._logger.warning(
-                                "Failed to import the 'pywin32' package. This should install automatically on windows."
-                                "Please try reinstalling to resolve this issue."
-                            )
-                    else:
-                        self._logger.warning("Windows Event Log handler is only available on Windows.")
 
     def __init_tasks__(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/logger.py
+++ b/cognite/extractorutils/unstable/core/logger.py
@@ -327,9 +327,10 @@ class RobustFileHandler(TimedRotatingFileHandler):
 
         try:
             if self.create_dirs:
-                directory = os.path.dirname(filename)
-                if directory and not os.path.exists(directory):
-                    os.makedirs(directory, exist_ok=True)
+                directory = filename.parent
+                directory.mkdir(parents=True, exist_ok=True)
+                if not os.access(directory, os.W_OK):
+                    raise PermissionError(f"Cannot write to directory: {directory}")
 
             super().__init__(
                 filename,

--- a/cognite/extractorutils/unstable/core/logger.py
+++ b/cognite/extractorutils/unstable/core/logger.py
@@ -325,27 +325,23 @@ class RobustFileHandler(TimedRotatingFileHandler):
     ) -> None:
         self.create_dirs = create_dirs
 
-        try:
-            if self.create_dirs:
-                directory = filename.parent
-                directory.mkdir(parents=True, exist_ok=True)
-                if not os.access(directory, os.W_OK):
-                    raise PermissionError(f"Cannot write to directory: {directory}")
+        if self.create_dirs:
+            directory = filename.parent
+            directory.mkdir(parents=True, exist_ok=True)
+            if not os.access(directory, os.W_OK):
+                raise PermissionError(f"Cannot write to directory: {directory}")
 
-            super().__init__(
-                filename,
-                when=when,
-                interval=interval,
-                backupCount=backupCount,
-                encoding=encoding,
-                delay=delay,
-                utc=utc,
-                atTime=atTime,
-                errors=errors,
-            )
+        super().__init__(
+            filename,
+            when=when,
+            interval=interval,
+            backupCount=backupCount,
+            encoding=encoding,
+            delay=delay,
+            utc=utc,
+            atTime=atTime,
+            errors=errors,
+        )
 
-            self.stream.write("")
-            self.stream.flush()
-
-        except (OSError, PermissionError) as e:
-            raise e
+        self.stream.write("")
+        self.stream.flush()

--- a/cognite/extractorutils/unstable/core/logger.py
+++ b/cognite/extractorutils/unstable/core/logger.py
@@ -5,8 +5,12 @@ This class is subclassed by both the ``TaskContext`` and the ``Extractor`` base 
 for logging and error handling in extractors.
 """
 
+import datetime
+import os
 from abc import ABC, abstractmethod
 from logging import Logger, getLogger
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 from traceback import format_exception
 from typing import Literal
 
@@ -296,3 +300,51 @@ class CogniteLogger(ABC):
             description=message,
             details=details,
         ).instant()
+
+
+class RobustFileHandler(TimedRotatingFileHandler):
+    """
+    A TimedRotatingFileHandler that gracefully handles directory/permission issues.
+
+    It can automatically create log directories and raise error to fallback to console logging
+    if the file cannot be created or accessed.
+    """
+
+    def __init__(
+        self,
+        filename: Path,
+        create_dirs: bool = True,
+        when: str = "h",
+        interval: int = 1,
+        backupCount: int = 0,
+        encoding: str | None = None,
+        delay: bool = False,
+        utc: bool = False,
+        atTime: datetime.time | None = None,
+        errors: str | None = None,
+    ) -> None:
+        self.create_dirs = create_dirs
+
+        try:
+            if self.create_dirs:
+                directory = os.path.dirname(filename)
+                if directory and not os.path.exists(directory):
+                    os.makedirs(directory, exist_ok=True)
+
+            super().__init__(
+                filename,
+                when=when,
+                interval=interval,
+                backupCount=backupCount,
+                encoding=encoding,
+                delay=delay,
+                utc=utc,
+                atTime=atTime,
+                errors=errors,
+            )
+
+            self.stream.write("")
+            self.stream.flush()
+
+        except (OSError, PermissionError) as e:
+            raise e

--- a/tests/test_unstable/test_logger.py
+++ b/tests/test_unstable/test_logger.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from cognite.extractorutils.unstable.core.logger import RobustFileHandler
@@ -12,8 +13,8 @@ from cognite.extractorutils.unstable.core.logger import RobustFileHandler
 class TestRobustFileHandler(unittest.TestCase):
     def setUp(self) -> None:
         self.test_dir = tempfile.mkdtemp()
-        self.log_dir = os.path.join(self.test_dir, "logs", "nested", "dir")
-        self.log_file = os.path.join(self.log_dir, "test.log")
+        self.log_dir = Path(self.test_dir, "logs", "nested", "dir")
+        self.log_file = Path(self.log_dir, "test.log")
 
     def tearDown(self) -> None:
         shutil.rmtree(self.test_dir)
@@ -45,10 +46,10 @@ class TestRobustFileHandler(unittest.TestCase):
                 create_dirs=False,
             )
 
-    @patch("os.makedirs")
-    def test_permission_error(self, mock_makedirs: unittest.mock.MagicMock) -> None:
+    @patch("pathlib.Path.mkdir")
+    def test_permission_error(self, mock_mkdir: unittest.mock.MagicMock) -> None:
         """Test handling of permission errors"""
-        mock_makedirs.side_effect = PermissionError("Permission denied")
+        mock_mkdir.side_effect = PermissionError("Permission denied")
 
         with self.assertRaises(PermissionError):
             RobustFileHandler(

--- a/tests/test_unstable/test_logger.py
+++ b/tests/test_unstable/test_logger.py
@@ -1,0 +1,89 @@
+import logging
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+from cognite.extractorutils.unstable.core.logger import RobustFileHandler
+
+
+class TestRobustFileHandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_dir = tempfile.mkdtemp()
+        self.log_dir = os.path.join(self.test_dir, "logs", "nested", "dir")
+        self.log_file = os.path.join(self.log_dir, "test.log")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.test_dir)
+
+    def test_create_dirs(self) -> None:
+        """Test that directories are created automatically"""
+        self.assertFalse(os.path.exists(self.log_dir))
+
+        handler = RobustFileHandler(
+            filename=self.log_file,
+            when="midnight",
+            utc=True,
+            backupCount=3,
+            create_dirs=True,
+        )
+
+        self.assertTrue(os.path.exists(self.log_dir))
+
+        handler.close()
+
+    def test_no_create_dirs(self) -> None:
+        """Test that create_dirs=False doesn't create directories"""
+        with self.assertRaises((OSError, FileNotFoundError)):
+            RobustFileHandler(
+                filename=self.log_file,
+                when="midnight",
+                utc=True,
+                backupCount=3,
+                create_dirs=False,
+            )
+
+    @patch("os.makedirs")
+    def test_permission_error(self, mock_makedirs: unittest.mock.MagicMock) -> None:
+        """Test handling of permission errors"""
+        mock_makedirs.side_effect = PermissionError("Permission denied")
+
+        with self.assertRaises(PermissionError):
+            RobustFileHandler(
+                filename=self.log_file,
+                when="midnight",
+                utc=True,
+                backupCount=3,
+                create_dirs=True,
+            )
+
+    def test_rotation(self) -> None:
+        """Test log rotation (simplified test)"""
+        handler = RobustFileHandler(
+            filename=self.log_file,
+            when="S",
+            utc=True,
+            backupCount=3,
+            create_dirs=True,
+        )
+
+        logger = logging.getLogger("test_rotation")
+        logger.setLevel(logging.INFO)
+        logger.addHandler(handler)
+
+        logger.info("Test message 1")
+
+        self.assertTrue(os.path.exists(self.log_file))
+
+        time.sleep(2)
+
+        logger.info("Test message 2")
+
+        self.assertTrue(os.path.exists(self.log_file))
+
+        rotated_files = [f for f in os.listdir(self.log_dir) if f.startswith(os.path.basename(self.log_file))]
+        self.assertEqual(len(rotated_files), 2)
+
+        handler.close()

--- a/tests/test_unstable/test_logger.py
+++ b/tests/test_unstable/test_logger.py
@@ -45,6 +45,7 @@ class TestRobustFileHandler(unittest.TestCase):
                 backupCount=3,
                 create_dirs=False,
             )
+        self.assertFalse(os.path.exists(self.log_dir))
 
     @patch("pathlib.Path.mkdir")
     def test_permission_error(self, mock_mkdir: unittest.mock.MagicMock) -> None:

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -123,6 +123,7 @@ def test_load_cdf_config_initial_empty(connection_config: ConnectionConfig) -> N
     errors = cognite_client.get(
         url=f"/api/v1/projects/{cognite_client.config.project}/odin/errors",
         params={"integration": connection_config.integration.external_id},
+        headers={"cdf-version": "alpha"},
     ).json()
 
     assert len(errors["items"]) == 1

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -7,6 +7,7 @@ from multiprocessing import Process
 from pathlib import Path
 from random import randint
 from threading import Thread
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -249,3 +250,65 @@ def test_runtime_cancellation_propagates_to_extractor(
     assert "Cancellation signal received from runtime. Shutting down gracefully." in combined, (
         f"Expected cancellation log line not found in output.\nCaptured output:\n{combined}"
     )
+
+
+@patch("sys.platform", "win32")
+@patch("cognite.extractorutils.unstable.core.runtime.Queue")
+@patch("cognite.extractorutils.unstable.core.runtime.WindowsEventHandler")
+@patch("logging.getLogger")
+def test_logging_on_windows(mock_get_logger: MagicMock, mock_windows_handler: MagicMock, mock_queue: MagicMock) -> None:
+    """
+    Tests that the logger correctly initializes a console handler
+    and a WindowsEventHandler when running on Windows.
+    """
+    mock_root_logger = MagicMock()
+    mock_get_logger.return_value = mock_root_logger
+    mock_handler_instance = MagicMock()
+    mock_windows_handler.return_value = mock_handler_instance
+
+    runtime = Runtime(TestExtractor)
+
+    mock_windows_handler.assert_called_once_with(TestExtractor.NAME)
+
+    assert mock_root_logger.addHandler.call_count == 2
+    mock_root_logger.addHandler.assert_any_call(mock_handler_instance)
+
+
+@patch("sys.platform", "linux")
+@patch("cognite.extractorutils.unstable.core.runtime.WindowsEventHandler")
+@patch("logging.getLogger")
+def test_logging_on_non_windows(mock_get_logger: MagicMock, mock_windows_handler: MagicMock) -> None:
+    """
+    Tests that the logger only initializes a console handler
+    and skips the WindowsEventHandler when not on Windows.
+    """
+    mock_root_logger = MagicMock()
+    mock_get_logger.return_value = mock_root_logger
+    runtime = Runtime(TestExtractor)
+
+    mock_windows_handler.assert_not_called()
+
+    assert mock_root_logger.addHandler.call_count == 1
+
+
+@patch("sys.platform", "win32")
+@patch("cognite.extractorutils.unstable.core.runtime.Queue")
+@patch("cognite.extractorutils.unstable.core.runtime.WindowsEventHandler", side_effect=ImportError)
+@patch("logging.getLogger")
+def test_logging_on_windows_with_import_error(
+    mock_get_logger: MagicMock, mock_windows_handler: MagicMock, mock_queue: MagicMock
+) -> None:
+    """
+    Tests that the bootstrap logger handles an ImportError gracefully if pywin32
+    is not installed on a Windows system.
+    """
+    mock_root_logger = MagicMock()
+    mock_get_logger.return_value = mock_root_logger
+    runtime = Runtime(TestExtractor)
+
+    runtime.logger.warning.assert_called_with(
+        "Failed to import the 'pywin32' package. This should install automatically on windows. "
+        "Please try reinstalling to resolve this issue."
+    )
+
+    assert mock_root_logger.addHandler.call_count == 1


### PR DESCRIPTION
This PR handles logging by making the following changes on top of the existing ones: 

1. Add handler to log to Windows Event log in case the extractor is running on windows. 
2. Check edge cases in case the log handler is FileHandler and and in case of exceptions default to console log. 