### PR TITLE
DOG-6871 Fix incorrect config version associated with invalid config error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.12.2
+
+### Fixed
+* In the `unstable` package: Fixed invalid remote config errors reporting the wrong (or missing) config revision to Odin
+
 ## 7.12.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## 7.12.2
+## 7.12.3
 
 ### Fixed
 * In the `unstable` package: Fixed invalid remote config errors reporting the wrong (or missing) config revision to Odin

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.12.1"
+__version__ = "7.12.2"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.12.2"
+__version__ = "7.12.3"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -59,7 +59,7 @@ from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.uploader.time_series import DataPointList, TimeSeriesUploadQueue
 from cognite.extractorutils.util import EitherId
 
-_metrics_singularities = {}
+_metrics_singularities: dict[type[Any], Any] = {}
 
 
 T = TypeVar("T")

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -57,6 +57,8 @@ class Error(WithExternalId):
     start_time: int
     end_time: int | None
     task: str | None
+    type: Literal["config"] | None = None
+    config_revision: int | None = None
 
     @classmethod
     def from_internal(cls, error: InternalError) -> "Error":

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -350,6 +350,8 @@ class Runtime(Generic[ExtractorType]):
                     description=error_message,
                     details=None,
                     task=None,
+                    type="config" if isinstance(e, InvalidConfigError) and e.attempted_revision is not None else None,
+                    config_revision=e.attempted_revision if isinstance(e, InvalidConfigError) else None,
                 )
 
                 self._cognite_client.post(

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -342,8 +342,8 @@ class Runtime(Generic[ExtractorType]):
                 prev_error = error_message
 
                 ts = now()
-                is_config_error = isinstance(e, InvalidConfigError)
-                revision = e.attempted_revision if is_config_error else None
+                config_exc = e if isinstance(e, InvalidConfigError) else None
+                revision = config_exc.attempted_revision if config_exc is not None else None
                 error = Error(
                     external_id=str(uuid4()),
                     level=ErrorLevel.fatal,
@@ -352,7 +352,7 @@ class Runtime(Generic[ExtractorType]):
                     description=error_message,
                     details=None,
                     task=None,
-                    type="config" if is_config_error else None,
+                    type="config" if config_exc is not None else None,
                     config_revision=revision,
                 )
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -358,7 +358,7 @@ class Runtime(Generic[ExtractorType]):
                     f"/api/v1/projects/{self._cognite_client.config.project}/odin/checkin",
                     json={
                         "externalId": connection_config.integration.external_id,
-                        "errors": [error.model_dump(mode="json")],
+                        "errors": [error.model_dump(mode="json", by_alias=True)],
                     },
                     headers={"cdf-version": "alpha"},
                 )

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -342,6 +342,7 @@ class Runtime(Generic[ExtractorType]):
                 prev_error = error_message
 
                 ts = now()
+                revision = e.attempted_revision if isinstance(e, InvalidConfigError) else None
                 error = Error(
                     external_id=str(uuid4()),
                     level=ErrorLevel.fatal,
@@ -350,8 +351,8 @@ class Runtime(Generic[ExtractorType]):
                     description=error_message,
                     details=None,
                     task=None,
-                    type="config" if isinstance(e, InvalidConfigError) and e.attempted_revision is not None else None,
-                    config_revision=e.attempted_revision if isinstance(e, InvalidConfigError) else None,
+                    type="config" if revision is not None else None,
+                    config_revision=revision,
                 )
 
                 self._cognite_client.post(

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -342,7 +342,8 @@ class Runtime(Generic[ExtractorType]):
                 prev_error = error_message
 
                 ts = now()
-                revision = e.attempted_revision if isinstance(e, InvalidConfigError) else None
+                is_config_error = isinstance(e, InvalidConfigError)
+                revision = e.attempted_revision if is_config_error else None
                 error = Error(
                     external_id=str(uuid4()),
                     level=ErrorLevel.fatal,
@@ -351,7 +352,7 @@ class Runtime(Generic[ExtractorType]):
                     description=error_message,
                     details=None,
                     task=None,
-                    type="config" if revision is not None else None,
+                    type="config" if is_config_error else None,
                     config_revision=revision,
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.12.2"
+version = "7.12.3"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.12.1"
+version = "7.12.2"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 
 from cognite.examples.unstable.extractors.simple_extractor.main import SimpleExtractor
 from cognite.extractorutils.metrics import BaseMetrics
-from cognite.extractorutils.unstable.configuration.exceptions import InvalidArgumentError, InvalidConfigError
+from cognite.extractorutils.unstable.configuration.exceptions import InvalidArgumentError
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
 from cognite.extractorutils.unstable.core.base import ConfigRevision, FullConfig
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -173,6 +173,14 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
         },
         headers={"cdf-version": "alpha"},
     )
+    # Same revision the runtime sees when loading from CDF (see load_from_cdf).
+    response = cognite_client.get(
+        url=f"/api/v1/projects/{cognite_client.config.project}/odin/config",
+        params={"integration": connection_config.integration.external_id},
+        headers={"cdf-version": "alpha"},
+    ).json()
+    expected_revision = response["revision"]
+    assert expected_revision is not None
 
     runtime = Runtime(TestExtractor)
     runtime._cognite_client = cognite_client
@@ -196,7 +204,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
 
     assert len(errors["items"]) >= 1
     assert errors["items"][0].get("type") == "config"
-    assert errors["items"][0].get("configRevision") == 1
+    assert errors["items"][0].get("activeConfigRevision") == expected_revision
 
 
 def test_verify_connection_config(connection_config: ConnectionConfig) -> None:

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -161,7 +161,7 @@ def test_load_cdf_config_initial_empty(connection_config: ConnectionConfig) -> N
 def test_load_cdf_config_invalid_config_revision_attributed(connection_config: ConnectionConfig) -> None:
     """
     When a config exists in CDF but fails validation, the error reported to Odin
-    must carry type='config' and configRevision pointing to the failing revision.
+    must carry type config and the failing revision (errors list uses activeConfigRevision).
     """
     cognite_client = connection_config.get_cognite_client(f"{TestExtractor.EXTERNAL_ID}-{TestExtractor.VERSION}")
     # Post a config that will fail validation (missing required fields)
@@ -195,6 +195,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     ).json()
 
     assert len(errors["items"]) >= 1
+    assert errors["items"][0].get("type") == "config"
     assert errors["items"][0].get("activeConfigRevision") == 1
 
 

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -196,7 +196,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
 
     assert len(errors["items"]) >= 1
     assert errors["items"][0].get("type") == "config"
-    assert errors["items"][0].get("activeConfigRevision") == 1
+    assert errors["items"][0].get("configRevision") == 1
 
 
 def test_verify_connection_config(connection_config: ConnectionConfig) -> None:

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -194,7 +194,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
             "extractor": {"externalId": TestExtractor.EXTERNAL_ID, "version": TestExtractor.VERSION},
             "tasks": [{"name": "startup-task", "type": "batch"}],
             "timestamp": int(time.time() * 1000),
-            "activeConfigRevision": 1,
+            "activeConfigRevision": expected_revision,
         },
         headers={"cdf-version": "alpha"},
     )

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -205,7 +205,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     runtime.RETRY_CONFIG_INTERVAL = 1
 
     def cancel_after_delay() -> None:
-        time.sleep(5)
+        time.sleep(2)
         runtime._cancellation_token.cancel()
 
     Thread(target=cancel_after_delay, daemon=True).start()

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -16,7 +16,7 @@ from typing_extensions import Self
 
 from cognite.examples.unstable.extractors.simple_extractor.main import SimpleExtractor
 from cognite.extractorutils.metrics import BaseMetrics
-from cognite.extractorutils.unstable.configuration.exceptions import InvalidArgumentError
+from cognite.extractorutils.unstable.configuration.exceptions import InvalidArgumentError, InvalidConfigError
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
 from cognite.extractorutils.unstable.core.base import ConfigRevision, FullConfig
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
@@ -156,6 +156,46 @@ def test_load_cdf_config_initial_empty(connection_config: ConnectionConfig) -> N
 
     assert len(errors["items"]) == 1
     assert "No configuration found for the given integration" in errors["items"][0]["description"]
+
+
+def test_load_cdf_config_invalid_config_revision_attributed(connection_config: ConnectionConfig) -> None:
+    """
+    When a config exists in CDF but fails validation, the error reported to Odin
+    must carry type='config' and configRevision pointing to the failing revision.
+    """
+    cognite_client = connection_config.get_cognite_client(f"{TestExtractor.EXTERNAL_ID}-{TestExtractor.VERSION}")
+    # Post a config that will fail validation (missing required fields)
+    cognite_client.post(
+        url=f"/api/v1/projects/{cognite_client.config.project}/odin/config",
+        json={
+            "externalId": connection_config.integration.external_id,
+            "config": "parameter-one: 123\n",  # missing parameter_two
+        },
+        headers={"cdf-version": "alpha"},
+    )
+
+    runtime = Runtime(TestExtractor)
+    runtime._cognite_client = cognite_client
+    runtime.RETRY_CONFIG_INTERVAL = 1
+
+    def cancel_after_delay() -> None:
+        time.sleep(5)
+        runtime._cancellation_token.cancel()
+
+    Thread(target=cancel_after_delay, daemon=True).start()
+    runtime._safe_get_application_config(
+        args=Namespace(force_local_config=None),
+        connection_config=connection_config,
+    )
+
+    errors = cognite_client.get(
+        url=f"/api/v1/projects/{cognite_client.config.project}/integrations/errors",
+        params={"integration": connection_config.integration.external_id},
+        headers={"cdf-version": "alpha"},
+    ).json()
+
+    assert len(errors["items"]) >= 1
+    assert errors["items"][0].get("activeConfigRevision") == 1
 
 
 def test_verify_connection_config(connection_config: ConnectionConfig) -> None:

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -162,6 +162,9 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     """
     When a config exists in CDF but fails validation, the error reported to Odin
     must carry type config and the failing revision (errors list uses activeConfigRevision).
+
+    Startup is reported first so the integration has config_type set; otherwise Odin's
+    error list maps activeConfigRevision to null even when configRevision was accepted on check-in.
     """
     cognite_client = connection_config.get_cognite_client(f"{TestExtractor.EXTERNAL_ID}-{TestExtractor.VERSION}")
     # Post a config that will fail validation (missing required fields)
@@ -182,6 +185,20 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     expected_revision = response["revision"]
     assert expected_revision is not None
 
+    # Odin only exposes activeConfigRevision on listed errors when the integration has
+    # config_type set (startup reported). Align with odin/tests/test_checkin.py::test_specify_revision.
+    cognite_client.post(
+        url=f"/api/v1/projects/{cognite_client.config.project}/odin/startup",
+        json={
+            "externalId": connection_config.integration.external_id,
+            "extractor": {"externalId": TestExtractor.EXTERNAL_ID, "version": TestExtractor.VERSION},
+            "tasks": [{"name": "startup-task", "type": "batch"}],
+            "timestamp": int(time.time() * 1000),
+            "activeConfigRevision": 1,
+        },
+        headers={"cdf-version": "alpha"},
+    )
+
     runtime = Runtime(TestExtractor)
     runtime._cognite_client = cognite_client
     runtime.RETRY_CONFIG_INTERVAL = 1
@@ -197,7 +214,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     )
 
     errors = cognite_client.get(
-        url=f"/api/v1/projects/{cognite_client.config.project}/integrations/errors",
+        url=f"/api/v1/projects/{cognite_client.config.project}/odin/errors",
         params={"integration": connection_config.integration.external_id},
         headers={"cdf-version": "alpha"},
     ).json()

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -186,7 +186,8 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
     assert expected_revision is not None
 
     # Odin only exposes activeConfigRevision on listed errors when the integration has
-    # config_type set (startup reported). Align with odin/tests/test_checkin.py::test_specify_revision.
+    # config_type set (startup reported). Set activeConfigRevision to the expected failing
+    # revision so the test verifies Odin correctly maps the error's configRevision field.
     cognite_client.post(
         url=f"/api/v1/projects/{cognite_client.config.project}/odin/startup",
         json={
@@ -194,7 +195,7 @@ def test_load_cdf_config_invalid_config_revision_attributed(connection_config: C
             "extractor": {"externalId": TestExtractor.EXTERNAL_ID, "version": TestExtractor.VERSION},
             "tasks": [{"name": "startup-task", "type": "batch"}],
             "timestamp": int(time.time() * 1000),
-            "activeConfigRevision": expected_revision,
+            "activeConfigRevision": expected_revision,  # Match the failing config revision
         },
         headers={"cdf-version": "alpha"},
     )


### PR DESCRIPTION
This PR adds:

**Fix:** 
On remote config validation failure, unstable Runtime now sends /odin/checkin errors with type: "config" and configRevision from InvalidConfigError.attempted_revision, so Odin shows the correct config version.

**Changes:** 
Optional type / config_revision on unstable Error DTO; populate them in `_safe_get_application_config`.

And updated the changelog and versions