### PR TITLE
fix: disable noisy gemini summary

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -5,7 +5,7 @@ code_review:
   max_review_comments: -1
   pull_request_opened:
     help: false
-    summary: true
+    summary: false
     code_review: true
     include_drafts: true
 ignore_patterns: []


### PR DESCRIPTION
Sets `pull_request_opened.summary` to `false` in `.gemini/config.yaml`, matching other repos (e.g. cognitedata/terraform#17602).

Made with [Cursor](https://cursor.com)