### PR TITLE
feat(odin): Integrate available actions in extractor

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -516,9 +516,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
-        except Exception:
-            self._logger.exception(f"Task '{task.name}' raised an unhandled exception")
-            raise
         finally:
             with self._running_task_tokens_lock:
                 if self._running_task_tokens.get(task.name) is child_token:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -466,6 +466,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         if any(t.name == task.name for t in self._tasks):
             raise ValueError(f"Task '{task.name}' is already registered.")
 
+        if isinstance(task, ScheduledTask):
+            conflict_names = {f"Start {task.name}", f"Stop {task.name}"}
+            for action in self._custom_actions:
+                if action.name in conflict_names:
+                    raise ValueError(
+                        f"Task name '{task.name}' would conflict with existing custom action '{action.name}'."
+                    )
+
         # Store this for later, since we'll override it with the wrapped version
         target = task.target
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -190,6 +190,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._tasks: list[Task] = []
         self._custom_actions: list[CustomAction] = []
         self._running_task_tokens: dict[str, CancellationToken] = {}
+        self._running_task_tokens_lock = RLock()
         self._start_time: datetime
 
         self.metrics: BaseMetrics = self._load_metrics(config.metrics_class)
@@ -359,6 +360,17 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         Args:
             action: The custom action to register.
         """
+        if any(a.name == action.name for a in self._custom_actions):
+            raise ValueError(f"Custom action '{action.name}' is already registered.")
+
+        reserved_names = {
+            name for t in self._tasks if isinstance(t, ScheduledTask) for name in (f"Start {t.name}", f"Stop {t.name}")
+        }
+        if action.name in reserved_names:
+            raise ValueError(
+                f"Custom action name '{action.name}' conflicts with an auto-generated scheduled task action."
+            )
+
         self._custom_actions.append(action)
 
     def _set_runtime_message_queue(self, queue: Queue) -> None:
@@ -500,13 +512,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         future start_task action handler.
         """
         child_token = self.cancellation_token.create_child_token()
-        self._running_task_tokens[task.name] = child_token
+        with self._running_task_tokens_lock:
+            self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
         finally:
-            # Only remove our token; a concurrent run may have already replaced it
-            if self._running_task_tokens.get(task.name) is child_token:
-                self._running_task_tokens.pop(task.name, None)
+            with self._running_task_tokens_lock:
+                if self._running_task_tokens.get(task.name) is child_token:
+                    self._running_task_tokens.pop(task.name, None)
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -477,9 +477,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     self.restart()
 
             finally:
-                # Record task end and clear any per-run cancellation token
+                # Record task end
                 self._checkin_worker.report_task_end(name=task.name, timestamp=now())
-                self._running_task_tokens.pop(task.name, None)
 
         task.target = run_task
         self._tasks.append(task)
@@ -502,7 +501,12 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         """
         child_token = self.cancellation_token.create_child_token()
         self._running_task_tokens[task.name] = child_token
-        task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        try:
+            task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        finally:
+            # Only remove our token; a concurrent run may have already replaced it
+            if self._running_task_tokens.get(task.name) is child_token:
+                self._running_task_tokens.pop(task.name, None)
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -516,6 +516,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        except Exception:
+            self._logger.exception(f"Task '{task.name}' raised an unhandled exception")
+            raise
         finally:
             with self._running_task_tokens_lock:
                 if self._running_task_tokens.get(task.name) is child_token:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -463,6 +463,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         Args:
             task: The task to add. It should be an instance of ``StartupTask``, ``ContinuousTask``, or ``ScheduledTask``
         """
+        if any(t.name == task.name for t in self._tasks):
+            raise ValueError(f"Task '{task.name}' is already registered.")
+
         # Store this for later, since we'll override it with the wrapped version
         target = task.target
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -85,6 +85,8 @@ from cognite.extractorutils.unstable.configuration.models import (
     create_state_store,
 )
 from cognite.extractorutils.unstable.core._dto import (
+    ActionType,
+    AvailableActionWrite,
     CogniteModel,
     ExtractorInfo,
     StartupRequest,
@@ -94,6 +96,7 @@ from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
 )
 from cognite.extractorutils.unstable.core._messaging import RuntimeMessage
+from cognite.extractorutils.unstable.core.actions import CustomAction
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.logger import CogniteLogger, RobustFileHandler
@@ -106,6 +109,7 @@ __all__ = [
     "CogniteModel",
     "ConfigRevision",
     "ConfigType",
+    "CustomAction",
     "Extractor",
 ]
 
@@ -184,6 +188,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._scheduler = TaskScheduler(self.cancellation_token.create_child_token())
 
         self._tasks: list[Task] = []
+        self._custom_actions: list[CustomAction] = []
+        self._running_task_tokens: dict[str, CancellationToken] = {}
         self._start_time: datetime
 
         self.metrics: BaseMetrics = self._load_metrics(config.metrics_class)
@@ -195,6 +201,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         )
 
         self.__init_tasks__()
+        self.__init_actions__()
 
     def _setup_cancellation_watcher(self, cancel_event: MpEvent) -> None:
         """Starts a daemon thread to watch the inter-process event."""
@@ -335,6 +342,25 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         """
         pass
 
+    def __init_actions__(self) -> None:
+        """
+        This method should be overridden by subclasses to register custom actions.
+
+        It is called automatically after ``__init_tasks__`` during initialization.
+
+        Subclasses should call ``self.add_action(...)`` to register custom actions.
+        """
+        pass
+
+    def add_action(self, action: CustomAction) -> None:
+        """
+        Register a custom action that Odin can invoke on this extractor.
+
+        Args:
+            action: The custom action to register.
+        """
+        self._custom_actions.append(action)
+
     def _set_runtime_message_queue(self, queue: Queue) -> None:
         self._runtime_messages = queue
 
@@ -343,6 +369,22 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._setup_cancellation_watcher(cancel_event)
 
     def _get_startup_request(self) -> StartupRequest:
+        available_actions: list[AvailableActionWrite] = []
+
+        for t in self._tasks:
+            if isinstance(t, ScheduledTask):
+                available_actions.append(
+                    AvailableActionWrite(name=f"Start {t.name}", type=ActionType.start_task, task=t.name)
+                )
+                available_actions.append(
+                    AvailableActionWrite(name=f"Stop {t.name}", type=ActionType.stop_task, task=t.name)
+                )
+
+        available_actions.extend(
+            AvailableActionWrite(name=a.name, type=ActionType.custom, description=a.description)
+            for a in self._custom_actions
+        )
+
         return StartupRequest(
             external_id=self.connection_config.integration.external_id,
             active_config_revision=self.current_config_revision,
@@ -358,6 +400,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             ]
             if len(self._tasks) > 0
             else None,
+            available_actions=available_actions or None,
             timestamp=int(self._start_time.timestamp() * 1000),
         )
 
@@ -434,8 +477,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     self.restart()
 
             finally:
-                # Record task end
+                # Record task end and clear any per-run cancellation token
                 self._checkin_worker.report_task_end(name=task.name, timestamp=now())
+                self._running_task_tokens.pop(task.name, None)
 
         task.target = run_task
         self._tasks.append(task)
@@ -445,14 +489,20 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 self._scheduler.schedule_task(
                     name=t.name,
                     schedule=t.schedule,
-                    task=lambda: t.target(
-                        TaskContext(
-                            task=task,
-                            extractor=self,
-                            cancellation_token=self.cancellation_token.create_child_token(),
-                        )
-                    ),
+                    task=lambda: self._run_task_with_token(t),
                 )
+
+    def _run_task_with_token(self, task: ScheduledTask) -> None:
+        """
+        Create a fresh child cancellation token for a scheduled task run.
+
+        Stores the token in ``_running_task_tokens`` for external cancellation (e.g. a
+        stop_task action), then executes the task. Called by both the scheduler and any
+        future start_task action handler.
+        """
+        child_token = self.cancellation_token.create_child_token()
+        self._running_task_tokens[task.name] = child_token
+        task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
 
     def start(self) -> None:
         """

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -1,0 +1,175 @@
+import time
+from datetime import datetime, timezone
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognite.extractorutils.unstable.core._dto import ActionType, StartupRequest
+from cognite.extractorutils.unstable.core.actions import CustomAction
+from cognite.extractorutils.unstable.core.base import Extractor, FullConfig
+from cognite.extractorutils.unstable.core.tasks import ContinuousTask, ScheduledTask, StartupTask, TaskContext
+
+from .conftest import TestConfig, TestExtractor
+
+
+def _make_extractor(extractor_cls: type[TestExtractor] = TestExtractor) -> TestExtractor:
+    conn = MagicMock()
+    conn.integration.external_id = "test-integration"
+    full_config = FullConfig(
+        connection_config=conn,
+        application_config=TestConfig(parameter_one=1, parameter_two="a"),
+        current_config_revision=1,
+    )
+    return extractor_cls(full_config, MagicMock())
+
+
+def _startup_request(extractor: Extractor) -> StartupRequest:
+    extractor._start_time = datetime.now(tz=timezone.utc)
+    return extractor._get_startup_request()
+
+
+# -- available_actions population --
+
+
+def test_no_scheduled_tasks_no_custom_actions_sends_available_actions_none() -> None:
+    # TestExtractor has one StartupTask; StartupTasks do not produce available_actions entries.
+    extractor = _make_extractor()
+    assert _startup_request(extractor).available_actions is None
+
+
+def test_two_scheduled_tasks_produce_four_available_actions() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="alpha", target=lambda _: None))
+    extractor.add_task(ScheduledTask.from_interval(interval="2h", name="beta", target=lambda _: None))
+    req = _startup_request(extractor)
+    assert req.available_actions is not None
+    assert len(req.available_actions) == 4
+    assert {a.name for a in req.available_actions} == {"Start alpha", "Stop alpha", "Start beta", "Stop beta"}
+
+
+@pytest.mark.parametrize(
+    "action_name,expected_type,expected_task",
+    [
+        ("Start alpha", ActionType.start_task, "alpha"),
+        ("Stop alpha", ActionType.stop_task, "alpha"),
+    ],
+)
+def test_scheduled_task_action_entry_has_correct_type_and_task_ref(
+    action_name: str, expected_type: ActionType, expected_task: str
+) -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="alpha", target=lambda _: None))
+    by_name = {a.name: a for a in _startup_request(extractor).available_actions}
+    assert by_name[action_name].type == expected_type
+    assert by_name[action_name].task == expected_task
+
+
+def test_continuous_and_startup_tasks_do_not_produce_available_actions() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ContinuousTask(name="cont", target=lambda _: None))
+    extractor.add_task(StartupTask(name="init", target=lambda _: None))
+    assert _startup_request(extractor).available_actions is None
+
+
+def test_custom_action_appears_with_correct_type_and_description() -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="flush cache", target=lambda _: None, description="Clears state"))
+    actions = _startup_request(extractor).available_actions
+    assert actions is not None and len(actions) == 1
+    assert actions[0].name == "flush cache"
+    assert actions[0].type == ActionType.custom
+    assert actions[0].description == "Clears state"
+
+
+# -- __init_actions__ hook and add_action --
+
+
+def test_init_actions_hook_called_after_init_tasks() -> None:
+    call_order: list[str] = []
+
+    class _Ext(TestExtractor):
+        def __init_tasks__(self) -> None:
+            call_order.append("tasks")
+
+        def __init_actions__(self) -> None:
+            call_order.append("actions")
+
+    _make_extractor(_Ext)
+    assert call_order == ["tasks", "actions"]
+
+
+def test_add_action_from_init_actions_subclass_hook() -> None:
+    class _Ext(TestExtractor):
+        def __init_tasks__(self) -> None:
+            pass
+
+        def __init_actions__(self) -> None:
+            self.add_action(CustomAction(name="ping", target=lambda _: None))
+
+    extractor = _make_extractor(_Ext)
+    assert len(extractor._custom_actions) == 1
+    assert extractor._custom_actions[0].name == "ping"
+
+
+def test_multiple_add_action_calls_accumulate_in_registration_order() -> None:
+    extractor = _make_extractor()
+    for name in ("a1", "a2", "a3"):
+        extractor.add_action(CustomAction(name=name, target=lambda _: None))
+    assert [a.name for a in extractor._custom_actions] == ["a1", "a2", "a3"]
+
+
+# -- _running_task_tokens lifecycle --
+
+
+def test_token_present_in_running_task_tokens_during_execution() -> None:
+    extractor = _make_extractor()
+    token_present: list[bool] = []
+    task_running = Event()
+    allow_finish = Event()
+
+    def target(_: TaskContext) -> None:
+        task_running.set()
+        token_present.append("the-task" in extractor._running_task_tokens)
+        allow_finish.wait(timeout=5)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    task_running.wait(timeout=5)
+    allow_finish.set()
+
+    assert token_present == [True]
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool) -> None:
+    extractor = _make_extractor()
+    done = Event()
+
+    def target(_: TaskContext) -> None:
+        done.set()
+        if raises:
+            raise RuntimeError("intentional")
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+    time.sleep(0.05)  # allow the finally block to execute after task body returns
+    assert "the-task" not in extractor._running_task_tokens
+
+
+def test_scheduled_task_token_is_child_of_extractor_cancellation_token() -> None:
+    extractor = _make_extractor()
+    captured: list = []
+    done = Event()
+
+    def target(_: TaskContext) -> None:
+        captured.append(extractor._running_task_tokens.get("the-task"))
+        done.set()
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+
+    assert len(captured) == 1 and captured[0] is not None
+    assert captured[0]._parent is extractor.cancellation_token

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -153,17 +153,20 @@ def test_token_present_in_running_task_tokens_during_execution() -> None:
     extractor = _make_extractor()
     token_present: list[bool] = []
     task_running = Event()
+    appended = Event()
     allow_finish = Event()
 
     def target(_: TaskContext) -> None:
         task_running.set()
         token_present.append("the-task" in extractor._running_task_tokens)
+        appended.set()
         allow_finish.wait(timeout=5)
 
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     task_running.wait(timeout=5)
     allow_finish.set()
+    appended.wait(timeout=5)
 
     assert token_present == [True]
 
@@ -181,7 +184,9 @@ def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     done.wait(timeout=5)
-    time.sleep(0.05)  # allow the finally block to execute after task body returns
+    deadline = time.monotonic() + 5
+    while "the-task" in extractor._running_task_tokens and time.monotonic() < deadline:
+        time.sleep(0.005)
     assert "the-task" not in extractor._running_task_tokens
 
 
@@ -198,7 +203,9 @@ def test_token_cleanup_does_not_clobber_replacement_token() -> None:
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     done.wait(timeout=5)
-    time.sleep(0.05)  # allow _run_task_with_token's finally to run
+    deadline = time.monotonic() + 5
+    while any(j.name == "the-task" for j in extractor._scheduler._running) and time.monotonic() < deadline:
+        time.sleep(0.005)
 
     # Identity check must preserve the replacement — the old blind pop would remove it
     assert extractor._running_task_tokens.get("the-task") is replacement

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -72,6 +72,18 @@ def test_continuous_and_startup_tasks_do_not_produce_available_actions() -> None
     assert _startup_request(extractor).available_actions is None
 
 
+def test_scheduled_and_custom_actions_combined_ordering() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+    extractor.add_action(CustomAction(name="flush", target=lambda _: None))
+    req = _startup_request(extractor)
+    assert req.available_actions is not None
+    assert len(req.available_actions) == 3
+    # Scheduled task entries appear before custom actions
+    names = [a.name for a in req.available_actions]
+    assert names == ["Start sync", "Stop sync", "flush"]
+
+
 def test_custom_action_appears_with_correct_type_and_description() -> None:
     extractor = _make_extractor()
     extractor.add_action(CustomAction(name="flush cache", target=lambda _: None, description="Clears state"))
@@ -156,6 +168,25 @@ def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool
     done.wait(timeout=5)
     time.sleep(0.05)  # allow the finally block to execute after task body returns
     assert "the-task" not in extractor._running_task_tokens
+
+
+def test_token_cleanup_does_not_clobber_replacement_token() -> None:
+    extractor = _make_extractor()
+    done = Event()
+    replacement = extractor.cancellation_token.create_child_token()
+
+    def target(_: TaskContext) -> None:
+        # Simulate a subsequent invocation overwriting the entry before this run finishes
+        extractor._running_task_tokens["the-task"] = replacement
+        done.set()
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+    time.sleep(0.05)  # allow _run_task_with_token's finally to run
+
+    # Identity check must preserve the replacement — the old blind pop would remove it
+    assert extractor._running_task_tokens.get("the-task") is replacement
 
 
 def test_scheduled_task_token_is_child_of_extractor_cancellation_token() -> None:

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -131,6 +131,21 @@ def test_multiple_add_action_calls_accumulate_in_registration_order() -> None:
     assert [a.name for a in extractor._custom_actions] == ["a1", "a2", "a3"]
 
 
+def test_add_action_raises_on_duplicate_name() -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="ping", target=lambda _: None))
+    with pytest.raises(ValueError, match="ping"):
+        extractor.add_action(CustomAction(name="ping", target=lambda _: None))
+
+
+@pytest.mark.parametrize("conflicting_name", ["Start sync", "Stop sync"])
+def test_add_action_raises_on_conflict_with_scheduled_task_action_name(conflicting_name: str) -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+    with pytest.raises(ValueError, match=conflicting_name):
+        extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
+
+
 # -- _running_task_tokens lifecycle --
 
 


### PR DESCRIPTION
### PR Short Summary
- Adds the public API for registering custom actions (add_action / __init_actions__) and updates _get_startup_request to announce the extractor's capabilities to Odin on startup via available_actions.

### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

### What changed
cognite/extractorutils/unstable/core/base.py
- New _custom_actions / _running_task_tokens instance attributes
- __init_actions__() hook (called after __init_tasks__()) for subclasses to register custom actions via add_action()
- _run_task_with_token() — single entry point for task execution; creates a child cancellation token, stores it in _running_task_tokens, runs the task, then cleans up in finally
- _get_startup_request() now populates available_actions: start_task + stop_task per ScheduledTask, one custom entry per registered action; None if empty

tests/test_unstable/test_action_registration.py — new test file covering all acceptance criteria

### Why it changed
-Odin needs extractors to declare available actions in the startup request so the UI can surface them.

### What to focus on during review
- _run_task_with_token: verify the store → run → pop flow, especially the identity check in finally that prevents clobbering a concurrent run's token
- add_action now validates against duplicate names and conflicts with auto-generated "Start/Stop {task}" names

### Test evidence
tests/test_unstable/test_action_registration.py  13 passed
tests/test_unstable/test_task_context.py          3 passed
tests/test_unstable/test_actions.py              10 passed
ruff check — All checks passed

### Risks and unknowns
- "Start {t.name}" / "Stop {t.name}" action name format is hardcoded here — if Odin changes its convention the names will drift. Should be defined as a constant or validated against the server contract when that lands.

### Rollout and rollback
- N/A — purely additive. Extractors that don't override __init_actions__ behave identically to before.

### Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated
- [x] Docs updated (N/A — internal framework, no public docs affected)
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams (none)