### PR TITLE
EDGE-278 Log Forbidden message is unclear

### DIFF
--- a/cognite/extractorutils/unstable/core/checkin_worker.py
+++ b/cognite/extractorutils/unstable/core/checkin_worker.py
@@ -417,8 +417,15 @@ class CheckinWorker:
         except CogniteAPIError as e:
             if e.code == 401:
                 self._logger.critical(
-                    "Got a 401 error from CDF. Please check your configuration. "
-                    "Make sure the credentials and project is correct."
+                    "Got a 401 (Unauthorized) error from CDF. Please check your configuration. "
+                    "Make sure the credentials and project are correct."
+                )
+                exception_to_report = e
+
+            elif e.code == 403:
+                self._logger.critical(
+                    "Got a 403 (Forbidden) error from CDF. Please check your configuration. "
+                    "Make sure the credentials and project are correct."
                 )
                 exception_to_report = e
 

--- a/cognite/extractorutils/unstable/core/runtime.py
+++ b/cognite/extractorutils/unstable/core/runtime.py
@@ -398,8 +398,14 @@ class Runtime(Generic[ExtractorType]):
             # Error response from the CDF API
             if e.code == 401:
                 self.logger.critical(
-                    "Got a 401 error from CDF. Please check your configuration. "
-                    "Make sure the credentials and project is correct."
+                    "Got a 401 (Unauthorized) error from CDF. Please check your configuration. "
+                    "Make sure the credentials and project are correct."
+                )
+
+            elif e.code == 403:
+                self.logger.critical(
+                    "Got a 403 (Forbidden) error from CDF. Please check your configuration. "
+                    "Make sure the credentials and project are correct."
                 )
 
             elif e.message:

--- a/tests/test_unstable/test_checkin_worker.py
+++ b/tests/test_unstable/test_checkin_worker.py
@@ -6,6 +6,7 @@ from threading import Thread
 from time import sleep
 
 import faker
+import pytest
 import requests_mock
 
 from cognite.extractorutils.threading import CancellationToken
@@ -377,14 +378,21 @@ def test_run_report_periodic_checkin(
     assert len(worker._task_updates) == 0
 
 
+@pytest.mark.parametrize(
+    "status_code, status_message",
+    [(401, "Unauthorized request"), (403, "Forbidden request")],
+    ids=["401-Unauthorized", "403-Forbidden"],
+)
 def test_on_fatal_hook_is_called(
     connection_config: ConnectionConfig,
     application_config: TestConfig,
     requests_mock: requests_mock.Mocker,
+    status_code: int,
+    status_message: str,
     mock_startup_request: Callable[[requests_mock.Mocker, int, str], None],
 ) -> None:
     requests_mock.real_http = True
-    mock_startup_request(requests_mock, 401, "Unauthorized request")
+    mock_startup_request(requests_mock, status_code, status_message)
     cognite_client = connection_config.get_cognite_client("test_checkin")
     on_fatal_count = 0
 


### PR DESCRIPTION
## Background

While starting the file extractor main branch, if the application (client ID) doesnt have required permission (case observed) for the cognite API `/api/v1/projects/{self._cognite_client.config.project}/odin/checkin`, raises a `CogntieAPIError` with status code `403` and error message `"Forbidden"` and the log shows only “Forbidden”. The log could be improved.

<img width="1820" height="85" alt="Image of previous forbidden log" src="https://github.com/user-attachments/assets/01c1ec3f-5311-4831-b7ef-a8195758f60b" />


## Summary

This PR addresses error handling for authentication and authorization failures from CDF:

- **403 Forbidden support**: Adds explicit handling for 403 errors alongside existing 401 (Unauthorized) errors
- **Improved observability**: Clarifies error messages by labeling error codes (e.g., "401 (Unauthorized)") and fixing grammar
- **Test coverage**: Parametrizes the fatal hook test to verify both 401 and 403 error paths trigger the handler correctly

<img width="1139" height="144" alt="Image of update forbidden log" src="https://github.com/user-attachments/assets/a9c60c0a-74f8-4344-aaa8-3286bdec242c" />


## Changes

### `checkin_worker.py` & `runtime.py`
- Updated 401 error message: "Got a 401 error" → "Got a 401 (Unauthorized) error"
- Fixed grammar: "credentials and project is correct" → "credentials and project are correct"
- Added new `elif e.code == 403:` block with Forbidden error message

### `test_checkin_worker.py`
- Parametrized `test_on_fatal_hook_is_called` with `@pytest.mark.parametrize` decorator
- Test runs twice: once for 401, once for 403
- Added readable `ids` for test output clarity

## Test Plan

- `test_on_fatal_hook_is_called[401-Unauthorized]` — verifies fatal hook fires on 401
- `test_on_fatal_hook_is_called[403-Forbidden]` — verifies fatal hook fires on 403