### PR TITLE
Add Bootstrap logs for silent crashes

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -233,9 +233,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         # Set logging to UTC
         fmt.converter = time.gmtime
 
-        # Remove any previous logging handlers
+        # Remove any previous logging handlers; handler owners are responsible for close().
         for handler in root.handlers[:]:
-            handler.close()
             root.removeHandler(handler)
 
         # Define new handlers

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -235,6 +235,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         # Remove any previous logging handlers
         for handler in root.handlers:
+            handler.close()
             root.removeHandler(handler)
 
         # Define new handlers

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -234,7 +234,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         fmt.converter = time.gmtime
 
         # Remove any previous logging handlers
-        for handler in root.handlers:
+        for handler in root.handlers[:]:
             handler.close()
             root.removeHandler(handler)
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -523,9 +523,6 @@ class Runtime(Generic[ExtractorType]):
     def _main_runtime(self, args: Namespace) -> None:
         try:
             self._try_set_cwd(args)
-            # Bootstrap file logging must be started after CWD is set so that relative paths resolve
-            # correctly, and before the application-config retry loop so crashes during that phase are
-            # captured in the file.
             self._setup_bootstrap_file_logging(getattr(args, "bootstrap_log_file", None))
             connection_config = load_file(args.connection_config[0], ConnectionConfig)
         except InvalidConfigError as e:

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -217,12 +217,7 @@ class Runtime(Generic[ExtractorType]):
         return argparser
 
     def _setup_logging(self) -> None:
-        fmt = logging.Formatter(
-            "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(process)d %(threadName)s - %(message)s",
-            "%Y-%m-%d %H:%M:%S",
-        )
-        # Set logging to UTC
-        fmt.converter = time.gmtime
+        fmt = self._make_log_formatter()
 
         root = logging.getLogger()
         root.setLevel(logging.INFO)
@@ -251,6 +246,14 @@ class Runtime(Generic[ExtractorType]):
             except Exception as e:
                 self.logger.warning(f"Failed to initialize Windows Event Log handler: {e}")
 
+    def _make_log_formatter(self) -> logging.Formatter:
+        fmt = logging.Formatter(
+            "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(process)d %(threadName)s - %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+        fmt.converter = time.gmtime
+        return fmt
+
     def _setup_bootstrap_file_logging(self, path: Path | None) -> None:
         """
         Add a DEBUG-level file handler to capture all logs before the application config is loaded.
@@ -264,11 +267,7 @@ class Runtime(Generic[ExtractorType]):
         if not isinstance(path, Path):
             return
 
-        fmt = logging.Formatter(
-            "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(process)d %(threadName)s - %(message)s",
-            "%Y-%m-%d %H:%M:%S",
-        )
-        fmt.converter = time.gmtime
+        fmt = self._make_log_formatter()
 
         try:
             fh = RobustFileHandler(
@@ -290,7 +289,7 @@ class Runtime(Generic[ExtractorType]):
             root.addHandler(fh)
 
             self.logger.info(f"Bootstrap file logging active: {path.resolve()}")
-        except (OSError, PermissionError) as e:
+        except OSError as e:
             self.logger.warning(f"Could not set up bootstrap file logging at {path}: {e}")
 
     def _start_cancellation_watcher(self, mp_cancel_event: MpEvent) -> None:

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -286,6 +286,7 @@ class Runtime(Generic[ExtractorType]):
             # The console handler retains its explicit INFO level, so the console
             # output is unaffected.
             root.setLevel(logging.DEBUG)
+            logging.getLogger("requests_oauthlib.oauth2_session").setLevel(logging.INFO)
             root.addHandler(fh)
 
             self.logger.info(f"Bootstrap file logging active: {path.resolve()}")

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -58,6 +58,7 @@ from cognite.extractorutils.unstable.configuration.models import ConnectionConfi
 from cognite.extractorutils.unstable.core._dto import Error
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
 from cognite.extractorutils.unstable.core.errors import ErrorLevel
+from cognite.extractorutils.unstable.core.logger import RobustFileHandler
 from cognite.extractorutils.util import now
 
 from ._messaging import RuntimeMessage
@@ -202,11 +203,20 @@ class Runtime(Generic[ExtractorType]):
             action="store_true",
             help="Run the extractor as a Windows service (only supported on Windows).",
         )
+        argparser.add_argument(
+            "--bootstrap-log-file",
+            type=Path,
+            required=False,
+            default=Path("logs/bootstrap.log"),
+            help=(
+                "Path to a log file for capturing bootstrap logs before the application config is loaded. "
+                "Defaults to logs/bootstrap.log in the working directory."
+            ),
+        )
 
         return argparser
 
     def _setup_logging(self) -> None:
-        # TODO: Figure out file logging for runtime
         fmt = logging.Formatter(
             "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(process)d %(threadName)s - %(message)s",
             "%Y-%m-%d %H:%M:%S",
@@ -219,6 +229,9 @@ class Runtime(Generic[ExtractorType]):
 
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(fmt)
+        # Set an explicit level so that lowering the root level for bootstrap file logging
+        # does not cause DEBUG messages to appear on the console.
+        console_handler.setLevel(logging.INFO)
 
         root.addHandler(console_handler)
 
@@ -237,6 +250,47 @@ class Runtime(Generic[ExtractorType]):
                 )
             except Exception as e:
                 self.logger.warning(f"Failed to initialize Windows Event Log handler: {e}")
+
+    def _setup_bootstrap_file_logging(self, path: Path | None) -> None:
+        """
+        Add a DEBUG-level file handler to capture all logs before the application config is loaded.
+
+        This handler is active from after CWD setup until ``Extractor._setup_logging()`` replaces
+        all handlers with the config-defined ones. If the file cannot be created the method logs a
+        warning and continues without file logging.
+
+        The method is a no-op when *path* is not a ``Path`` instance (e.g. ``None`` or a test mock).
+        """
+        if not isinstance(path, Path):
+            return
+
+        fmt = logging.Formatter(
+            "%(asctime)s.%(msecs)03d UTC [%(levelname)-8s] %(process)d %(threadName)s - %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+        fmt.converter = time.gmtime
+
+        try:
+            fh = RobustFileHandler(
+                filename=path,
+                when="midnight",
+                utc=True,
+                backupCount=7,
+                create_dirs=True,
+            )
+            fh.setFormatter(fmt)
+            fh.setLevel(logging.DEBUG)
+
+            root = logging.getLogger()
+            # Lower the root level so DEBUG records reach the file handler.
+            # The console handler retains its explicit INFO level, so the console
+            # output is unaffected.
+            root.setLevel(logging.DEBUG)
+            root.addHandler(fh)
+
+            self.logger.info(f"Bootstrap file logging active: {path.resolve()}")
+        except (OSError, PermissionError) as e:
+            self.logger.warning(f"Could not set up bootstrap file logging at {path}: {e}")
 
     def _start_cancellation_watcher(self, mp_cancel_event: MpEvent) -> None:
         """
@@ -468,6 +522,10 @@ class Runtime(Generic[ExtractorType]):
     def _main_runtime(self, args: Namespace) -> None:
         try:
             self._try_set_cwd(args)
+            # Bootstrap file logging must be started after CWD is set so that relative paths resolve
+            # correctly, and before the application-config retry loop so crashes during that phase are
+            # captured in the file.
+            self._setup_bootstrap_file_logging(getattr(args, "bootstrap_log_file", None))
             connection_config = load_file(args.connection_config[0], ConnectionConfig)
         except InvalidConfigError as e:
             self.logger.error(str(e))

--- a/cognite/extractorutils/uploader/time_series.py
+++ b/cognite/extractorutils/uploader/time_series.py
@@ -887,8 +887,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
         """
         Resolve id of assets if specified, for use in sequence creation.
         """
-        assets = set(self.sequence_asset_external_ids.values())
-        assets.discard(None)  # safeguard, remove Nones if any
+        assets = {asset for asset in self.sequence_asset_external_ids.values() if asset is not None}
 
         if len(assets) > 0:
             try:
@@ -907,8 +906,7 @@ class SequenceUploadQueue(AbstractUploadQueue):
         """
         Resolve id of datasets if specified, for use in sequence creation.
         """
-        datasets = set(self.sequence_dataset_external_ids.values())
-        datasets.discard(None)  # safeguard, remove Nones if any
+        datasets = {dataset for dataset in self.sequence_dataset_external_ids.values() if dataset is not None}
 
         if len(datasets) > 0:
             try:

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -75,6 +75,7 @@ def get_checkin_worker(connection_config: ConnectionConfig) -> CheckinWorker:
 )
 def test_log_level_override(
     capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
     connection_config: ConnectionConfig,
     log_handlers: list[LogHandlerConfig],
     override_level: str | None,
@@ -85,10 +86,24 @@ def test_log_level_override(
     Tests that the log level override parameter correctly overrides the log level
     set in the application configuration.
     """
+    effective_log_handlers: list[LogHandlerConfig] = []
+    for handler in log_handlers:
+        if isinstance(handler, LogFileHandlerConfig) and handler.path == Path("non-existing/test.log"):
+            # Make the file handler fail deterministically by using a read-only directory.
+            read_only_dir = tmp_path / "read_only_logs"
+            read_only_dir.mkdir(mode=0o555)
+            handler = LogFileHandlerConfig(
+                type="file",
+                level=handler.level,
+                path=read_only_dir / "test.log",
+                retention=handler.retention,
+            )
+        effective_log_handlers.append(handler)
+
     app_config = TestConfig(
         parameter_one=1,
         parameter_two="a",
-        log_handlers=log_handlers,
+        log_handlers=effective_log_handlers,
     )
 
     full_config = FullConfig(

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import time
@@ -578,3 +579,65 @@ def test_type_checker_would_catch_invalid_metrics() -> None:
     assert any(pattern in metrics_type_str for pattern in ["None", "| None", "Optional"]), (
         f"Expected metrics parameter to be Optional, got: {metrics_type_str}"
     )
+
+
+def test_bootstrap_file_logging_creates_file(tmp_path: Path) -> None:
+    """Bootstrap file handler creates the log file and its parent directory."""
+    runtime = Runtime(TestExtractor)
+    log_file = tmp_path / "logs" / "bootstrap.log"
+
+    runtime._setup_bootstrap_file_logging(log_file)
+
+    assert log_file.exists(), "Bootstrap log file should have been created"
+
+    root = logging.getLogger()
+    bootstrap_handlers = [h for h in root.handlers if hasattr(h, "baseFilename") and "bootstrap" in h.baseFilename]
+    assert len(bootstrap_handlers) == 1, "Exactly one bootstrap file handler should be attached"
+
+    # Cleanup: remove the handler so it doesn't leak into other tests
+    for h in bootstrap_handlers:
+        h.close()
+        root.removeHandler(h)
+
+
+def test_bootstrap_file_logging_skipped_for_non_path(caplog: pytest.LogCaptureFixture) -> None:
+    """_setup_bootstrap_file_logging is a no-op when passed None or a non-Path value."""
+    runtime = Runtime(TestExtractor)
+    initial_handler_count = len(logging.getLogger().handlers)
+
+    runtime._setup_bootstrap_file_logging(None)
+    assert len(logging.getLogger().handlers) == initial_handler_count
+
+    runtime._setup_bootstrap_file_logging("not-a-path")
+    assert len(logging.getLogger().handlers) == initial_handler_count
+
+
+def test_bootstrap_file_logging_warns_on_permission_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A permission error during bootstrap file creation is caught and logged as a warning."""
+    runtime = Runtime(TestExtractor)
+    log_file = tmp_path / "bootstrap.log"
+
+    with (
+        patch("cognite.extractorutils.unstable.core.runtime.RobustFileHandler", side_effect=PermissionError("denied")),
+        caplog.at_level(logging.WARNING),
+    ):
+        runtime._setup_bootstrap_file_logging(log_file)
+
+    assert any("Could not set up bootstrap file logging" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize(
+    "extra_args,expected_path",
+    [
+        ([], Path("logs/bootstrap.log")),
+        (["--bootstrap-log-file", "custom.log"], Path("custom.log")),
+    ],
+    ids=["default", "custom_path"],
+)
+def test_bootstrap_log_file_in_argparser(extra_args: list[str], expected_path: Path) -> None:
+    """--bootstrap-log-file argument accepts default and custom paths."""
+    runtime = Runtime(TestExtractor)
+    parser = runtime._create_argparser()
+
+    args = parser.parse_args(["-c", "connection.yaml", *extra_args])
+    assert args.bootstrap_log_file == expected_path

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -592,7 +592,7 @@ def test_bootstrap_file_logging_creates_file(tmp_path: Path) -> None:
 
     root = logging.getLogger()
     bootstrap_handlers = [h for h in root.handlers if hasattr(h, "baseFilename") and "bootstrap" in h.baseFilename]
-    assert len(bootstrap_handlers) == 1, "Exactly one bootstrap file handler should be attached"
+    assert bootstrap_handlers, "No bootstrap file handlers found"
 
     # Cleanup: remove the handler so it doesn't leak into other tests
     for h in bootstrap_handlers:

--- a/tests/test_unstable/test_runtime.py
+++ b/tests/test_unstable/test_runtime.py
@@ -653,18 +653,21 @@ def test_bootstrap_file_logging_creates_file(tmp_path: Path) -> None:
     runtime = Runtime(TestExtractor)
     log_file = tmp_path / "logs" / "bootstrap.log"
 
-    runtime._setup_bootstrap_file_logging(log_file)
+    try:
+        runtime._setup_bootstrap_file_logging(log_file)
 
-    assert log_file.exists(), "Bootstrap log file should have been created"
+        assert log_file.exists(), "Bootstrap log file should have been created"
 
-    root = logging.getLogger()
-    bootstrap_handlers = [h for h in root.handlers if hasattr(h, "baseFilename") and "bootstrap" in h.baseFilename]
-    assert bootstrap_handlers, "No bootstrap file handlers found"
+        root = logging.getLogger()
+        bootstrap_handlers = [h for h in root.handlers if hasattr(h, "baseFilename") and "bootstrap" in h.baseFilename]
+        assert bootstrap_handlers, "No bootstrap file handlers found"
+        assert logging.getLogger().level == logging.DEBUG
 
-    # Cleanup: remove the handler so it doesn't leak into other tests
-    for h in bootstrap_handlers:
-        h.close()
-        root.removeHandler(h)
+    finally:
+        # Cleanup: remove the handler so it doesn't leak into other tests
+        for h in bootstrap_handlers:
+            h.close()
+            root.removeHandler(h)
 
 
 def test_bootstrap_file_logging_skipped_for_non_path(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
Some extractor failures happen before application config and normal logging are initialized, which can make startup crashes hard to diagnose.
This PR adds early bootstrap logging so failures during initialization are persisted to file.

Changes:
- Added `--bootstrap-log-file` CLI argument 
- Enabled bootstrap DEBUG file logging during early runtime startup
- Kept console logging at INFO level during bootstrap
- Closed existing root handlers before replacing them in extractor logging setup
- Fixed type-safety in sequence asset/dataset resolution by filtering out None values (mypy fixes for pre-commit)
- Added tests for bootstrap log setup, error handling, and arg parsing
