### PR TITLE
Fix log message for Loading app config from CDF

### DIFF
--- a/cognite/extractorutils/unstable/core/logger.py
+++ b/cognite/extractorutils/unstable/core/logger.py
@@ -343,7 +343,6 @@ class RobustFileHandler(TimedRotatingFileHandler):
             errors=errors,
         )
 
-        # FileHandler leaves stream unset until first emit when delay=True; typeshed types it as optional.
-        if self.stream is not None:
-            self.stream.write("")
-            self.stream.flush()
+        # Ensure the log file path exists and is writable. Using touch validates when
+        # delay=True, because FileHandler does not open the stream until the first emit.
+        filename.touch()

--- a/cognite/extractorutils/unstable/core/logger.py
+++ b/cognite/extractorutils/unstable/core/logger.py
@@ -343,5 +343,7 @@ class RobustFileHandler(TimedRotatingFileHandler):
             errors=errors,
         )
 
-        self.stream.write("")
-        self.stream.flush()
+        # FileHandler leaves stream unset until first emit when delay=True; typeshed types it as optional.
+        if self.stream is not None:
+            self.stream.write("")
+            self.stream.flush()

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -298,7 +298,9 @@ class Runtime(Generic[ExtractorType]):
                 raise InvalidConfigError(str(e)) from e
 
         else:
-            self.logger.info("Loading application config from CDF")
+            self.logger.info(
+                f"Loading application config from CDF for integration: {connection_config.integration.external_id}"
+            )
 
             application_config, current_config_revision = load_from_cdf(
                 self._cognite_client,

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -333,9 +333,10 @@ class Runtime(Generic[ExtractorType]):
 
             except Exception as e:
                 error_message = str(e)
-                self.logger.error(f"{error_message}")
+                self.logger.error(error_message)
                 if error_message == prev_error:
-                    # Wait and retry if the error is the same as the previous one
+                    # Back off with a random delay in [1, RETRY_CONFIG_INTERVAL] seconds so retries are spread over time
+                    # to reduce synchronized retries / thundering herd when loading config fails.
                     self._cancellation_token.wait(randint(1, self.RETRY_CONFIG_INTERVAL))
                     continue
                 prev_error = error_message

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -333,12 +333,11 @@ class Runtime(Generic[ExtractorType]):
 
             except Exception as e:
                 error_message = str(e)
+                self.logger.error(f"{error_message}")
                 if error_message == prev_error:
-                    # Log the error again to make sure it is not missed
-                    self.logger.error(error_message)
+                    # Wait and retry if the error is the same as the previous one
                     self._cancellation_token.wait(randint(1, self.RETRY_CONFIG_INTERVAL))
                     continue
-                self.logger.error(error_message)
                 prev_error = error_message
 
                 ts = now()

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -334,7 +334,8 @@ class Runtime(Generic[ExtractorType]):
             except Exception as e:
                 error_message = str(e)
                 if error_message == prev_error:
-                    # Same error as before, no need to log it again
+                    # Log the error again to make sure it is not missed
+                    self.logger.error(f"{error_message}")
                     self._cancellation_token.wait(randint(1, self.RETRY_CONFIG_INTERVAL))
                     continue
                 self.logger.error(error_message)

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -298,9 +298,7 @@ class Runtime(Generic[ExtractorType]):
                 raise InvalidConfigError(str(e)) from e
 
         else:
-            self.logger.info(
-                f"Loading application config from CDF for integration: {connection_config.integration.external_id}"
-            )
+            self.logger.info("Loading application config from CDF")
 
             application_config, current_config_revision = load_from_cdf(
                 self._cognite_client,
@@ -337,7 +335,7 @@ class Runtime(Generic[ExtractorType]):
                 error_message = str(e)
                 if error_message == prev_error:
                     # Log the error again to make sure it is not missed
-                    self.logger.error(f"{error_message}")
+                    self.logger.error(error_message)
                     self._cancellation_token.wait(randint(1, self.RETRY_CONFIG_INTERVAL))
                     continue
                 self.logger.error(error_message)

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -888,7 +888,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
         Resolve id of assets if specified, for use in sequence creation.
         """
         assets = set(self.sequence_asset_external_ids.values())
-        assets.discard(None)  # type: ignore  # safeguard, remove Nones if any
+        assets.discard(None)  # safeguard, remove Nones if any
 
         if len(assets) > 0:
             try:
@@ -908,7 +908,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
         Resolve id of datasets if specified, for use in sequence creation.
         """
         datasets = set(self.sequence_dataset_external_ids.values())
-        datasets.discard(None)  # type: ignore  # safeguard, remove Nones if any
+        datasets.discard(None)  # safeguard, remove Nones if any
 
         if len(datasets) > 0:
             try:


### PR DESCRIPTION
The log showed repeated "Loading application config from CDF" when the config in the integrations UI is invalid.
If same error were to repeat, it wasn't logged.

This PR:
- logs the invalid error message along with the "Loading application config from CDF" so that the user has more context why there is trouble in loading the config from CDF