### PR TITLE
[add] Implement state store in unstable module

### DIFF
--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -503,7 +503,7 @@ class StateStoreConfig(ConfigModel):
 
         if self.local:
             if self.local.path.is_dir():
-                raise ValueError(f"{self.local.path} is a directory, and not a file")
+                raise IsADirectoryError(f"{self.local.path}")
 
             return LocalStateStore(
                 file_path=str(self.local.path),
@@ -513,8 +513,8 @@ class StateStoreConfig(ConfigModel):
 
         if default_to_local:
             return LocalStateStore(file_path="states.json", cancellation_token=cancellation_token)
-        else:
-            return NoStateStore()
+
+        return NoStateStore()
 
 
 class ExtractorConfig(ConfigModel):

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -503,7 +503,7 @@ class StateStoreConfig(ConfigModel):
 
         if self.local:
             if self.local.path.is_dir():
-                raise IsADirectoryError(f"{self.local.path}")
+                raise IsADirectoryError(self.local.path)
 
             return LocalStateStore(
                 file_path=str(self.local.path),

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -5,6 +5,7 @@ Module containing pre-built models for common extractor configuration.
 import os
 import re
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
@@ -24,6 +25,13 @@ from cognite.client.credentials import (
 )
 from cognite.extractorutils.configtools._util import _load_certificate_data
 from cognite.extractorutils.exceptions import InvalidConfigError
+from cognite.extractorutils.statestore import (
+    AbstractStateStore,
+    LocalStateStore,
+    NoStateStore,
+    RawStateStore,
+)
+from cognite.extractorutils.threading import CancellationToken
 
 __all__ = [
     "AuthenticationConfig",
@@ -427,11 +435,99 @@ def _log_handler_default() -> list[LogHandlerConfig]:
     return [LogConsoleHandlerConfig(type="console", level=LogLevel.INFO)]
 
 
+@dataclass
+class RawDestinationConfig:
+    """
+    Configuration parameters for using Raw.
+    """
+
+    database: str
+    table: str
+
+
+@dataclass
+class RawStateStoreConfig(RawDestinationConfig):
+    """
+    Configuration of a state store based on CDF RAW.
+    """
+
+    upload_interval: TimeIntervalConfig = field(default_factory=lambda: TimeIntervalConfig("30s"))
+
+
+@dataclass
+class LocalStateStoreConfig:
+    """
+    Configuration of a state store using a local JSON file.
+    """
+
+    path: Path
+    save_interval: TimeIntervalConfig = field(default_factory=lambda: TimeIntervalConfig("30s"))
+
+
+@dataclass
+class StateStoreConfig:
+    """
+    Configuration of the State Store, containing ``LocalStateStoreConfig`` or ``RawStateStoreConfig``.
+    """
+
+    raw: RawStateStoreConfig | None = None
+    local: LocalStateStoreConfig | None = None
+
+    def create_state_store(
+        self,
+        cdf_client: CogniteClient | None = None,
+        default_to_local: bool = True,
+        cancellation_token: CancellationToken | None = None,
+    ) -> AbstractStateStore:
+        """
+        Create a state store object based on the config.
+
+        Args:
+            cdf_client: CogniteClient object to use in case of a RAW state store (ignored otherwise)
+            default_to_local: If true, return a LocalStateStore if no state store is configured. Otherwise return a
+                NoStateStore
+            cancellation_token: Cancellation token to pass to created state stores
+
+        Returns:
+            An (uninitialized) state store
+        """
+        if self.raw and self.local:
+            raise ValueError("Only one state store can be used simultaneously")
+
+        if self.raw:
+            if cdf_client is None:
+                raise TypeError("A cognite client object must be provided when state store is RAW")
+
+            return RawStateStore(
+                cdf_client=cdf_client,
+                database=self.raw.database,
+                table=self.raw.table,
+                save_interval=self.raw.upload_interval.seconds,
+                cancellation_token=cancellation_token,
+            )
+
+        if self.local:
+            if self.local.path.is_dir():
+                raise ValueError(f"{self.local.path} is a directory, and not a file")
+
+            return LocalStateStore(
+                file_path=str(self.local.path),
+                save_interval=self.local.save_interval.seconds,
+                cancellation_token=cancellation_token,
+            )
+
+        if default_to_local:
+            return LocalStateStore(file_path="states.json", cancellation_token=cancellation_token)
+        else:
+            return NoStateStore()
+
+
 class ExtractorConfig(ConfigModel):
     """
     Base class for application configuration for extractors.
     """
 
+    state_store: StateStoreConfig | None = None
     log_handlers: list[LogHandlerConfig] = Field(default_factory=_log_handler_default)
     retry_startup: bool = True
 

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -5,7 +5,6 @@ Module containing pre-built models for common extractor configuration.
 import os
 import re
 from collections.abc import Iterator
-from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
@@ -435,8 +434,7 @@ def _log_handler_default() -> list[LogHandlerConfig]:
     return [LogConsoleHandlerConfig(type="console", level=LogLevel.INFO)]
 
 
-@dataclass
-class RawDestinationConfig:
+class RawDestinationConfig(ConfigModel):
     """
     Configuration parameters for using Raw.
     """
@@ -445,27 +443,24 @@ class RawDestinationConfig:
     table: str
 
 
-@dataclass
 class RawStateStoreConfig(RawDestinationConfig):
     """
     Configuration of a state store based on CDF RAW.
     """
 
-    upload_interval: TimeIntervalConfig = field(default_factory=lambda: TimeIntervalConfig("30s"))
+    upload_interval: TimeIntervalConfig = Field(default_factory=lambda: TimeIntervalConfig("30s"))
 
 
-@dataclass
-class LocalStateStoreConfig:
+class LocalStateStoreConfig(ConfigModel):
     """
     Configuration of a state store using a local JSON file.
     """
 
     path: Path
-    save_interval: TimeIntervalConfig = field(default_factory=lambda: TimeIntervalConfig("30s"))
+    save_interval: TimeIntervalConfig = Field(default_factory=lambda: TimeIntervalConfig("30s"))
 
 
-@dataclass
-class StateStoreConfig:
+class StateStoreConfig(ConfigModel):
     """
     Configuration of the State Store, containing ``LocalStateStoreConfig`` or ``RawStateStoreConfig``.
     """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -61,9 +61,6 @@ from humps import pascalize
 from typing_extensions import Self, assert_never
 
 from cognite.extractorutils._inner_util import _resolve_log_level
-from cognite.extractorutils.configtools import (
-    StateStoreConfig,
-)
 from cognite.extractorutils.statestore import (
     AbstractStateStore,
     LocalStateStore,
@@ -77,6 +74,7 @@ from cognite.extractorutils.unstable.configuration.models import (
     ExtractorConfig,
     LogConsoleHandlerConfig,
     LogFileHandlerConfig,
+    StateStoreConfig,
 )
 from cognite.extractorutils.unstable.core._dto import (
     CogniteModel,

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -284,17 +284,16 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 default_to_local=self.USE_DEFAULT_STATE_STORE,
                 cancellation_token=self.cancellation_token,
             )
+        elif self.USE_DEFAULT_STATE_STORE:
+            self.state_store = LocalStateStore("states.json", cancellation_token=self.cancellation_token)
         else:
-            self.state_store = (
-                LocalStateStore("states.json", cancellation_token=self.cancellation_token)
-                if self.USE_DEFAULT_STATE_STORE
-                else NoStateStore()
-            )
+            self.state_store = NoStateStore()
 
         try:
             self.state_store.initialize()
         except ValueError:
             self._logger.exception("Could not load state store, using an empty state store as default")
+            self.state_store = NoStateStore()
 
         Extractor._statestore_singleton = self.state_store
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -47,14 +47,13 @@ The subclass should also define several class attributes:
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import is_dataclass
 from datetime import datetime, timezone
 from functools import partial
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event as MpEvent
 from threading import RLock, Thread
 from types import TracebackType
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from humps import pascalize
 from typing_extensions import Self, assert_never
@@ -73,7 +72,6 @@ from cognite.extractorutils.unstable.configuration.models import (
     ExtractorConfig,
     LogConsoleHandlerConfig,
     LogFileHandlerConfig,
-    StateStoreConfig,
 )
 from cognite.extractorutils.unstable.core._dto import (
     CogniteModel,
@@ -266,9 +264,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         Either way, the state_store attribute is guaranteed to be set after calling this method.
         """
-
         state_store_config = self.application_config.state_store
-        
+
         if state_store_config:
             self.state_store = state_store_config.create_state_store(
                 cdf_client=self.cognite_client,

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -267,17 +267,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         Either way, the state_store attribute is guaranteed to be set after calling this method.
         """
 
-        def recursive_find_state_store(d: dict[str, Any]) -> StateStoreConfig | None:
-            for k in d:
-                if is_dataclass(d[k]):
-                    res = recursive_find_state_store(d[k].__dict__)
-                    if res:
-                        return res
-                if isinstance(d[k], StateStoreConfig):
-                    return d[k]
-            return None
-
-        state_store_config = recursive_find_state_store(self.application_config.__dict__)
+        state_store_config = self.application_config.state_store
+        
         if state_store_config:
             self.state_store = state_store_config.create_state_store(
                 cdf_client=self.cognite_client,

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -202,3 +202,14 @@ class TestExtractor(Extractor[TestConfig]):
             ctx.warning("This is a warning message.")
 
         self.add_task(StartupTask(name="log_task", target=log_messages_task))
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton() -> Generator[None, None, None]:
+    """
+    This fixture ensures that the _statestore_singleton class
+    variable is reset, providing test isolation.
+    """
+    Extractor._statestore_singleton = None
+    yield
+    Extractor._statestore_singleton = None

--- a/tests/test_unstable/conftest.py
+++ b/tests/test_unstable/conftest.py
@@ -1,7 +1,7 @@
 import gzip
 import json
 import os
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterator
 from threading import RLock
 from time import sleep, time
 from typing import Any
@@ -23,6 +23,17 @@ from cognite.extractorutils.unstable.configuration.models import (
 from cognite.extractorutils.unstable.core.base import Extractor, StartupTask, TaskContext
 
 working_dir = os.getcwd()
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton() -> Iterator[None]:
+    """
+    This fixture ensures that the _statestore_singleton class
+    variable is reset, providing test isolation.
+    """
+    Extractor._statestore_singleton = None
+    yield
+    Extractor._statestore_singleton = None
 
 
 @pytest.fixture(autouse=True)
@@ -202,14 +213,3 @@ class TestExtractor(Extractor[TestConfig]):
             ctx.warning("This is a warning message.")
 
         self.add_task(StartupTask(name="log_task", target=log_messages_task))
-
-
-@pytest.fixture(autouse=True)
-def reset_singleton() -> Generator[None, None, None]:
-    """
-    This fixture ensures that the _statestore_singleton class
-    variable is reset, providing test isolation.
-    """
-    Extractor._statestore_singleton = None
-    yield
-    Extractor._statestore_singleton = None

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -1,11 +1,21 @@
+import contextlib
+import json
 import logging
+import random
+from collections.abc import Generator
+from pathlib import Path
 
 import pytest
 
+from cognite.client import CogniteClient
+from cognite.client.exceptions import CogniteNotFoundError
 from cognite.extractorutils.unstable.configuration.models import (
     ConnectionConfig,
+    LocalStateStoreConfig,
     LogConsoleHandlerConfig,
     LogLevel,
+    RawStateStoreConfig,
+    StateStoreConfig,
 )
 from cognite.extractorutils.unstable.core.base import FullConfig
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
@@ -84,3 +94,129 @@ def test_log_level_override(
         assert log in console_output
     for log in unexpected_logs:
         assert log not in console_output
+
+
+@pytest.fixture
+def local_state_file(tmp_path: Path) -> Path:
+    """
+    Provides a path to a temporary file for a single test function run.
+    The file and its parent directory are automatically cleaned up by pytest.
+    """
+    return tmp_path / "test_states.json"
+
+
+def get_checkin_worker(connection_config: ConnectionConfig) -> CheckinWorker:
+    """
+    Helper function to create a CheckinWorker instance for tests.
+    """
+    worker = CheckinWorker(
+        connection_config.get_cognite_client("testing"),
+        connection_config.integration.external_id,
+        logging.getLogger(__name__),
+        lambda _: None,
+        lambda _: None,
+        1,
+        False,
+    )
+    return worker
+
+
+def test_local_state_store_integration(local_state_file: Path, connection_config: ConnectionConfig) -> None:
+    """
+    Tests the integration of LocalStateStore with the extractor configuration.
+    """
+    app_config = TestConfig(
+        parameter_one=1,
+        parameter_two="a",
+        log_handlers=[LogConsoleHandlerConfig(type="console", level=LogLevel("INFO"))],
+        state_store=StateStoreConfig(local=LocalStateStoreConfig(path=local_state_file)),
+    )
+
+    full_config = FullConfig(
+        connection_config=connection_config,
+        application_config=app_config,
+        current_config_revision=1,
+    )
+
+    worker = get_checkin_worker(connection_config)
+    extractor = TestExtractor(full_config, worker)
+
+    with extractor:
+        state_store = extractor.state_store
+
+        assert not local_state_file.exists()
+        assert state_store.get_state("my-test-id") == (None, None)
+
+        state_store.set_state(external_id="my-test-id", low=1, high=5)
+        state_store.synchronize()
+
+        assert local_state_file.exists()
+        with open(local_state_file) as f:
+            data = json.load(f)
+            assert data["my-test-id"] == {"low": 1, "high": 5}
+
+    new_extractor = TestExtractor(full_config, worker)
+    with new_extractor:
+        assert new_extractor.state_store.get_state("my-test-id") == (1, 5)
+
+
+@pytest.fixture(scope="function")
+def raw_db_table_name() -> str:
+    """Provides a unique database name for a single test function run."""
+    test_id = random.randint(0, int(1e9))
+    return f"test_db_{test_id}", f"test_table_{test_id}"
+
+
+@pytest.fixture
+def setup_and_teardown_raw_db(
+    set_client: CogniteClient, raw_db_table_name: str
+) -> Generator[tuple[str, str], None, None]:
+    """
+    This fixture ensures the RAW database/table is cleaned up after the test.
+    """
+    db_name, table_name = raw_db_table_name
+
+    yield db_name, table_name
+
+    with contextlib.suppress(CogniteNotFoundError):
+        set_client.raw.databases.delete(name=db_name, recursive=True)
+
+
+def test_raw_state_store_integration(
+    connection_config: ConnectionConfig,
+    setup_and_teardown_raw_db: tuple[str, str],
+) -> None:
+    """
+    Tests the integration of LocalStateStore with the extractor configuration.
+    """
+    db_name, table_name = setup_and_teardown_raw_db
+
+    app_config = TestConfig(
+        parameter_one=1,
+        parameter_two="a",
+        log_handlers=[LogConsoleHandlerConfig(type="console", level=LogLevel("INFO"))],
+        state_store=StateStoreConfig(raw=RawStateStoreConfig(database=db_name, table=table_name)),
+    )
+
+    full_config = FullConfig(
+        connection_config=connection_config,
+        application_config=app_config,
+        current_config_revision=1,
+    )
+
+    worker = get_checkin_worker(connection_config)
+    extractor = TestExtractor(full_config, worker)
+
+    with extractor:
+        state_store = extractor.state_store
+
+        assert state_store.get_state("my-test-id") == (None, None)
+
+        state_store.set_state(external_id="my-test-id", low=1, high=5)
+        state_store.synchronize()
+
+        assert state_store.get_state("my-test-id") == (1, 5)
+
+    new_extractor = TestExtractor(full_config, worker)
+    with new_extractor:
+        assert new_extractor.state_store.get_state("my-test-id") == (1, 5)


### PR DESCRIPTION
This PR aims to bring the state store related changes from base extractor to the unstable module. The state store provides a standardized way for extractors to persist state between runs, enabling efficient incremental extraction patterns.