### PR TITLE
feat(odin): Add DTOs for actions

### DIFF
--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -78,6 +78,7 @@ TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]
 ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
+NameType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
 JSONType = TypeAliasType(  # type: ignore[misc]
     "JSONType",
@@ -98,6 +99,21 @@ class TaskType(Enum):
     batch = "batch"
 
 
+class ActionType(Enum):
+    start_task = "start_task"
+    stop_task = "stop_task"
+    custom = "custom"
+
+
+class ActionStatus(Enum):
+    pending = "pending"
+    running = "running"
+    failed = "failed"
+    succeeded = "succeeded"
+    cancel_pending = "cancel_pending"
+    canceled = "canceled"
+
+
 class Task(CogniteModel):
     type: TaskType
     name: str
@@ -105,17 +121,49 @@ class Task(CogniteModel):
     description: DescriptionType | None = None
 
 
+class AvailableActionWrite(CogniteModel):
+    name: NameType
+    type: ActionType
+    description: DescriptionType | None = None
+    task: str | None = None
+
+
+class Action(CogniteModel):
+    external_id: str
+    action_name: str
+    type: ActionType
+    task: str | None = None
+    call_metadata: JSONType | None = None
+
+
+class ActionUpdate(CogniteModel):
+    external_id: str
+    status: ActionStatus
+    result_message: MessageType | None = None
+    result_metadata: JSONType | None = None
+
+
+AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=1, max_length=1000)]
+ActionUpdateList = Annotated[list[ActionUpdate], Len(min_length=1, max_length=1000)]
+PendingActionList = Annotated[list[Action], Len(min_length=1, max_length=1000)]
+
+
 class StartupRequest(WithExternalId):
     extractor: ExtractorInfo
     tasks: TaskList | None = None
     active_config_revision: int | Literal["local"] | None = None
     timestamp: int | None = None
+    available_actions: AvailableActionList | None = None
 
 
 class CheckinRequest(WithExternalId):
     task_events: TaskUpdateList | None = None
     errors: ErrorList | None = None
+    action_updates: ActionUpdateList | None = None
 
 
 class CheckinResponse(WithExternalId):
+    model_config = ConfigDict(extra="ignore")
+
     last_config_revision: int | None = None
+    pending_actions: PendingActionList | None = None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -80,7 +80,6 @@ TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]
 ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
-ActionDescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=1000)]
 IdentifierType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
 JSONType = TypeAliasType(  # type: ignore[misc]
@@ -127,7 +126,7 @@ class Task(CogniteModel):
 class AvailableActionWrite(CogniteModel):
     name: IdentifierType
     type: ActionType
-    description: ActionDescriptionType | None = None
+    description: MessageType | None = None
     task: IdentifierType | None = None
 
 

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -1,5 +1,7 @@
 """
 Temporary holding place for DTOs against Extraction Pipelines 2.0 until it's in the SDK.
+
+Jira ticket: https://cognitedata.atlassian.net/browse/EDGE-493
 """
 
 from enum import Enum
@@ -129,6 +131,8 @@ class AvailableActionWrite(CogniteModel):
 
 
 class Action(CogniteModel):
+    model_config = ConfigDict(extra="ignore")
+
     external_id: str
     action_name: str
     type: ActionType
@@ -145,7 +149,7 @@ class ActionUpdate(CogniteModel):
 
 AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=1, max_length=1000)]
 ActionUpdateList = Annotated[list[ActionUpdate], Len(min_length=1, max_length=1000)]
-PendingActionList = Annotated[list[Action], Len(min_length=1, max_length=1000)]
+PendingActionList = Annotated[list[Action], Len(min_length=0, max_length=1000)]
 
 
 class StartupRequest(WithExternalId):

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -155,7 +155,6 @@ class ActionUpdate(CogniteModel):
 
 AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=0, max_length=100)]
 ActionUpdateList = Annotated[list[ActionUpdate], Len(min_length=0, max_length=100)]
-PendingActionList = Annotated[list[Action], Len(min_length=0, max_length=1000)]
 
 
 class StartupRequest(WithExternalId):
@@ -176,4 +175,4 @@ class CheckinResponse(WithExternalId):
     model_config = ConfigDict(extra="ignore")
 
     last_config_revision: int | None = None
-    pending_actions: PendingActionList | None = None
+    pending_actions: list[Action] | None = None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -80,7 +80,10 @@ TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]
 ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
+ActionDescriptionType = Annotated[str, StringConstraints(min_length=1, max_length=1000)]
 NameType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
+AvailableActionTaskType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
+ExternalIdType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
 JSONType = TypeAliasType(  # type: ignore[misc]
     "JSONType",
@@ -126,29 +129,32 @@ class Task(CogniteModel):
 class AvailableActionWrite(CogniteModel):
     name: NameType
     type: ActionType
-    description: DescriptionType | None = None
-    task: str | None = None
+    description: ActionDescriptionType | None = None
+    task: AvailableActionTaskType | None = None
 
 
 class Action(CogniteModel):
     model_config = ConfigDict(extra="ignore")
 
-    external_id: str
+    external_id: ExternalIdType
     action_name: str
-    type: ActionType
-    task: str | None = None
-    call_metadata: JSONType | None = None
+    status: ActionStatus
+    call_metadata: dict[str, str] | None = None
+    created_time: int | None = None
+    last_updated_time: int | None = None
+    result_message: MessageType | None = None
+    result_metadata: dict[str, str] | None = None
 
 
 class ActionUpdate(CogniteModel):
     external_id: str
     status: ActionStatus
     result_message: MessageType | None = None
-    result_metadata: JSONType | None = None
+    result_metadata: dict[str, str] | None = None
 
 
-AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=1, max_length=1000)]
-ActionUpdateList = Annotated[list[ActionUpdate], Len(min_length=1, max_length=1000)]
+AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=0, max_length=100)]
+ActionUpdateList = Annotated[list[ActionUpdate], Len(min_length=0, max_length=100)]
 PendingActionList = Annotated[list[Action], Len(min_length=0, max_length=1000)]
 
 

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, Literal, Optional
 
 from annotated_types import Len
 from humps import camelize
-from pydantic import BaseModel, ConfigDict, StringConstraints
+from pydantic import BaseModel, ConfigDict, StringConstraints, field_validator
 from typing_extensions import TypeAliasType
 
 from cognite.extractorutils.unstable.core.errors import Error as InternalError
@@ -81,9 +81,7 @@ ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
 ActionDescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=1000)]
-NameType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
-AvailableActionTaskType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
-ExternalIdType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
+IdentifierType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
 JSONType = TypeAliasType(  # type: ignore[misc]
     "JSONType",
@@ -127,17 +125,19 @@ class Task(CogniteModel):
 
 
 class AvailableActionWrite(CogniteModel):
-    name: NameType
+    name: IdentifierType
     type: ActionType
     description: ActionDescriptionType | None = None
-    task: AvailableActionTaskType | None = None
+    task: IdentifierType | None = None
 
 
 class Action(CogniteModel):
+    """Server may add fields before SDK is updated, so ignore extras on deserialize."""
+
     model_config = ConfigDict(extra="ignore")
 
-    external_id: ExternalIdType
-    action_name: NameType
+    external_id: IdentifierType
+    action_name: IdentifierType
     status: ActionStatus
     call_metadata: dict[str, str] | None = None
     created_time: int | None = None
@@ -147,10 +147,17 @@ class Action(CogniteModel):
 
 
 class ActionUpdate(CogniteModel):
-    external_id: ExternalIdType
+    external_id: IdentifierType
     status: ActionStatus
     result_message: MessageType | None = None
     result_metadata: dict[str, str] | None = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: ActionStatus) -> ActionStatus:
+        if v in (ActionStatus.pending, ActionStatus.cancel_pending):
+            raise ValueError(f"Extractors cannot set action status to '{v.value}'")
+        return v
 
 
 AvailableActionList = Annotated[list[AvailableActionWrite], Len(min_length=0, max_length=100)]
@@ -172,6 +179,8 @@ class CheckinRequest(WithExternalId):
 
 
 class CheckinResponse(WithExternalId):
+    """Server may add fields before SDK is updated, so ignore extras on deserialize."""
+
     model_config = ConfigDict(extra="ignore")
 
     last_config_revision: int | None = None

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -80,7 +80,7 @@ TaskUpdateList = Annotated[list[TaskUpdate], Len(min_length=1, max_length=1000)]
 ErrorList = Annotated[list[Error], Len(min_length=0, max_length=1000)]
 VersionType = Annotated[str, StringConstraints(min_length=1, max_length=32)]
 DescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=500)]
-ActionDescriptionType = Annotated[str, StringConstraints(min_length=1, max_length=1000)]
+ActionDescriptionType = Annotated[str, StringConstraints(min_length=0, max_length=1000)]
 NameType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 AvailableActionTaskType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 ExternalIdType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
@@ -137,7 +137,7 @@ class Action(CogniteModel):
     model_config = ConfigDict(extra="ignore")
 
     external_id: ExternalIdType
-    action_name: str
+    action_name: NameType
     status: ActionStatus
     call_metadata: dict[str, str] | None = None
     created_time: int | None = None
@@ -147,7 +147,7 @@ class Action(CogniteModel):
 
 
 class ActionUpdate(CogniteModel):
-    external_id: str
+    external_id: ExternalIdType
     status: ActionStatus
     result_message: MessageType | None = None
     result_metadata: dict[str, str] | None = None

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -83,27 +83,27 @@ class TestStartupRequest:
             StartupRequest(
                 external_id="x",
                 extractor=ExtractorInfo(external_id="x"),
-                available_actions=[AvailableActionWrite(name=f"a{i}", type=ActionType.custom) for i in range(1001)],
+                available_actions=[AvailableActionWrite(name=f"a{i}", type=ActionType.custom) for i in range(101)],
             )
 
 
 class TestAction:
     def test_camel_case_serialization(self) -> None:
-        action = Action(external_id="act-1", action_name="restart", type=ActionType.start_task, task="main")
+        action = Action(external_id="act-1", action_name="restart", status=ActionStatus.running)
         body = action.model_dump(mode="json", by_alias=True)
         assert body["externalId"] == "act-1"
         assert body["actionName"] == "restart"
-        assert body["type"] == "start_task"
+        assert body["status"] == "running"
 
     def test_none_fields_excluded(self) -> None:
-        action = Action(external_id="act-1", action_name="ping", type=ActionType.custom)
+        action = Action(external_id="act-1", action_name="ping", status=ActionStatus.pending)
         body = action.model_dump(mode="json", by_alias=True)
-        assert "task" not in body
         assert "callMetadata" not in body
+        assert "resultMetadata" not in body
 
     def test_unknown_fields_ignored(self) -> None:
         action = Action.model_validate(
-            {"externalId": "act-1", "actionName": "ping", "type": "custom", "futureField": "odin-added-this"}
+            {"externalId": "act-1", "actionName": "ping", "status": "running", "futureField": "odin-added-this"}
         )
         assert action.external_id == "act-1"
 
@@ -134,15 +134,15 @@ class TestCheckinResponse:
             {
                 "externalId": "my-extractor",
                 "pendingActions": [
-                    {"externalId": "act-1", "actionName": "restart", "type": "start_task", "task": "main"},
-                    {"externalId": "act-2", "actionName": "ping", "type": "custom"},
+                    {"externalId": "act-1", "actionName": "restart", "status": "pending"},
+                    {"externalId": "act-2", "actionName": "ping", "status": "cancel_pending"},
                 ],
             }
         )
         assert response.pending_actions is not None
         assert len(response.pending_actions) == 2
         assert response.pending_actions[0].external_id == "act-1"
-        assert response.pending_actions[0].type == ActionType.start_task
+        assert response.pending_actions[0].status == ActionStatus.pending
         assert response.pending_actions[1].call_metadata is None
 
     def test_unknown_fields_ignored(self) -> None:
@@ -167,8 +167,8 @@ class TestCheckinResponse:
                     {
                         "externalId": "act-3",
                         "actionName": "configure",
-                        "type": "custom",
-                        "callMetadata": {"key": "value", "count": 3},
+                        "status": "pending",
+                        "callMetadata": {"key": "value", "count": "3"},
                     }
                 ],
             }

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -1,0 +1,184 @@
+import pytest
+
+from cognite.extractorutils.unstable.core._dto import (
+    Action,
+    ActionStatus,
+    ActionType,
+    ActionUpdate,
+    AvailableActionWrite,
+    CheckinRequest,
+    CheckinResponse,
+    ExtractorInfo,
+    StartupRequest,
+)
+
+
+def _startup_request() -> StartupRequest:
+    return StartupRequest(
+        external_id="my-extractor",
+        extractor=ExtractorInfo(external_id="my-extractor", version="1.0.0"),
+    )
+
+
+class TestAvailableActionWrite:
+    def test_camel_case_serialization(self) -> None:
+        action = AvailableActionWrite(name="restart", type=ActionType.start_task, task="main")
+        body = action.model_dump(mode="json", by_alias=True)
+        assert body["type"] == "start_task"
+        assert body["task"] == "main"
+
+    def test_none_fields_excluded(self) -> None:
+        action = AvailableActionWrite(name="restart", type=ActionType.custom)
+        body = action.model_dump(mode="json", by_alias=True)
+        assert "description" not in body
+        assert "task" not in body
+
+    def test_name_min_length_enforced(self) -> None:
+        with pytest.raises(Exception):
+            AvailableActionWrite(name="", type=ActionType.custom)
+
+    def test_name_max_length_enforced(self) -> None:
+        with pytest.raises(Exception):
+            AvailableActionWrite(name="x" * 256, type=ActionType.custom)
+
+
+class TestActionUpdate:
+    def test_camel_case_serialization(self) -> None:
+        update = ActionUpdate(
+            external_id="act-1",
+            status=ActionStatus.succeeded,
+            result_message="done",
+        )
+        body = update.model_dump(mode="json", by_alias=True)
+        assert body["externalId"] == "act-1"
+        assert body["status"] == "succeeded"
+        assert body["resultMessage"] == "done"
+
+    def test_none_fields_excluded(self) -> None:
+        update = ActionUpdate(external_id="act-1", status=ActionStatus.running)
+        body = update.model_dump(mode="json", by_alias=True)
+        assert "resultMessage" not in body
+        assert "resultMetadata" not in body
+
+
+class TestStartupRequest:
+    def test_available_actions_serialized(self) -> None:
+        req = _startup_request()
+        req.available_actions = [
+            AvailableActionWrite(name="restart", type=ActionType.start_task, task="main"),
+            AvailableActionWrite(name="ping", type=ActionType.custom),
+        ]
+        body = req.model_dump(mode="json", by_alias=True)
+        assert "availableActions" in body
+        assert len(body["availableActions"]) == 2
+        assert body["availableActions"][0]["name"] == "restart"
+        assert body["availableActions"][0]["type"] == "start_task"
+
+    def test_available_actions_none_excluded(self) -> None:
+        body = _startup_request().model_dump(mode="json", by_alias=True)
+        assert "availableActions" not in body
+
+    def test_available_actions_max_length_enforced(self) -> None:
+        with pytest.raises(Exception):
+            StartupRequest(
+                external_id="x",
+                extractor=ExtractorInfo(external_id="x"),
+                available_actions=[AvailableActionWrite(name=f"a{i}", type=ActionType.custom) for i in range(1001)],
+            )
+
+
+class TestCheckinRequest:
+    def test_action_updates_serialized(self) -> None:
+        req = CheckinRequest(
+            external_id="my-extractor",
+            action_updates=[
+                ActionUpdate(external_id="act-1", status=ActionStatus.running),
+                ActionUpdate(external_id="act-2", status=ActionStatus.failed, result_message="timeout"),
+            ],
+        )
+        body = req.model_dump(mode="json", by_alias=True)
+        assert "actionUpdates" in body
+        assert len(body["actionUpdates"]) == 2
+        assert body["actionUpdates"][0]["status"] == "running"
+        assert body["actionUpdates"][1]["resultMessage"] == "timeout"
+
+    def test_action_updates_none_excluded(self) -> None:
+        body = CheckinRequest(external_id="x").model_dump(mode="json", by_alias=True)
+        assert "actionUpdates" not in body
+
+
+class TestCheckinResponse:
+    def test_pending_actions_deserialized(self) -> None:
+        response = CheckinResponse.model_validate(
+            {
+                "externalId": "my-extractor",
+                "pendingActions": [
+                    {"externalId": "act-1", "actionName": "restart", "type": "start_task", "task": "main"},
+                    {"externalId": "act-2", "actionName": "ping", "type": "custom"},
+                ],
+            }
+        )
+        assert response.pending_actions is not None
+        assert len(response.pending_actions) == 2
+        assert response.pending_actions[0].external_id == "act-1"
+        assert response.pending_actions[0].type == ActionType.start_task
+        assert response.pending_actions[1].call_metadata is None
+
+    def test_unknown_fields_ignored(self) -> None:
+        response = CheckinResponse.model_validate(
+            {"externalId": "x", "newFieldFromOdin": "some-value", "anotherUnknown": 42}
+        )
+        assert response.external_id == "x"
+
+    def test_pending_actions_none_when_absent(self) -> None:
+        response = CheckinResponse.model_validate({"externalId": "x"})
+        assert response.pending_actions is None
+
+    def test_action_with_call_metadata_deserialized(self) -> None:
+        response = CheckinResponse.model_validate(
+            {
+                "externalId": "x",
+                "pendingActions": [
+                    {
+                        "externalId": "act-3",
+                        "actionName": "configure",
+                        "type": "custom",
+                        "callMetadata": {"key": "value", "count": 3},
+                    }
+                ],
+            }
+        )
+        assert response.pending_actions is not None
+        action = response.pending_actions[0]
+        assert isinstance(action.call_metadata, dict)
+        assert action.call_metadata["key"] == "value"
+
+
+class TestActionEnum:
+    def test_action_type_values(self) -> None:
+        assert ActionType.start_task.value == "start_task"
+        assert ActionType.stop_task.value == "stop_task"
+        assert ActionType.custom.value == "custom"
+
+    def test_action_status_values(self) -> None:
+        assert ActionStatus.pending.value == "pending"
+        assert ActionStatus.running.value == "running"
+        assert ActionStatus.failed.value == "failed"
+        assert ActionStatus.succeeded.value == "succeeded"
+        assert ActionStatus.cancel_pending.value == "cancel_pending"
+        assert ActionStatus.canceled.value == "canceled"
+
+
+class TestAction:
+    def test_camel_case_serialization(self) -> None:
+        action = Action(external_id="act-1", action_name="restart", type=ActionType.start_task, task="main")
+        body = action.model_dump(mode="json", by_alias=True)
+        assert body["externalId"] == "act-1"
+        assert body["actionName"] == "restart"
+        assert body["type"] == "start_task"
+
+    def test_none_fields_excluded(self) -> None:
+        action = Action(external_id="act-1", action_name="ping", type=ActionType.custom)
+        body = action.model_dump(mode="json", by_alias=True)
+        assert "task" not in body
+        assert "callMetadata" not in body

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -87,6 +87,27 @@ class TestStartupRequest:
             )
 
 
+class TestAction:
+    def test_camel_case_serialization(self) -> None:
+        action = Action(external_id="act-1", action_name="restart", type=ActionType.start_task, task="main")
+        body = action.model_dump(mode="json", by_alias=True)
+        assert body["externalId"] == "act-1"
+        assert body["actionName"] == "restart"
+        assert body["type"] == "start_task"
+
+    def test_none_fields_excluded(self) -> None:
+        action = Action(external_id="act-1", action_name="ping", type=ActionType.custom)
+        body = action.model_dump(mode="json", by_alias=True)
+        assert "task" not in body
+        assert "callMetadata" not in body
+
+    def test_unknown_fields_ignored(self) -> None:
+        action = Action.model_validate(
+            {"externalId": "act-1", "actionName": "ping", "type": "custom", "futureField": "odin-added-this"}
+        )
+        assert action.external_id == "act-1"
+
+
 class TestCheckinRequest:
     def test_action_updates_serialized(self) -> None:
         req = CheckinRequest(
@@ -134,6 +155,10 @@ class TestCheckinResponse:
         response = CheckinResponse.model_validate({"externalId": "x"})
         assert response.pending_actions is None
 
+    def test_pending_actions_empty_list_accepted(self) -> None:
+        response = CheckinResponse.model_validate({"externalId": "x", "pendingActions": []})
+        assert response.pending_actions == []
+
     def test_action_with_call_metadata_deserialized(self) -> None:
         response = CheckinResponse.model_validate(
             {
@@ -167,18 +192,3 @@ class TestActionEnum:
         assert ActionStatus.succeeded.value == "succeeded"
         assert ActionStatus.cancel_pending.value == "cancel_pending"
         assert ActionStatus.canceled.value == "canceled"
-
-
-class TestAction:
-    def test_camel_case_serialization(self) -> None:
-        action = Action(external_id="act-1", action_name="restart", type=ActionType.start_task, task="main")
-        body = action.model_dump(mode="json", by_alias=True)
-        assert body["externalId"] == "act-1"
-        assert body["actionName"] == "restart"
-        assert body["type"] == "start_task"
-
-    def test_none_fields_excluded(self) -> None:
-        action = Action(external_id="act-1", action_name="ping", type=ActionType.custom)
-        body = action.model_dump(mode="json", by_alias=True)
-        assert "task" not in body
-        assert "callMetadata" not in body

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -22,16 +22,18 @@ def _startup_request() -> StartupRequest:
 
 
 class TestAvailableActionWrite:
-    @pytest.mark.parametrize("action_type", [ActionType.start_task, ActionType.stop_task, ActionType.custom])
-    def test_type_serialization(self, action_type: ActionType) -> None:
-        body = AvailableActionWrite(name="test", type=action_type).model_dump(mode="json", by_alias=True)
-        assert body["type"] == action_type.value
-
-    def test_camel_case_serialization(self) -> None:
-        action = AvailableActionWrite(name="restart", type=ActionType.start_task, task="main")
-        body = action.model_dump(mode="json", by_alias=True)
-        assert body["type"] == "start_task"
-        assert body["task"] == "main"
+    @pytest.mark.parametrize(
+        "action_type,task,expected_body",
+        [
+            (ActionType.start_task, "main", {"type": "start_task", "task": "main"}),
+            (ActionType.stop_task, None, {"type": "stop_task"}),
+            (ActionType.custom, None, {"type": "custom"}),
+        ],
+    )
+    def test_serialization(self, action_type: ActionType, task: str | None, expected_body: dict[str, str]) -> None:
+        body = AvailableActionWrite(name="test", type=action_type, task=task).model_dump(mode="json", by_alias=True)
+        for key, val in expected_body.items():
+            assert body[key] == val
 
     def test_none_fields_excluded(self) -> None:
         action = AvailableActionWrite(name="restart", type=ActionType.custom)
@@ -41,11 +43,16 @@ class TestAvailableActionWrite:
 
     @pytest.mark.parametrize("invalid_name", ["", "x" * 256])
     def test_invalid_name_rejected(self, invalid_name: str) -> None:
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="String should have"):
             AvailableActionWrite(name=invalid_name, type=ActionType.custom)
 
 
 class TestActionUpdate:
+    @pytest.mark.parametrize("status", [ActionStatus.pending, ActionStatus.cancel_pending])
+    def test_extractor_reserved_statuses_rejected(self, status: ActionStatus) -> None:
+        with pytest.raises(ValidationError, match="Extractors cannot set action status"):
+            ActionUpdate(external_id="act-1", status=status)
+
     def test_camel_case_serialization(self) -> None:
         update = ActionUpdate(
             external_id="act-1",
@@ -82,7 +89,7 @@ class TestStartupRequest:
         assert "availableActions" not in body
 
     def test_available_actions_max_length_enforced(self) -> None:
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="at most 100"):
             StartupRequest(
                 external_id="x",
                 extractor=ExtractorInfo(external_id="x"),
@@ -106,9 +113,15 @@ class TestAction:
 
     def test_unknown_fields_ignored(self) -> None:
         action = Action.model_validate(
-            {"externalId": "act-1", "actionName": "ping", "status": "running", "futureField": "odin-added-this"}
+            {"externalId": "act-1", "actionName": "ping", "status": "running", "unknownField": "unknown-value"}
         )
         assert action.external_id == "act-1"
+
+    def test_call_metadata_non_string_value_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Input should be a valid string"):
+            Action.model_validate(
+                {"externalId": "act-1", "actionName": "ping", "status": "pending", "callMetadata": {"count": 3}}
+            )
 
 
 class TestCheckinRequest:
@@ -130,6 +143,13 @@ class TestCheckinRequest:
         body = CheckinRequest(external_id="x").model_dump(mode="json", by_alias=True)
         assert "actionUpdates" not in body
 
+    def test_action_updates_max_length_enforced(self) -> None:
+        with pytest.raises(ValidationError, match="at most 100"):
+            CheckinRequest(
+                external_id="x",
+                action_updates=[ActionUpdate(external_id=f"act-{i}", status=ActionStatus.running) for i in range(101)],
+            )
+
 
 class TestCheckinResponse:
     def test_pending_actions_deserialized(self) -> None:
@@ -150,7 +170,7 @@ class TestCheckinResponse:
 
     def test_unknown_fields_ignored(self) -> None:
         response = CheckinResponse.model_validate(
-            {"externalId": "x", "newFieldFromOdin": "some-value", "anotherUnknown": 42}
+            {"externalId": "x", "unknownField": "some-value", "anotherUnknown": 42}
         )
         assert response.external_id == "x"
 
@@ -183,15 +203,18 @@ class TestCheckinResponse:
 
 
 class TestActionEnum:
-    def test_action_type_values(self) -> None:
-        assert ActionType.start_task.value == "start_task"
-        assert ActionType.stop_task.value == "stop_task"
-        assert ActionType.custom.value == "custom"
+    @pytest.mark.parametrize("value", ["start_task", "stop_task", "custom"])
+    def test_action_type_lookup_by_value(self, value: str) -> None:
+        assert ActionType(value).value == value
 
-    def test_action_status_values(self) -> None:
-        assert ActionStatus.pending.value == "pending"
-        assert ActionStatus.running.value == "running"
-        assert ActionStatus.failed.value == "failed"
-        assert ActionStatus.succeeded.value == "succeeded"
-        assert ActionStatus.cancel_pending.value == "cancel_pending"
-        assert ActionStatus.canceled.value == "canceled"
+    def test_action_type_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ActionType("unknown_action")
+
+    @pytest.mark.parametrize("value", ["pending", "running", "failed", "succeeded", "cancel_pending", "canceled"])
+    def test_action_status_lookup_by_value(self, value: str) -> None:
+        assert ActionStatus(value).value == value
+
+    def test_action_status_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ActionStatus("unknown_status")

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from cognite.extractorutils.unstable.core._dto import (
     Action,
@@ -21,6 +22,11 @@ def _startup_request() -> StartupRequest:
 
 
 class TestAvailableActionWrite:
+    @pytest.mark.parametrize("action_type", [ActionType.start_task, ActionType.stop_task, ActionType.custom])
+    def test_type_serialization(self, action_type: ActionType) -> None:
+        body = AvailableActionWrite(name="test", type=action_type).model_dump(mode="json", by_alias=True)
+        assert body["type"] == action_type.value
+
     def test_camel_case_serialization(self) -> None:
         action = AvailableActionWrite(name="restart", type=ActionType.start_task, task="main")
         body = action.model_dump(mode="json", by_alias=True)
@@ -33,13 +39,10 @@ class TestAvailableActionWrite:
         assert "description" not in body
         assert "task" not in body
 
-    def test_name_min_length_enforced(self) -> None:
-        with pytest.raises(Exception):
-            AvailableActionWrite(name="", type=ActionType.custom)
-
-    def test_name_max_length_enforced(self) -> None:
-        with pytest.raises(Exception):
-            AvailableActionWrite(name="x" * 256, type=ActionType.custom)
+    @pytest.mark.parametrize("invalid_name", ["", "x" * 256])
+    def test_invalid_name_rejected(self, invalid_name: str) -> None:
+        with pytest.raises(ValidationError):
+            AvailableActionWrite(name=invalid_name, type=ActionType.custom)
 
 
 class TestActionUpdate:
@@ -79,7 +82,7 @@ class TestStartupRequest:
         assert "availableActions" not in body
 
     def test_available_actions_max_length_enforced(self) -> None:
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             StartupRequest(
                 external_id="x",
                 extractor=ExtractorInfo(external_id="x"),

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -21,200 +21,211 @@ def _startup_request() -> StartupRequest:
     )
 
 
-class TestAvailableActionWrite:
-    @pytest.mark.parametrize(
-        "action_type,task,expected_body",
-        [
-            (ActionType.start_task, "main", {"type": "start_task", "task": "main"}),
-            (ActionType.stop_task, None, {"type": "stop_task"}),
-            (ActionType.custom, None, {"type": "custom"}),
+@pytest.mark.parametrize(
+    "action_type,task,expected_body",
+    [
+        (ActionType.start_task, "main", {"type": "start_task", "task": "main"}),
+        (ActionType.stop_task, None, {"type": "stop_task"}),
+        (ActionType.custom, None, {"type": "custom"}),
+    ],
+)
+def test_available_action_write_serialization(
+    action_type: ActionType, task: str | None, expected_body: dict[str, str]
+) -> None:
+    body = AvailableActionWrite(name="test", type=action_type, task=task).model_dump(mode="json", by_alias=True)
+    for key, val in expected_body.items():
+        assert body[key] == val
+
+
+def test_available_action_write_none_fields_excluded() -> None:
+    action = AvailableActionWrite(name="restart", type=ActionType.custom)
+    body = action.model_dump(mode="json", by_alias=True)
+    assert "description" not in body
+    assert "task" not in body
+
+
+@pytest.mark.parametrize("invalid_name", ["", "x" * 256])
+def test_available_action_write_invalid_name_rejected(invalid_name: str) -> None:
+    with pytest.raises(ValidationError, match="String should have"):
+        AvailableActionWrite(name=invalid_name, type=ActionType.custom)
+
+
+@pytest.mark.parametrize("status", [ActionStatus.pending, ActionStatus.cancel_pending])
+def test_action_update_extractor_reserved_statuses_rejected(status: ActionStatus) -> None:
+    with pytest.raises(ValidationError, match="Extractors cannot set action status"):
+        ActionUpdate(external_id="act-1", status=status)
+
+
+def test_action_update_camel_case_serialization() -> None:
+    update = ActionUpdate(
+        external_id="act-1",
+        status=ActionStatus.succeeded,
+        result_message="done",
+    )
+    body = update.model_dump(mode="json", by_alias=True)
+    assert body["externalId"] == "act-1"
+    assert body["status"] == "succeeded"
+    assert body["resultMessage"] == "done"
+
+
+def test_action_update_none_fields_excluded() -> None:
+    update = ActionUpdate(external_id="act-1", status=ActionStatus.running)
+    body = update.model_dump(mode="json", by_alias=True)
+    assert "resultMessage" not in body
+    assert "resultMetadata" not in body
+
+
+def test_startup_request_available_actions_serialized() -> None:
+    req = _startup_request()
+    req.available_actions = [
+        AvailableActionWrite(name="restart", type=ActionType.start_task, task="main"),
+        AvailableActionWrite(name="ping", type=ActionType.custom),
+    ]
+    body = req.model_dump(mode="json", by_alias=True)
+    assert "availableActions" in body
+    assert len(body["availableActions"]) == 2
+    assert body["availableActions"][0]["name"] == "restart"
+    assert body["availableActions"][0]["type"] == "start_task"
+
+
+def test_startup_request_available_actions_none_excluded() -> None:
+    body = _startup_request().model_dump(mode="json", by_alias=True)
+    assert "availableActions" not in body
+
+
+def test_startup_request_available_actions_max_length_enforced() -> None:
+    with pytest.raises(ValidationError, match="at most 100"):
+        StartupRequest(
+            external_id="x",
+            extractor=ExtractorInfo(external_id="x"),
+            available_actions=[AvailableActionWrite(name=f"a{i}", type=ActionType.custom) for i in range(101)],
+        )
+
+
+def test_action_camel_case_serialization() -> None:
+    action = Action(external_id="act-1", action_name="restart", status=ActionStatus.running)
+    body = action.model_dump(mode="json", by_alias=True)
+    assert body["externalId"] == "act-1"
+    assert body["actionName"] == "restart"
+    assert body["status"] == "running"
+
+
+def test_action_none_fields_excluded() -> None:
+    action = Action(external_id="act-1", action_name="ping", status=ActionStatus.pending)
+    body = action.model_dump(mode="json", by_alias=True)
+    assert "callMetadata" not in body
+    assert "resultMetadata" not in body
+
+
+def test_action_unknown_fields_ignored() -> None:
+    action = Action.model_validate(
+        {"externalId": "act-1", "actionName": "ping", "status": "running", "unknownField": "unknown-value"}
+    )
+    assert action.external_id == "act-1"
+
+
+def test_action_call_metadata_non_string_value_rejected() -> None:
+    with pytest.raises(ValidationError, match="Input should be a valid string"):
+        Action.model_validate(
+            {"externalId": "act-1", "actionName": "ping", "status": "pending", "callMetadata": {"count": 3}}
+        )
+
+
+def test_checkin_request_action_updates_serialized() -> None:
+    req = CheckinRequest(
+        external_id="my-extractor",
+        action_updates=[
+            ActionUpdate(external_id="act-1", status=ActionStatus.running),
+            ActionUpdate(external_id="act-2", status=ActionStatus.failed, result_message="timeout"),
         ],
     )
-    def test_serialization(self, action_type: ActionType, task: str | None, expected_body: dict[str, str]) -> None:
-        body = AvailableActionWrite(name="test", type=action_type, task=task).model_dump(mode="json", by_alias=True)
-        for key, val in expected_body.items():
-            assert body[key] == val
-
-    def test_none_fields_excluded(self) -> None:
-        action = AvailableActionWrite(name="restart", type=ActionType.custom)
-        body = action.model_dump(mode="json", by_alias=True)
-        assert "description" not in body
-        assert "task" not in body
-
-    @pytest.mark.parametrize("invalid_name", ["", "x" * 256])
-    def test_invalid_name_rejected(self, invalid_name: str) -> None:
-        with pytest.raises(ValidationError, match="String should have"):
-            AvailableActionWrite(name=invalid_name, type=ActionType.custom)
+    body = req.model_dump(mode="json", by_alias=True)
+    assert "actionUpdates" in body
+    assert len(body["actionUpdates"]) == 2
+    assert body["actionUpdates"][0]["status"] == "running"
+    assert body["actionUpdates"][1]["resultMessage"] == "timeout"
 
 
-class TestActionUpdate:
-    @pytest.mark.parametrize("status", [ActionStatus.pending, ActionStatus.cancel_pending])
-    def test_extractor_reserved_statuses_rejected(self, status: ActionStatus) -> None:
-        with pytest.raises(ValidationError, match="Extractors cannot set action status"):
-            ActionUpdate(external_id="act-1", status=status)
+def test_checkin_request_action_updates_none_excluded() -> None:
+    body = CheckinRequest(external_id="x").model_dump(mode="json", by_alias=True)
+    assert "actionUpdates" not in body
 
-    def test_camel_case_serialization(self) -> None:
-        update = ActionUpdate(
-            external_id="act-1",
-            status=ActionStatus.succeeded,
-            result_message="done",
+
+def test_checkin_request_action_updates_max_length_enforced() -> None:
+    with pytest.raises(ValidationError, match="at most 100"):
+        CheckinRequest(
+            external_id="x",
+            action_updates=[ActionUpdate(external_id=f"act-{i}", status=ActionStatus.running) for i in range(101)],
         )
-        body = update.model_dump(mode="json", by_alias=True)
-        assert body["externalId"] == "act-1"
-        assert body["status"] == "succeeded"
-        assert body["resultMessage"] == "done"
-
-    def test_none_fields_excluded(self) -> None:
-        update = ActionUpdate(external_id="act-1", status=ActionStatus.running)
-        body = update.model_dump(mode="json", by_alias=True)
-        assert "resultMessage" not in body
-        assert "resultMetadata" not in body
 
 
-class TestStartupRequest:
-    def test_available_actions_serialized(self) -> None:
-        req = _startup_request()
-        req.available_actions = [
-            AvailableActionWrite(name="restart", type=ActionType.start_task, task="main"),
-            AvailableActionWrite(name="ping", type=ActionType.custom),
-        ]
-        body = req.model_dump(mode="json", by_alias=True)
-        assert "availableActions" in body
-        assert len(body["availableActions"]) == 2
-        assert body["availableActions"][0]["name"] == "restart"
-        assert body["availableActions"][0]["type"] == "start_task"
-
-    def test_available_actions_none_excluded(self) -> None:
-        body = _startup_request().model_dump(mode="json", by_alias=True)
-        assert "availableActions" not in body
-
-    def test_available_actions_max_length_enforced(self) -> None:
-        with pytest.raises(ValidationError, match="at most 100"):
-            StartupRequest(
-                external_id="x",
-                extractor=ExtractorInfo(external_id="x"),
-                available_actions=[AvailableActionWrite(name=f"a{i}", type=ActionType.custom) for i in range(101)],
-            )
-
-
-class TestAction:
-    def test_camel_case_serialization(self) -> None:
-        action = Action(external_id="act-1", action_name="restart", status=ActionStatus.running)
-        body = action.model_dump(mode="json", by_alias=True)
-        assert body["externalId"] == "act-1"
-        assert body["actionName"] == "restart"
-        assert body["status"] == "running"
-
-    def test_none_fields_excluded(self) -> None:
-        action = Action(external_id="act-1", action_name="ping", status=ActionStatus.pending)
-        body = action.model_dump(mode="json", by_alias=True)
-        assert "callMetadata" not in body
-        assert "resultMetadata" not in body
-
-    def test_unknown_fields_ignored(self) -> None:
-        action = Action.model_validate(
-            {"externalId": "act-1", "actionName": "ping", "status": "running", "unknownField": "unknown-value"}
-        )
-        assert action.external_id == "act-1"
-
-    def test_call_metadata_non_string_value_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Input should be a valid string"):
-            Action.model_validate(
-                {"externalId": "act-1", "actionName": "ping", "status": "pending", "callMetadata": {"count": 3}}
-            )
-
-
-class TestCheckinRequest:
-    def test_action_updates_serialized(self) -> None:
-        req = CheckinRequest(
-            external_id="my-extractor",
-            action_updates=[
-                ActionUpdate(external_id="act-1", status=ActionStatus.running),
-                ActionUpdate(external_id="act-2", status=ActionStatus.failed, result_message="timeout"),
+def test_checkin_response_pending_actions_deserialized() -> None:
+    response = CheckinResponse.model_validate(
+        {
+            "externalId": "my-extractor",
+            "pendingActions": [
+                {"externalId": "act-1", "actionName": "restart", "status": "pending"},
+                {"externalId": "act-2", "actionName": "ping", "status": "cancel_pending"},
             ],
-        )
-        body = req.model_dump(mode="json", by_alias=True)
-        assert "actionUpdates" in body
-        assert len(body["actionUpdates"]) == 2
-        assert body["actionUpdates"][0]["status"] == "running"
-        assert body["actionUpdates"][1]["resultMessage"] == "timeout"
-
-    def test_action_updates_none_excluded(self) -> None:
-        body = CheckinRequest(external_id="x").model_dump(mode="json", by_alias=True)
-        assert "actionUpdates" not in body
-
-    def test_action_updates_max_length_enforced(self) -> None:
-        with pytest.raises(ValidationError, match="at most 100"):
-            CheckinRequest(
-                external_id="x",
-                action_updates=[ActionUpdate(external_id=f"act-{i}", status=ActionStatus.running) for i in range(101)],
-            )
+        }
+    )
+    assert response.pending_actions is not None
+    assert len(response.pending_actions) == 2
+    assert response.pending_actions[0].external_id == "act-1"
+    assert response.pending_actions[0].status == ActionStatus.pending
+    assert response.pending_actions[1].call_metadata is None
 
 
-class TestCheckinResponse:
-    def test_pending_actions_deserialized(self) -> None:
-        response = CheckinResponse.model_validate(
-            {
-                "externalId": "my-extractor",
-                "pendingActions": [
-                    {"externalId": "act-1", "actionName": "restart", "status": "pending"},
-                    {"externalId": "act-2", "actionName": "ping", "status": "cancel_pending"},
-                ],
-            }
-        )
-        assert response.pending_actions is not None
-        assert len(response.pending_actions) == 2
-        assert response.pending_actions[0].external_id == "act-1"
-        assert response.pending_actions[0].status == ActionStatus.pending
-        assert response.pending_actions[1].call_metadata is None
-
-    def test_unknown_fields_ignored(self) -> None:
-        response = CheckinResponse.model_validate(
-            {"externalId": "x", "unknownField": "some-value", "anotherUnknown": 42}
-        )
-        assert response.external_id == "x"
-
-    def test_pending_actions_none_when_absent(self) -> None:
-        response = CheckinResponse.model_validate({"externalId": "x"})
-        assert response.pending_actions is None
-
-    def test_pending_actions_empty_list_accepted(self) -> None:
-        response = CheckinResponse.model_validate({"externalId": "x", "pendingActions": []})
-        assert response.pending_actions == []
-
-    def test_action_with_call_metadata_deserialized(self) -> None:
-        response = CheckinResponse.model_validate(
-            {
-                "externalId": "x",
-                "pendingActions": [
-                    {
-                        "externalId": "act-3",
-                        "actionName": "configure",
-                        "status": "pending",
-                        "callMetadata": {"key": "value", "count": "3"},
-                    }
-                ],
-            }
-        )
-        assert response.pending_actions is not None
-        action = response.pending_actions[0]
-        assert isinstance(action.call_metadata, dict)
-        assert action.call_metadata["key"] == "value"
+def test_checkin_response_unknown_fields_ignored() -> None:
+    response = CheckinResponse.model_validate({"externalId": "x", "unknownField": "some-value", "anotherUnknown": 42})
+    assert response.external_id == "x"
 
 
-class TestActionEnum:
-    @pytest.mark.parametrize("value", ["start_task", "stop_task", "custom"])
-    def test_action_type_lookup_by_value(self, value: str) -> None:
-        assert ActionType(value).value == value
+def test_checkin_response_pending_actions_none_when_absent() -> None:
+    response = CheckinResponse.model_validate({"externalId": "x"})
+    assert response.pending_actions is None
 
-    def test_action_type_invalid_value_raises(self) -> None:
-        with pytest.raises(ValueError):
-            ActionType("unknown_action")
 
-    @pytest.mark.parametrize("value", ["pending", "running", "failed", "succeeded", "cancel_pending", "canceled"])
-    def test_action_status_lookup_by_value(self, value: str) -> None:
-        assert ActionStatus(value).value == value
+def test_checkin_response_pending_actions_empty_list_accepted() -> None:
+    response = CheckinResponse.model_validate({"externalId": "x", "pendingActions": []})
+    assert response.pending_actions == []
 
-    def test_action_status_invalid_value_raises(self) -> None:
-        with pytest.raises(ValueError):
-            ActionStatus("unknown_status")
+
+def test_checkin_response_action_with_call_metadata_deserialized() -> None:
+    response = CheckinResponse.model_validate(
+        {
+            "externalId": "x",
+            "pendingActions": [
+                {
+                    "externalId": "act-3",
+                    "actionName": "configure",
+                    "status": "pending",
+                    "callMetadata": {"key": "value", "count": "3"},
+                }
+            ],
+        }
+    )
+    assert response.pending_actions is not None
+    action = response.pending_actions[0]
+    assert isinstance(action.call_metadata, dict)
+    assert action.call_metadata["key"] == "value"
+
+
+@pytest.mark.parametrize("value", ["start_task", "stop_task", "custom"])
+def test_action_type_lookup_by_value(value: str) -> None:
+    assert ActionType(value).value == value
+
+
+def test_action_type_invalid_value_raises() -> None:
+    with pytest.raises(ValueError):
+        ActionType("unknown_action")
+
+
+@pytest.mark.parametrize("value", ["pending", "running", "failed", "succeeded", "cancel_pending", "canceled"])
+def test_action_status_lookup_by_value(value: str) -> None:
+    assert ActionStatus(value).value == value
+
+
+def test_action_status_invalid_value_raises() -> None:
+    with pytest.raises(ValueError):
+        ActionStatus("unknown_status")


### PR DESCRIPTION
### PR short summary:
- Adds the data types (DTOs) needed for the actions feature so extractors can communicate with Odin about actions.

---
### What changed:
- Added ActionType, ActionStatus enums and AvailableActionWrite, Action, ActionUpdate models to _dto.py
- StartupRequest now includes available_actions (what actions the extractor supports)
- CheckinRequest now includes action_updates (progress updates sent to Odin)
- CheckinResponse now includes pending_actions (actions Odin wants the extractor to run)
- New test file test_dto.py covering all the new types

---
### Why it changed:
- Odin already has the actions API. This PR adds the matching types on the extractor side so that we can invoke the add actions as part of startup and checkin.

---
### What to focus on:
- Do the field names and types match what Odin expects? (cross-referenced against odin/backend/dto/checkin.py)

---
### Test evidence:
- All unit tests in tests/test_unstable/test_dto.py pass.

---
### Risks or unknowns:
- Actions aren't live yet, the startup and checkin worker aren't wired up to send/receive these fields, so there is no risk.