### PR TITLE
Allow log levels from lowercase

### DIFF
--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal, TypeVar
+from typing import Annotated, Any, Literal, Self, TypeVar
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
@@ -404,6 +404,15 @@ class LogLevel(Enum):
     WARNING = "WARNING"
     INFO = "INFO"
     DEBUG = "DEBUG"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        if not isinstance(value, str):
+            raise ValueError(f"{value} is not a valid log level")
+        for member in cls:
+            if member.value == value.upper():
+                return member
+        raise ValueError(f"{value} is not a valid log level")
 
 
 class LogFileHandlerConfig(ConfigModel):

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -4,18 +4,11 @@ Module containing pre-built models for common extractor configuration.
 
 import os
 import re
-import sys
 from collections.abc import Iterator
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any, Literal, TypeVar
-
-# Check if python >= 3.11 for Self
-if tuple(map(int, sys.version.split(".")[:2])) >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler
@@ -413,7 +406,7 @@ class LogLevel(Enum):
     DEBUG = "DEBUG"
 
     @classmethod
-    def _missing_(cls, value: object) -> Self:
+    def _missing_(cls, value: object) -> "LogLevel":
         if not isinstance(value, str):
             raise ValueError(f"{value} is not a valid log level")
         for member in cls:

--- a/cognite/extractorutils/unstable/configuration/models.py
+++ b/cognite/extractorutils/unstable/configuration/models.py
@@ -4,11 +4,18 @@ Module containing pre-built models for common extractor configuration.
 
 import os
 import re
+import sys
 from collections.abc import Iterator
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal, Self, TypeVar
+from typing import Annotated, Any, Literal, TypeVar
+
+# Check if python >= 3.11 for Self
+if tuple(map(int, sys.version.split(".")[:2])) >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from humps import kebabize
 from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler

--- a/tests/test_unstable/test_configuration.py
+++ b/tests/test_unstable/test_configuration.py
@@ -7,6 +7,7 @@ from cognite.client.credentials import OAuthClientCredentials
 from cognite.extractorutils.unstable.configuration.loaders import ConfigFormat, load_io
 from cognite.extractorutils.unstable.configuration.models import (
     ConnectionConfig,
+    LogLevel,
     TimeIntervalConfig,
     _ClientCredentialsConfig,
 )
@@ -212,3 +213,14 @@ def test_from_env() -> None:
 
     # Check that the produces cogniteclient object is valid
     assert len(client.assets.list(limit=1)) == 1
+
+
+def test_setting_log_level_from_any_case() -> None:
+    log_level = LogLevel("DEBUG")
+    assert log_level == LogLevel.DEBUG
+
+    log_level = LogLevel("debug")
+    assert log_level == LogLevel.DEBUG
+
+    with pytest.raises(ValueError):
+        LogLevel("not-a-log-level")


### PR DESCRIPTION
Encountered this while testing and discovered that log levels can only be set with all caps. From experience, most users will usually prefer lower cases hence this change.