### PR TITLE
feat(odin): Add custom action support

### DIFF
--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -50,6 +50,7 @@ class ActionContext(CogniteLogger):
             level=level,
             description=description,
             details=details,
+            task_name=task_name or self._action.name,
         )
 
 

--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -20,6 +20,9 @@ class ActionContext(CogniteLogger):
     Context for a custom action invocation.
 
     This class is used to log errors and messages related to the action invocation.
+
+    ``external_id`` and ``call_metadata`` come from the pending action payload sent by Odin and are
+    available for use when reporting results back to the server.
     """
 
     def __init__(

--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -6,7 +6,6 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from cognite.extractorutils.unstable.core._dto import JSONType
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.logger import CogniteLogger
 
@@ -28,7 +27,7 @@ class ActionContext(CogniteLogger):
         action: "CustomAction",
         extractor: "Extractor",
         external_id: str,
-        call_metadata: JSONType | None = None,
+        call_metadata: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._action = action
@@ -50,7 +49,7 @@ class ActionContext(CogniteLogger):
             level=level,
             description=description,
             details=details,
-            task_name=task_name or self._action.name,
+            task_name=task_name if task_name is not None else self._action.name,
         )
 
 

--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -36,9 +36,7 @@ class ActionContext(CogniteLogger):
         self.external_id = external_id
         self.call_metadata = call_metadata
 
-        self._logger = logging.getLogger(
-            f"{self._extractor.EXTERNAL_ID}.action.{self._action.name.replace(' ', '')}"
-        )
+        self._logger = logging.getLogger(f"{self._extractor.EXTERNAL_ID}.action.{self._action.name.replace(' ', '')}")
 
     def _new_error(
         self,

--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -1,0 +1,80 @@
+"""
+This module defines the base classes for custom actions in the extractor framework.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from cognite.extractorutils.unstable.core._dto import JSONType
+from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
+from cognite.extractorutils.unstable.core.logger import CogniteLogger
+
+if TYPE_CHECKING:
+    from cognite.extractorutils.unstable.core.base import Extractor
+
+__all__ = ["ActionContext", "ActionTarget", "CustomAction"]
+
+
+class ActionContext(CogniteLogger):
+    """
+    Context for a custom action invocation.
+
+    This class is used to log errors and messages related to the action invocation.
+    """
+
+    def __init__(
+        self,
+        action: "CustomAction",
+        extractor: "Extractor",
+        external_id: str,
+        call_metadata: JSONType | None = None,
+    ) -> None:
+        super().__init__()
+        self._action = action
+        self._extractor = extractor
+        self.external_id = external_id
+        self.call_metadata = call_metadata
+
+        self._logger = logging.getLogger(
+            f"{self._extractor.EXTERNAL_ID}.action.{self._action.name.replace(' ', '')}"
+        )
+
+    def _new_error(
+        self,
+        level: ErrorLevel,
+        description: str,
+        *,
+        details: str | None = None,
+        task_name: str | None = None,
+    ) -> Error:
+        return self._extractor._new_error(
+            level=level,
+            description=description,
+            details=details,
+        )
+
+
+ActionTarget = Callable[["ActionContext"], None]
+
+
+class CustomAction:
+    """
+    A user-invocable operation exposed by an extractor beyond start/stop of a task.
+
+    Args:
+        name: The name of the action.
+        target: A callable that takes an ``ActionContext`` and performs the action.
+        description: An optional description of the action.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        target: ActionTarget,
+        description: str | None = None,
+    ) -> None:
+        self.name = name
+        self.target = target
+        self.description = description

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -82,16 +82,17 @@ def test_action_context_error_delegates_to_extractor(mock_extractor: MagicMock, 
         level=ErrorLevel.warning,
         description="Something went wrong",
         details=None,
+        task_name="my action",
     )
 
 
-def test_action_context_error_does_not_pass_task_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
+def test_action_context_error_passes_explicit_task_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
     ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
 
-    ctx._new_error(level=ErrorLevel.error, description="Fail", details="details", task_name="ignored")
+    ctx._new_error(level=ErrorLevel.error, description="Fail", details="details", task_name="custom-task")
 
     call_kwargs = mock_extractor._new_error.call_args.kwargs
-    assert "task_name" not in call_kwargs
+    assert call_kwargs["task_name"] == "custom-task"
 
 
 def test_action_target_is_callable() -> None:

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -78,6 +78,8 @@ def test_action_context_logger_name_strips_spaces(mock_extractor: MagicMock) -> 
     [
         (None, "my action"),
         ("custom-task", "custom-task"),
+        # Empty string is not None, so it passes through as-is rather than falling back to action name.
+        # Callers should avoid passing "" if they want the default; use None instead.
         ("", ""),
     ],
 )
@@ -89,10 +91,14 @@ def test_action_context_error_task_name(
 ) -> None:
     ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
 
-    ctx._new_error(level=ErrorLevel.warning, description="Something went wrong", task_name=task_name)
+    ctx._new_error(
+        level=ErrorLevel.warning, description="Something went wrong", details="some details", task_name=task_name
+    )
 
     call_kwargs = mock_extractor._new_error.call_args.kwargs
     assert call_kwargs["task_name"] == expected_task_name
+    assert call_kwargs["details"] == "some details"
+    assert call_kwargs["level"] == ErrorLevel.warning
 
 
 def test_action_target_is_callable(mock_extractor: MagicMock) -> None:

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -73,35 +73,37 @@ def test_action_context_logger_name_strips_spaces(mock_extractor: MagicMock) -> 
     assert ctx._logger.name == "test-extractor.action.processdata"
 
 
-def test_action_context_error_delegates_to_extractor(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
+@pytest.mark.parametrize(
+    "task_name,expected_task_name",
+    [
+        (None, "my action"),
+        ("custom-task", "custom-task"),
+        ("", ""),
+    ],
+)
+def test_action_context_error_task_name(
+    mock_extractor: MagicMock,
+    simple_action: CustomAction,
+    task_name: str | None,
+    expected_task_name: str,
+) -> None:
     ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
 
-    ctx._new_error(level=ErrorLevel.warning, description="Something went wrong")
-
-    mock_extractor._new_error.assert_called_once_with(
-        level=ErrorLevel.warning,
-        description="Something went wrong",
-        details=None,
-        task_name="my action",
-    )
-
-
-def test_action_context_error_passes_explicit_task_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
-    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
-
-    ctx._new_error(level=ErrorLevel.error, description="Fail", details="details", task_name="custom-task")
+    ctx._new_error(level=ErrorLevel.warning, description="Something went wrong", task_name=task_name)
 
     call_kwargs = mock_extractor._new_error.call_args.kwargs
-    assert call_kwargs["task_name"] == "custom-task"
+    assert call_kwargs["task_name"] == expected_task_name
 
 
-def test_action_target_is_callable() -> None:
+def test_action_target_is_callable(mock_extractor: MagicMock) -> None:
     called: list[ActionContext] = []
 
     def my_action(ctx: ActionContext) -> None:
         called.append(ctx)
 
     action = CustomAction(name="test", target=my_action)
+    ctx = ActionContext(action=action, extractor=mock_extractor, external_id="ext-id")
 
     assert callable(action.target)
-    assert action.target is my_action
+    action.target(ctx)
+    assert called == [ctx]

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognite.extractorutils.unstable.core.actions import ActionContext, CustomAction
+from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
+
+
+@pytest.fixture
+def mock_extractor() -> MagicMock:
+    extractor = MagicMock()
+    extractor.EXTERNAL_ID = "test-extractor"
+    extractor._new_error.side_effect = lambda level, description, details=None, task_name=None: MagicMock(
+        spec=Error,
+        level=level,
+        description=description,
+        details=details,
+        _task_name=task_name,
+    )
+    return extractor
+
+
+@pytest.fixture
+def simple_action() -> CustomAction:
+    return CustomAction(name="my action", target=lambda ctx: None)
+
+
+def test_custom_action_instantiation() -> None:
+    def my_action(ctx: ActionContext) -> None:
+        pass
+
+    action = CustomAction(name="my action", target=my_action, description="Does something")
+
+    assert action.name == "my action"
+    assert action.target is my_action
+    assert action.description == "Does something"
+
+
+def test_custom_action_without_description() -> None:
+    action = CustomAction(name="my action", target=lambda ctx: None)
+
+    assert action.description is None
+
+
+def test_action_context_attributes(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
+    ctx = ActionContext(
+        action=simple_action,
+        extractor=mock_extractor,
+        external_id="triggered-action-ext-id",
+        call_metadata={"key": "value"},
+    )
+
+    assert ctx.external_id == "triggered-action-ext-id"
+    assert ctx.call_metadata == {"key": "value"}
+
+
+def test_action_context_call_metadata_none(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
+    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+
+    assert ctx.call_metadata is None
+
+
+def test_action_context_logger_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
+    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+
+    assert ctx._logger.name == "test-extractor.action.myaction"
+
+
+def test_action_context_logger_name_strips_spaces(mock_extractor: MagicMock) -> None:
+    action = CustomAction(name="process data", target=lambda ctx: None)
+    ctx = ActionContext(action=action, extractor=mock_extractor, external_id="ext-id")
+
+    assert ctx._logger.name == "test-extractor.action.processdata"
+
+
+def test_action_context_error_delegates_to_extractor(
+    mock_extractor: MagicMock, simple_action: CustomAction
+) -> None:
+    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+
+    ctx._new_error(level=ErrorLevel.warning, description="Something went wrong")
+
+    mock_extractor._new_error.assert_called_once_with(
+        level=ErrorLevel.warning,
+        description="Something went wrong",
+        details=None,
+    )
+
+
+def test_action_context_error_does_not_pass_task_name(
+    mock_extractor: MagicMock, simple_action: CustomAction
+) -> None:
+    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+
+    ctx._new_error(level=ErrorLevel.error, description="Fail", details="details", task_name="ignored")
+
+    call_kwargs = mock_extractor._new_error.call_args.kwargs
+    assert "task_name" not in call_kwargs
+
+
+def test_action_target_is_callable() -> None:
+    called: list[ActionContext] = []
+
+    def my_action(ctx: ActionContext) -> None:
+        called.append(ctx)
+
+    action = CustomAction(name="test", target=my_action)
+
+    assert callable(action.target)
+    assert action.target is my_action

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -73,9 +73,7 @@ def test_action_context_logger_name_strips_spaces(mock_extractor: MagicMock) -> 
     assert ctx._logger.name == "test-extractor.action.processdata"
 
 
-def test_action_context_error_delegates_to_extractor(
-    mock_extractor: MagicMock, simple_action: CustomAction
-) -> None:
+def test_action_context_error_delegates_to_extractor(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
     ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
 
     ctx._new_error(level=ErrorLevel.warning, description="Something went wrong")
@@ -87,9 +85,7 @@ def test_action_context_error_delegates_to_extractor(
     )
 
 
-def test_action_context_error_does_not_pass_task_name(
-    mock_extractor: MagicMock, simple_action: CustomAction
-) -> None:
+def test_action_context_error_does_not_pass_task_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
     ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
 
     ctx._new_error(level=ErrorLevel.error, description="Fail", details="details", task_name="ignored")


### PR DESCRIPTION
### PR short summary:
- Adds support for custom actions - named operations that extractor authors can define and expose to be triggered at runtime by an operator.

---
### What changed:
- New actions.py with CustomAction (holds name + callable), ActionContext (passed to the callable, handles error logging), and ActionTarget (type alias for the callable).
- Unit tests covering the new classes.

---
### Why it changed:
- Extractors only supported start/stop of tasks. Odin needs a way to trigger ad-hoc operations like, say fetch logs, without going through the task lifecycle.

---
### What to focus on:
- ActionContext._new_error - errors default to using the action's name as task_name unless overridden.
- Logger naming format: {extractor_id}.action.{action_name} - confirm this matches what Odin expects.

---
### Test evidence:
- All unit tests under tests/test_unstable/test_actions.py pass.

---
### Risks or unknowns:
- No wiring to the Extractor base class yet so no risk yet.