### PR TITLE
Add content-type header for zero byte files

### DIFF
--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -440,7 +440,7 @@ class IOFileUploadQueue(AbstractUploadQueue):
 
         for url in upload_urls:
             chunks.next_chunk()
-            resp = self._httpx_client.send(self._get_file_upload_request(url, chunks, len(chunks), file_meta.mime_type))
+            resp = self._httpx_client.send(self._get_file_upload_request(url, chunks, len(chunks), mime_type=None))
             resp.raise_for_status()
 
         completed_headers = (

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -513,6 +513,11 @@ class IOFileUploadQueue(AbstractUploadQueue):
             read_file: Callable[[], BinaryIO],
             file_meta: FileMetadataOrCogniteExtractorFile,
         ) -> None:
+            # Default to `application/octet-stream` so uploads succeed
+            # regardless of cluster when the caller didn't supply a mime type.
+            if file_meta.mime_type is None:
+                file_meta.mime_type = "application/octet-stream"
+
             with read_file() as file:
                 size = super_len(file)
                 if size == 0:

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -440,6 +440,8 @@ class IOFileUploadQueue(AbstractUploadQueue):
 
         for url in upload_urls:
             chunks.next_chunk()
+            # PUT requests for a multi-part upload should NOT have a Content-Type request header.
+            # This can interfere with the upload in certain clusters and can cause 403.
             resp = self._httpx_client.send(self._get_file_upload_request(url, chunks, len(chunks), mime_type=None))
             resp.raise_for_status()
 

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -392,7 +392,7 @@ class IOFileUploadQueue(AbstractUploadQueue):
         resp = self._httpx_client.send(self._get_file_upload_request(url, file, size, file_meta.mime_type))
         resp.raise_for_status()
 
-    def _prepare_request_data_for_empty_file(self, url_str: str) -> Request:
+    def _prepare_request_data_for_empty_file(self, url_str: str, mime_type: str | None = None) -> Request:
         FILE_SIZE = 0  # this path is only entered for an empty file
         EMPTY_CONTENT = ""
 
@@ -417,10 +417,13 @@ class IOFileUploadQueue(AbstractUploadQueue):
             }
         )
 
+        if mime_type is not None:
+            headers.update({"Content-Type": mime_type})
+
         return Request(method="PUT", url=upload_url, headers=headers, content=EMPTY_CONTENT)
 
     def _upload_only_file_reference(self, file_meta: FileMetadataOrCogniteExtractorFile, url_str: str) -> None:
-        request_data = self._prepare_request_data_for_empty_file(url_str)
+        request_data = self._prepare_request_data_for_empty_file(url_str, file_meta.mime_type)
         resp = self._httpx_client.send(request_data)
         resp.raise_for_status()
 

--- a/tests/tests_integration/test_file_integration.py
+++ b/tests/tests_integration/test_file_integration.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import contextlib
 import io
 import os
 import pathlib
@@ -23,12 +24,15 @@ from typing import BinaryIO
 import jsonlines
 import pytest
 from cognite.client import CogniteClient
+from cognite.client.config import ClientConfig
+from cognite.client.credentials import OAuthClientCredentials
 from cognite.client.data_classes import FileMetadata
 from cognite.client.data_classes.data_modeling import NodeId
 from cognite.client.data_classes.data_modeling.extractor_extensions.v1 import (
     CogniteExtractorFile,
     CogniteExtractorFileApply,
 )
+from cognite.client.exceptions import CogniteNotFoundError
 from conftest import ETestType, ParamTest
 
 from cognite.extractorutils.uploader.files import (
@@ -399,3 +403,69 @@ def test_update_files(set_upload_test: tuple[CogniteClient, ParamTest]) -> None:
     file = client.files.retrieve(external_id=test_parameter.external_ids[0])
     assert file.source == "some-source"
     assert file.directory == "/some/directory"
+
+
+_ZERO_BYTE_CLUSTERS = [
+    pytest.param(
+        "extractor-bluefield-testing",
+        "https://bluefield.cognitedata.com",
+        id="azure-bluefield",
+    ),
+    pytest.param(
+        "extractor-aws-dub-dev-testing",
+        "https://aws-dub-dev.cognitedata.com",
+        id="aws-dub-dev",
+    ),
+]
+
+
+def _build_cognite_client(project: str, base_url: str) -> CogniteClient:
+    token_url = os.environ["COGNITE_TOKEN_URL"]
+    client_id = os.environ["COGNITE_CLIENT_ID"]
+    client_secret = os.environ["COGNITE_CLIENT_SECRET"]
+    scopes = [f"{base_url}/.default"]
+
+    return CogniteClient(
+        ClientConfig(
+            project=project,
+            base_url=base_url,
+            credentials=OAuthClientCredentials(token_url, client_id, client_secret, scopes),
+            client_name="extractor-utils-zero-byte-test",
+        )
+    )
+
+
+@pytest.mark.parametrize(("project", "base_url"), _ZERO_BYTE_CLUSTERS)
+def test_zero_byte_file_upload_across_clusters(project: str, base_url: str) -> None:
+    # AWS S3 presigned URL signs `content-type` — empty-file PUT must include it for AWS clusters
+    # or will get 403 from S3 and a failed upload, while Azure does not require it and will succeed either way.
+    # This test ensures that the zero-byte file upload logic works across both types of clusters.
+    client = _build_cognite_client(project, base_url)
+
+    external_id = f"util_integration_zero_byte_{random.randint(0, 2**31)}"
+    current_dir = pathlib.Path(__file__).parent.resolve()
+    empty_file = current_dir.joinpath("empty_file.txt")
+    assert empty_file.stat().st_size == 0, "empty_file.txt must be zero bytes"
+
+    queue = FileUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1)
+    queue.add_to_upload_queue(
+        file_meta=FileMetadata(
+            external_id=external_id,
+            name=external_id,
+            mime_type="text/plain",
+        ),
+        file_name=empty_file,
+    )
+
+    try:
+        queue.upload()
+
+        assert queue.errors == [], f"Zero-byte upload failed on {project} ({base_url}) with errors: {queue.errors}"
+
+        retrieved = client.files.retrieve(external_id=external_id)
+        assert retrieved is not None, f"File metadata not found on {project}"
+        assert retrieved.name == external_id
+        assert retrieved.mime_type == "text/plain"
+    finally:
+        with contextlib.suppress(CogniteNotFoundError):
+            client.files.delete(external_id=external_id)

--- a/tests/tests_integration/test_file_integration.py
+++ b/tests/tests_integration/test_file_integration.py
@@ -405,7 +405,7 @@ def test_update_files(set_upload_test: tuple[CogniteClient, ParamTest]) -> None:
     assert file.directory == "/some/directory"
 
 
-_ZERO_BYTE_CLUSTERS = [
+_CLUSTERS = [
     pytest.param(
         "extractor-bluefield-testing",
         "https://bluefield.cognitedata.com",
@@ -416,56 +416,146 @@ _ZERO_BYTE_CLUSTERS = [
         "https://aws-dub-dev.cognitedata.com",
         id="aws-dub-dev",
     ),
+    pytest.param(
+        "extractor-tests",
+        "https://greenfield.cognitedata.com",
+        id="greenfield",
+    ),
 ]
 
-
-def _build_cognite_client(project: str, base_url: str) -> CogniteClient:
-    token_url = os.environ["COGNITE_TOKEN_URL"]
-    client_id = os.environ["COGNITE_CLIENT_ID"]
-    client_secret = os.environ["COGNITE_CLIENT_SECRET"]
-    scopes = [f"{base_url}/.default"]
-
-    return CogniteClient(
-        ClientConfig(
-            project=project,
-            base_url=base_url,
-            credentials=OAuthClientCredentials(token_url, client_id, client_secret, scopes),
-            client_name="extractor-utils-zero-byte-test",
-        )
-    )
+_BIG_FILE_BYTES = b"large" * 2_000_000
+_MULTIPART_CHUNK_SIZE = 6_000_000
 
 
-@pytest.mark.parametrize(("project", "base_url"), _ZERO_BYTE_CLUSTERS)
-def test_zero_byte_file_upload_across_clusters(project: str, base_url: str) -> None:
-    # AWS S3 presigned URL signs `content-type` — empty-file PUT must include it for AWS clusters
-    # or will get 403 from S3 and a failed upload, while Azure does not require it and will succeed either way.
-    # This test ensures that the zero-byte file upload logic works across both types of clusters.
-    client = _build_cognite_client(project, base_url)
-
-    external_id = f"util_integration_zero_byte_{random.randint(0, 2**31)}"
-    current_dir = pathlib.Path(__file__).parent.resolve()
-    empty_file = current_dir.joinpath("empty_file.txt")
-    assert empty_file.stat().st_size == 0, "empty_file.txt must be zero bytes"
-
-    queue = FileUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1)
-    queue.add_to_upload_queue(
-        file_meta=FileMetadata(
-            external_id=external_id,
-            name=external_id,
-            mime_type="text/plain",
+def _build_cluster_client(project: str, base_url: str) -> CogniteClient:
+    cognite_token_url = os.environ["COGNITE_TOKEN_URL"]
+    cognite_client_id = os.environ["COGNITE_CLIENT_ID"]
+    cognite_client_secret = os.environ["COGNITE_CLIENT_SECRET"]
+    cognite_project_scopes = [f"{base_url.rstrip('/')}/.default"]
+    client_config = ClientConfig(
+        project=project,
+        base_url=base_url,
+        credentials=OAuthClientCredentials(
+            cognite_token_url,
+            cognite_client_id,
+            cognite_client_secret,
+            cognite_project_scopes,
         ),
-        file_name=empty_file,
+        client_name="extractor-utils-integration-tests",
     )
+    return CogniteClient(client_config)
 
+
+def _safe_delete_file(client: CogniteClient, external_id: str) -> None:
+    with contextlib.suppress(CogniteNotFoundError):
+        client.files.delete(external_id=external_id)
+
+
+@pytest.mark.parametrize(("project", "base_url"), _CLUSTERS)
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        pytest.param("text/plain", id="with-mime"),
+        pytest.param(None, id="without-mime"),
+    ],
+)
+def test_some_size_file_upload_across_clusters(project: str, base_url: str, mime_type: str | None) -> None:
+    client = _build_cluster_client(project, base_url)
+    external_id = f"util_some_size_{'mime' if mime_type else 'nomime'}_{random.randint(0, 2**31)}"
+    _safe_delete_file(client, external_id)
     try:
+        queue = BytesUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1)
+        queue.add_to_upload_queue(
+            content=b"hello world",
+            file_meta=FileMetadata(
+                external_id=external_id,
+                name=external_id,
+                mime_type=mime_type,
+            ),
+        )
         queue.upload()
 
-        assert queue.errors == [], f"Zero-byte upload failed on {project} ({base_url}) with errors: {queue.errors}"
+        await_is_uploaded_status(client, external_id=external_id)
+        retrieved = client.files.retrieve(external_id=external_id)
+        assert retrieved is not None
+        assert retrieved.uploaded is True
+        if mime_type is not None:
+            assert retrieved.mime_type == mime_type
+        downloaded = client.files.download_bytes(external_id=external_id)
+        assert downloaded == b"hello world"
+    finally:
+        _safe_delete_file(client, external_id)
+
+
+@pytest.mark.parametrize(("project", "base_url"), _CLUSTERS)
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        pytest.param("text/plain", id="with-mime"),
+        pytest.param(None, id="without-mime"),
+    ],
+)
+def test_zero_size_file_upload_across_clusters(project: str, base_url: str, mime_type: str | None) -> None:
+    client = _build_cluster_client(project, base_url)
+    external_id = f"util_zero_size_{'mime' if mime_type else 'nomime'}_{random.randint(0, 2**31)}"
+    current_dir = pathlib.Path(__file__).parent.resolve()
+    empty_file = current_dir.joinpath("empty_file.txt")
+    _safe_delete_file(client, external_id)
+    try:
+        queue = FileUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1)
+        queue.add_to_upload_queue(
+            file_meta=FileMetadata(
+                external_id=external_id,
+                name=external_id,
+                mime_type=mime_type,
+            ),
+            file_name=empty_file,
+        )
+        queue.upload()
 
         retrieved = client.files.retrieve(external_id=external_id)
-        assert retrieved is not None, f"File metadata not found on {project}"
+        assert retrieved is not None
         assert retrieved.name == external_id
-        assert retrieved.mime_type == "text/plain"
+        if mime_type is not None:
+            assert retrieved.mime_type == mime_type
     finally:
-        with contextlib.suppress(CogniteNotFoundError):
-            client.files.delete(external_id=external_id)
+        _safe_delete_file(client, external_id)
+
+
+@pytest.mark.parametrize(("project", "base_url"), _CLUSTERS)
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        pytest.param("application/octet-stream", id="with-mime"),
+        pytest.param(None, id="without-mime"),
+    ],
+)
+def test_big_file_multipart_upload_across_clusters(project: str, base_url: str, mime_type: str | None) -> None:
+    client = _build_cluster_client(project, base_url)
+    external_id = f"util_big_size_{'mime' if mime_type else 'nomime'}_{random.randint(0, 2**31)}"
+    _safe_delete_file(client, external_id)
+    try:
+        queue = BytesUploadQueue(cdf_client=client, overwrite_existing=True, max_queue_size=1)
+        queue.max_file_chunk_size = _MULTIPART_CHUNK_SIZE
+        queue.max_single_chunk_file_size = _MULTIPART_CHUNK_SIZE
+
+        queue.add_to_upload_queue(
+            content=_BIG_FILE_BYTES,
+            file_meta=FileMetadata(
+                external_id=external_id,
+                name=external_id,
+                mime_type=mime_type,
+            ),
+        )
+        queue.upload()
+
+        await_is_uploaded_status(client, external_id=external_id)
+        retrieved = client.files.retrieve(external_id=external_id)
+        assert retrieved is not None
+        assert retrieved.uploaded is True
+        if mime_type is not None:
+            assert retrieved.mime_type == mime_type
+        downloaded = client.files.download_bytes(external_id=external_id)
+        assert len(downloaded) == len(_BIG_FILE_BYTES)
+    finally:
+        _safe_delete_file(client, external_id)


### PR DESCRIPTION
This PR fixes 403 Forbidden when uploading zero-byte files to AWS clusters: AWS S3 presigned URLs sign `content-type`, so the empty-file PUT must include `Content-Type` matching the file's `mime_type`. Azure Blob doesn't sign it, which is why this only occured on AWS.

Solution: forward `file_meta.mime_type` from `_upload_only_file_reference` into `_prepare_request_data_for_empty_file`, mirroring the non-empty file path.

This also solves the exisiting bug related to greenfield and uploading multipart files with content-type set, which will result in 403. 
