### PR TITLE
feat(odin): Add cancellation token to TaskContext for cancel task

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -449,6 +449,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                         TaskContext(
                             task=task,
                             extractor=self,
+                            cancellation_token=self.cancellation_token.create_child_token(),
                         )
                     ),
                 )
@@ -546,6 +547,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                             TaskContext(
                                 task=task,
                                 extractor=self,
+                                cancellation_token=self.cancellation_token.create_child_token(),
                             ),
                         )
                     )
@@ -555,7 +557,13 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             Thread(
                 name=pascalize(task.name),
                 target=task.target,
-                args=(TaskContext(task=task, extractor=self),),
+                args=(
+                    TaskContext(
+                        task=task,
+                        extractor=self,
+                        cancellation_token=self.cancellation_token.create_child_token(),
+                    ),
+                ),
             ).start()
 
         if has_scheduled:

--- a/cognite/extractorutils/unstable/core/tasks.py
+++ b/cognite/extractorutils/unstable/core/tasks.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import (
     CronConfig,
     IntervalConfig,
@@ -28,10 +29,16 @@ class TaskContext(CogniteLogger):
     This class is used to log errors and messages related to the task execution.
     """
 
-    def __init__(self, task: "Task", extractor: "Extractor") -> None:
+    def __init__(
+        self,
+        task: "Task",
+        extractor: "Extractor",
+        cancellation_token: CancellationToken,
+    ) -> None:
         super().__init__()
         self._task = task
         self._extractor = extractor
+        self.cancellation_token = cancellation_token
 
         self._logger = logging.getLogger(f"{self._extractor.EXTERNAL_ID}.{self._task.name.replace(' ', '')}")
 

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -117,7 +117,9 @@ def test_log_level_override(
 
     with extractor:
         startup_task = next(t for t in extractor._tasks if t.name == "log_task")
-        task_context = TaskContext(task=startup_task, extractor=extractor, cancellation_token=extractor.cancellation_token.create_child_token())
+        task_context = TaskContext(
+            task=startup_task, extractor=extractor, cancellation_token=extractor.cancellation_token.create_child_token()
+        )
         startup_task.target(task_context)
 
     captured = capsys.readouterr()

--- a/tests/test_unstable/test_base.py
+++ b/tests/test_unstable/test_base.py
@@ -117,7 +117,7 @@ def test_log_level_override(
 
     with extractor:
         startup_task = next(t for t in extractor._tasks if t.name == "log_task")
-        task_context = TaskContext(task=startup_task, extractor=extractor)
+        task_context = TaskContext(task=startup_task, extractor=extractor, cancellation_token=extractor.cancellation_token.create_child_token())
         startup_task.target(task_context)
 
     captured = capsys.readouterr()

--- a/tests/test_unstable/test_task_context.py
+++ b/tests/test_unstable/test_task_context.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from cognite.extractorutils.threading import CancellationToken
+from cognite.extractorutils.unstable.core.tasks import StartupTask, TaskContext
+
+
+def _make_context(parent_token: CancellationToken) -> tuple[TaskContext, CancellationToken]:
+    task = StartupTask(name="test task", target=lambda ctx: None)
+    extractor = MagicMock()
+    extractor.EXTERNAL_ID = "test-extractor"
+    child_token = parent_token.create_child_token()
+    ctx = TaskContext(task=task, extractor=extractor, cancellation_token=child_token)
+    return ctx, child_token
+
+
+def test_cancellation_token_not_cancelled_initially() -> None:
+    parent = CancellationToken()
+    ctx, _ = _make_context(parent)
+    assert not ctx.cancellation_token.is_cancelled
+
+
+def test_cancelling_task_token_does_not_affect_extractor_token() -> None:
+    parent = CancellationToken()
+    ctx, child = _make_context(parent)
+
+    child.cancel()
+
+    assert ctx.cancellation_token.is_cancelled
+    assert not parent.is_cancelled
+
+
+def test_cancelling_extractor_token_cancels_task_token() -> None:
+    parent = CancellationToken()
+    ctx, _ = _make_context(parent)
+
+    parent.cancel()
+
+    assert ctx.cancellation_token.is_cancelled
+
+
+def test_task_token_is_child_of_extractor_token() -> None:
+    parent = CancellationToken()
+    _, child = _make_context(parent)
+
+    assert child._parent is parent

--- a/tests/test_unstable/test_task_context.py
+++ b/tests/test_unstable/test_task_context.py
@@ -1,45 +1,58 @@
+from threading import Event
 from unittest.mock import MagicMock
 
-from cognite.extractorutils.threading import CancellationToken
-from cognite.extractorutils.unstable.core.tasks import StartupTask, TaskContext
+from cognite.extractorutils.unstable.core.base import FullConfig
+from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
+from test_unstable.conftest import TestConfig, TestExtractor
 
 
-def _make_context(parent_token: CancellationToken) -> tuple[TaskContext, CancellationToken]:
-    task = StartupTask(name="test task", target=lambda ctx: None)
-    extractor = MagicMock()
-    extractor.EXTERNAL_ID = "test-extractor"
-    child_token = parent_token.create_child_token()
-    ctx = TaskContext(task=task, extractor=extractor, cancellation_token=child_token)
-    return ctx, child_token
+def _make_extractor() -> TestExtractor:
+    """Create a TestExtractor with a mocked connection — no real API calls."""
+    full_config = FullConfig(
+        connection_config=MagicMock(),
+        application_config=TestConfig(parameter_one=1, parameter_two="a"),
+        current_config_revision=1,
+    )
+    return TestExtractor(full_config, MagicMock())
 
 
-def test_cancellation_token_not_cancelled_initially() -> None:
-    parent = CancellationToken()
-    ctx, _ = _make_context(parent)
-    assert not ctx.cancellation_token.is_cancelled
+def _add_and_trigger(extractor: TestExtractor) -> TaskContext:
+    """
+    Add a ScheduledTask, trigger it via the scheduler, and return the TaskContext
+    the framework created. This exercises the actual add_task code path in base.py.
+    """
+    captured: list[TaskContext] = []
+    done = Event()
+
+    def capture(ctx: TaskContext) -> None:
+        captured.append(ctx)
+        done.set()
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="test-task", target=capture))
+    extractor._scheduler.trigger("test-task")
+    done.wait(timeout=5)
+    return captured[0]
 
 
-def test_cancelling_task_token_does_not_affect_extractor_token() -> None:
-    parent = CancellationToken()
-    ctx, child = _make_context(parent)
+def test_scheduled_task_gets_child_cancellation_token() -> None:
+    extractor = _make_extractor()
+    ctx = _add_and_trigger(extractor)
+    assert ctx.cancellation_token._parent is extractor.cancellation_token
 
-    child.cancel()
+
+def test_task_token_cancel_does_not_affect_extractor() -> None:
+    extractor = _make_extractor()
+    ctx = _add_and_trigger(extractor)
+
+    ctx.cancellation_token.cancel()
+
+    assert not extractor.cancellation_token.is_cancelled
+
+
+def test_extractor_token_cancel_propagates_to_task_token() -> None:
+    extractor = _make_extractor()
+    ctx = _add_and_trigger(extractor)
+
+    extractor.cancellation_token.cancel()
 
     assert ctx.cancellation_token.is_cancelled
-    assert not parent.is_cancelled
-
-
-def test_cancelling_extractor_token_cancels_task_token() -> None:
-    parent = CancellationToken()
-    ctx, _ = _make_context(parent)
-
-    parent.cancel()
-
-    assert ctx.cancellation_token.is_cancelled
-
-
-def test_task_token_is_child_of_extractor_token() -> None:
-    parent = CancellationToken()
-    _, child = _make_context(parent)
-
-    assert child._parent is parent


### PR DESCRIPTION
### PR Short Summary
- Adds a per-task cancellation_token (CancellationToken) to TaskContext so individual tasks can be cancelled
  cooperatively without stopping the whole extractor. Each task receives a child token derived from the extractor-level
   token, preserving parent-propagation semantics.

### What changed
- Added cancellation_token: CancellationToken as a required constructor parameter and public attribute on TaskContext.
- Updated all three TaskContext(...) call sites (scheduled task lambda, startup task thread pool, continuous task thread) to pass self.cancellation_token.create_child_token().
- Added tests.

### Why it changed
- Prerequisite for implementing **stop_task** actions: cancelling a single running batch task requires each task to own a cancellation token that can be signalled independently. Previously, task code could only check **extractor.cancellation_token**, which cancels the entire extractor process.

### What to focus on during review
- Check if the cancellation token passed to TaskContext is correct.
- Will the cancellation token only cancel the child token and not parent token when it is cancelled.

### Test evidence
- All newly added tests pass.

### Risks and unknowns
- None. Purely additive

### Rollout and rollback
- Reverting is a straight revert of the 4 changed files.