### PR TITLE
fix mypy check failure

### DIFF
--- a/cognite/extractorutils/metrics.py
+++ b/cognite/extractorutils/metrics.py
@@ -59,7 +59,7 @@ from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.uploader.time_series import DataPointList, TimeSeriesUploadQueue
 from cognite.extractorutils.util import EitherId
 
-_metrics_singularities = {}
+_metrics_singularities: dict[type[Any], Any] = {}
 
 
 T = TypeVar("T")


### PR DESCRIPTION
This PR adds:

- a fix to mypy check error emerged with update to the mypy version `1.20.2` --> `2.0.0`

