### PR TITLE
Move checkin worker to runtime layer

### DIFF
--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -67,9 +67,8 @@ def test_log_level_override(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
+    worker.active_revision = 1
     extractor = TestExtractor(full_config, worker)
 
     with extractor:

--- a/tests/test_unstable/test_checkin_worker.py
+++ b/tests/test_unstable/test_checkin_worker.py
@@ -35,8 +35,6 @@ def test_report_startup_request(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(
@@ -77,8 +75,6 @@ def test_flush_and_checkin(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     worker._has_reported_startup = True
     test_extractor = TestExtractor(
@@ -129,8 +125,6 @@ def test_run_report_periodic(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(
@@ -189,8 +183,6 @@ def test_run_report_periodic_ensure_reorder(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(
@@ -268,8 +260,6 @@ def test_run_report_periodic_checkin(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(
@@ -354,8 +344,6 @@ def test_on_fatal_hook_is_called(
         logging.getLogger(__name__),
         lambda _: None,
         on_fatal_hook,
-        1,
-        False,
     )
     worker._retry_startup = True
     test_extractor = TestExtractor(
@@ -405,8 +393,6 @@ def test_on_revision_change_hook_is_called(
         logging.getLogger(__name__),
         on_revision_change,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(
@@ -421,14 +407,15 @@ def test_on_revision_change_hook_is_called(
     cancellation_token = CancellationToken()
     on_revision_change_value = 0
 
-    worker._retry_startup = True
+    worker.should_retry_startup()
+    worker.active_revision = 1
 
     process = Thread(
         target=worker.run_periodic_checkin,
         args=(cancellation_token, test_extractor._get_startup_request(), 5),
     )
     process.start()
-    process.join(timeout=10)
+    process.join(timeout=5)
 
     assert on_revision_change_value == 2
 
@@ -452,8 +439,6 @@ def test_run_report_periodic_checkin_requeue(
         logging.getLogger(__name__),
         lambda _: None,
         lambda _: None,
-        1,
-        False,
     )
     test_extractor = TestExtractor(
         FullConfig(


### PR DESCRIPTION
This moves the check-in worker to runtime layer. The worker itself should only be started once, but with the previous implementation, a new instance is created every time the extractor has to restart.