### PR TITLE
Fix encoding issue in windows.

### DIFF
--- a/cognite/extractorutils/configtools/elements.py
+++ b/cognite/extractorutils/configtools/elements.py
@@ -605,6 +605,7 @@ class LoggingConfig:
                 when="midnight",
                 utc=True,
                 backupCount=self.file.retention,
+                encoding="utf-8",
             )
             file_handler.setLevel(self.file.level)
             file_handler.setFormatter(fmt)

--- a/cognite/extractorutils/configtools/loaders.py
+++ b/cognite/extractorutils/configtools/loaders.py
@@ -384,7 +384,7 @@ class ConfigResolver(Generic[CustomConfigClass]):
         self._cognite_client: CogniteClient | None = None
 
     def _reload_file(self) -> None:
-        with open(self.config_path) as stream:
+        with open(self.config_path, encoding="utf-8") as stream:
             self._config_text = stream.read()
 
     @property

--- a/tests/tests_unit/greek_dummy_config.yaml
+++ b/tests/tests_unit/greek_dummy_config.yaml
@@ -1,0 +1,16 @@
+logger:
+    console:
+        level: INFO
+    file:
+        level: DEBUG
+        path: C:\Cognite\ΔΙΕΡΓΑΣΙΕΣHEALTH & SAFETY MANAGEMENT (HSM)ΑΡΧΕΙΟ HSMΑΣΚΗΣΕΙΣ ΠΥΡΑΣΦΑΛΕΙΑΣ 2025
+
+cognite:
+    project: mathiaslohne-develop
+
+    idp-authentication:
+        client-id: abc123
+        secret: def567
+        token-url: https://get-a-token.com/token
+        scopes:
+            - https://api.cognitedata.com/.default


### PR DESCRIPTION
This PR fixes an issue where files containing Greek characters could not be read on Windows. The problem occurred because Windows defaults to the `cp1252` encoding, which does not support Greek characters properly.

To ensure consistent behavior across all platforms (Windows, Linux, macOS), we now explicitly enforce `UTF-8` as the default encoding when opening files. This guarantees correct handling of multilingual text regardless of the underlying system’s locale or default encoding. Prevents UnicodeDecodeErrors on Windows when reading files containing non-ASCII characters (e.g., Greek).

Changes
1. Updated file open logic to always use `encoding="utf-8"` unless explicitly overridden.
2. Test cases.
 
