### PR TITLE
Add Service flag logic

### DIFF
--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -439,7 +439,7 @@ class Runtime(Generic[ExtractorType]):
             register_service(service_main, self._extractor_class.NAME, cancel_service)
             run_service()
             return
-        else:
+        elif args.service and sys.platform != "win32":
             self.logger.critical("--service is only supported on Windows.")
             sys.exit(1)
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -196,6 +196,11 @@ class Runtime(Generic[ExtractorType]):
             required=False,
             help="Set the current working directory for the extractor.",
         )
+        argparser.add_argument(
+            "--service",
+            action="store_true",
+            help="Run the extractor as a Windows service (only supported on Windows).",
+        )
 
         return argparser
 
@@ -402,6 +407,40 @@ class Runtime(Generic[ExtractorType]):
 
         self.logger.info(f"Started runtime with PID {os.getpid()}")
 
+        if args.service:
+            if sys.platform != "win32":
+                self.logger.critical("--service is only supported on Windows.")
+                sys.exit(1)
+            try:
+                from simple_winservice import ServiceHandle, register_service, run_service
+            except ImportError:
+                self.logger.critical("simple-winservice library is not installed.")
+                sys.exit(1)
+
+            # Cancellation function for the service
+            def cancel_service() -> None:
+                self.logger.info("Service cancellation requested.")
+                self._cancellation_token.cancel()
+
+            # Wrap the main runtime loop in a function for the service
+            def service_main(handle: ServiceHandle, service_args: list[str]) -> None:
+                handle.event_log_info("Extractor Windows service is starting.")
+                try:
+                    self._main_runtime(args)
+                except Exception as exc:
+                    handle.event_log_error(f"Service crashed: {exc}")
+                    self.logger.critical(f"Service crashed: {exc}", exc_info=True)
+                    sys.exit(1)
+                handle.event_log_info("Extractor Windows service is stopping.")
+
+            # Register and run the service
+            register_service(service_main, self._extractor_class.NAME, cancel_service)
+            run_service()
+            return
+
+        self._main_runtime(args)
+
+    def _main_runtime(self, args: Namespace) -> None:
         try:
             self._try_set_cwd(args)
             connection_config = load_file(args.connection_config[0], ConnectionConfig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ repository = "https://github.com/cognitedata/python-extractor-utils"
 
 [project.optional-dependencies]
 experimental = ["cognite-sdk-experimental"]
+windows-service = [
+    "simple-winservice; sys_platform == 'win32'"
+]
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pyhumps>=3.8.0",
     "croniter>=6.0.0",
     "jsonlines>=4.0.0",
+    "simple-winservice>=0.1.0 ; sys_platform == 'win32'",
 ]
 
 [project.urls]
@@ -40,9 +41,6 @@ repository = "https://github.com/cognitedata/python-extractor-utils"
 
 [project.optional-dependencies]
 experimental = ["cognite-sdk-experimental"]
-windows-service = [
-    "simple-winservice; sys_platform == 'win32'"
-]
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -7,6 +7,8 @@ from multiprocessing import Process
 from pathlib import Path
 from random import randint
 from threading import Thread
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -249,3 +251,79 @@ def test_runtime_cancellation_propagates_to_extractor(
     assert "Cancellation signal received from runtime. Shutting down gracefully." in combined, (
         f"Expected cancellation log line not found in output.\nCaptured output:\n{combined}"
     )
+
+
+def test_service_flag_non_windows(monkeypatch: MonkeyPatch) -> None:
+    runtime = Runtime(TestExtractor)
+    monkeypatch.setattr(sys, "platform", "linux")
+    with patch("argparse.ArgumentParser.parse_args") as mock_args:
+        mock_args.return_value = MagicMock(service=True, log_level="info")
+        with pytest.raises(SystemExit) as excinfo:
+            runtime.run()
+        assert excinfo.value.code == 1
+
+
+def test_service_flag_windows_import_error(monkeypatch: MonkeyPatch) -> None:
+    runtime = Runtime(TestExtractor)
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch("argparse.ArgumentParser.parse_args") as mock_args:
+        mock_args.return_value = MagicMock(service=True, log_level="info")
+        with patch.dict("sys.modules", {"simple_winservice": None}):
+            with pytest.raises(SystemExit) as excinfo:
+                runtime.run()
+            assert excinfo.value.code == 1
+
+
+def test_service_flag_windows_success(monkeypatch: MonkeyPatch) -> None:
+    runtime = Runtime(TestExtractor)
+    monkeypatch.setattr(sys, "platform", "win32")
+    with patch("argparse.ArgumentParser.parse_args") as mock_args:
+        mock_args.return_value = MagicMock(service=True, log_level="info")
+        mock_register = MagicMock()
+        mock_run = MagicMock()
+        mock_handle = MagicMock()
+        sys.modules["simple_winservice"] = MagicMock(
+            register_service=mock_register,
+            run_service=mock_run,
+            ServiceHandle=mock_handle,
+        )
+        with (
+            patch("simple_winservice.register_service", mock_register),
+            patch("simple_winservice.run_service", mock_run),
+        ):
+            runtime.run()
+            mock_register.assert_called()
+            mock_run.assert_called()
+
+
+def test_service_main_entrypoint(monkeypatch: MonkeyPatch) -> None:
+    runtime = Runtime(TestExtractor)
+    monkeypatch.setattr(sys, "platform", "win32")
+    args = MagicMock(service=True, log_level="info")
+    handle = MagicMock()
+
+    # Simulate cancellation after a short delay
+    def cancel() -> None:
+        time.sleep(0.5)
+        runtime._cancellation_token.cancel()
+
+    cancel_thread = Thread(target=cancel)
+    cancel_thread.start()
+    with patch.object(runtime, "_main_runtime") as mock_main:
+
+        def main_side_effect(*_: Any) -> None:
+            time.sleep(1)
+
+        mock_main.side_effect = main_side_effect
+
+        from simple_winservice import ServiceHandle
+
+        # Simulate service_main logic
+        def service_main(handle: ServiceHandle, service_args: list[str]) -> None:
+            handle.event_log_info("Extractor Windows service is starting.")
+            runtime._main_runtime(args)
+            handle.event_log_info("Extractor Windows service is stopping.")
+
+        # Should not raise
+        service_main(handle, [])
+    cancel_thread.join()

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -321,12 +321,15 @@ def test_service_main_entrypoint(monkeypatch: MonkeyPatch) -> None:
         # Simulate service_main logic
         def service_main(handle: ServiceHandle, service_args: list[str]) -> None:
             handle.event_log_info("Extractor Windows service is starting.")
+            handle.event_log_info.assert_any_call("Extractor Windows service is starting.")
             runtime._main_runtime(args)
             handle.event_log_info("Extractor Windows service is stopping.")
 
         # Should not raise
         service_main(handle, [])
     cancel_thread.join()
+    handle.event_log_info.assert_any_call("Extractor Windows service is stopping.")
+    assert mock_main.call_count == 1
 
 
 @patch("sys.platform", "win32")

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -325,6 +325,8 @@ def test_service_main_entrypoint(monkeypatch: MonkeyPatch, connection_config: Co
         # Assert that 'Shutting down runtime' was logged, confirming _main_runtime ran
         mock_logger_info.assert_any_call("Shutting down runtime")
 
+    assert runtime._cancellation_token.is_cancelled()
+
 
 @patch("sys.platform", "win32")
 @patch("cognite.extractorutils.unstable.core.runtime.Queue")


### PR DESCRIPTION
This PR introduces a new `--service` flag to the Runtime.

1. When passed, the extractor will run as a Windows Service.
2. The Windows Service functionality is only available in Windows environments.
3. It requires the inbuilt Python library `simple-winservice` to function.

After passing the --service flag, users need to register the service in Windows before starting it. This can be done using the sc utility:

`sc create <service_name> binPath= "<path_to_extractor.exe> --service"`