### PR TITLE
DOG-7148 Modify the syntax of the schema/docs in python-extractor-utils

### DIFF
--- a/schema/docs/envsub.md
+++ b/schema/docs/envsub.md
@@ -13,10 +13,10 @@ will load the value from the `COGNITE_CLIENT_SECRET` environment variable into t
 url: http://my-host.com/api/endpoint?secret=${MY_SECRET_TOKEN}
 ```
 
-:::info Note
+<Info>
 Implicit substitutions only work for unquoted value strings. For quoted strings, use the `!env` tag to activate environment substitution:
 
 ```yaml
 url: !env 'http://my-host.com/api/endpoint?secret=${MY_SECRET_TOKEN}'
 ```
-:::
+</Info>

--- a/schema/docs/remote_tip.md
+++ b/schema/docs/remote_tip.md
@@ -1,3 +1,3 @@
-:::tip Tip
+<Tip>
 You can set up [extraction pipelines](../../interfaces/configure_integrations.md) to use versioned extractor configuration files stored in the cloud.
-:::
+</Tip>


### PR DESCRIPTION
This PR adds 
Modifications to the syntax of the `schema/docs` in python-extractor-utils which would be used for the documentation flow (with mintlify)