### PR TITLE
feat(odin): Execute incoming actions from Odin

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -85,7 +85,10 @@ from cognite.extractorutils.unstable.configuration.models import (
     create_state_store,
 )
 from cognite.extractorutils.unstable.core._dto import (
+    Action,
+    ActionStatus,
     ActionType,
+    ActionUpdate,
     AvailableActionWrite,
     CogniteModel,
     ExtractorInfo,
@@ -96,7 +99,7 @@ from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
 )
 from cognite.extractorutils.unstable.core._messaging import RuntimeMessage
-from cognite.extractorutils.unstable.core.actions import CustomAction
+from cognite.extractorutils.unstable.core.actions import ActionContext, CustomAction
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.logger import CogniteLogger, RobustFileHandler
@@ -524,6 +527,136 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 if self._running_task_tokens.get(task.name) is child_token:
                     self._running_task_tokens.pop(task.name, None)
 
+    def _handle_actions(self, actions: list[Action]) -> None:
+        for action in actions:
+            Thread(
+                target=self._dispatch_single_action,
+                args=(action,),
+                name=f"Action-{action.external_id}",
+                daemon=True,
+            ).start()
+
+    def _dispatch_single_action(self, action: Action) -> None:
+        scheduled_start_names = {f"Start {t.name}" for t in self._tasks if isinstance(t, ScheduledTask)}
+        scheduled_stop_names = {f"Stop {t.name}" for t in self._tasks if isinstance(t, ScheduledTask)}
+        custom_names = {a.name for a in self._custom_actions}
+
+        if action.action_name in scheduled_start_names:
+            self._handle_start_task_action(action)
+        elif action.action_name in scheduled_stop_names:
+            self._handle_stop_task_action(action)
+        elif action.action_name in custom_names:
+            self._handle_custom_action(action)
+        else:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=f"No action named '{action.action_name}' registered",
+                )
+            )
+
+    def _handle_start_task_action(self, action: Action) -> None:
+        task_name = action.action_name[len("Start ") :]
+        task = next(
+            (t for t in self._tasks if t.name == task_name and isinstance(t, ScheduledTask)),
+            None,
+        )
+        if task is None:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=f"No scheduled task named '{task_name}' found",
+                )
+            )
+            return
+
+        with self._running_task_tokens_lock:
+            if task_name in self._running_task_tokens:
+                self._checkin_worker.queue_action_update(
+                    ActionUpdate(
+                        external_id=action.external_id,
+                        status=ActionStatus.failed,
+                        result_message=f"Task '{task_name}' is already running",
+                    )
+                )
+                return
+
+        self._checkin_worker.queue_action_update(
+            ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
+        )
+
+        try:
+            self._run_task_with_token(task)
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(external_id=action.external_id, status=ActionStatus.succeeded)
+            )
+        except Exception as e:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=str(e),
+                )
+            )
+
+    def _handle_stop_task_action(self, action: Action) -> None:
+        task_name = action.action_name[len("Stop ") :]
+        with self._running_task_tokens_lock:
+            token = self._running_task_tokens.get(task_name)
+        if token is None:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=f"Task '{task_name}' is not currently running",
+                )
+            )
+            return
+
+        token.cancel()
+        self._checkin_worker.queue_action_update(
+            ActionUpdate(external_id=action.external_id, status=ActionStatus.canceled)
+        )
+
+    def _handle_custom_action(self, action: Action) -> None:
+        custom = next((a for a in self._custom_actions if a.name == action.action_name), None)
+        if custom is None:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=f"No custom action named '{action.action_name}' registered",
+                )
+            )
+            return
+
+        self._checkin_worker.queue_action_update(
+            ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
+        )
+
+        ctx = ActionContext(
+            action=custom,
+            extractor=self,
+            external_id=action.external_id,
+            call_metadata=action.call_metadata,
+        )
+
+        try:
+            custom.target(ctx)
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(external_id=action.external_id, status=ActionStatus.succeeded)
+            )
+        except Exception as e:
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(
+                    external_id=action.external_id,
+                    status=ActionStatus.failed,
+                    result_message=str(e),
+                )
+            )
+
     def start(self) -> None:
         """
         Start the extractor.
@@ -536,6 +669,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         self._load_state_store()
         self.state_store.start()
+
+        self._checkin_worker.set_action_dispatcher(self._handle_actions)
 
         Thread(target=self._run_checkin, name="ExtractorCheckin", daemon=True).start()
         if self.metrics_push_manager:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -516,9 +516,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
-        except Exception:
-            self._logger.exception(f"Task '{task.name}' raised an unhandled exception")
-            raise
         finally:
             with self._running_task_tokens_lock:
                 if self._running_task_tokens.get(task.name) is child_token:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -533,8 +533,11 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         registration step and goes straight to execution.
         """
         if child_token is None:
-            child_token = self.cancellation_token.create_child_token()
             with self._running_task_tokens_lock:
+                if task.name in self._running_task_tokens:
+                    self._logger.warning("Task '%s' is already running, skipping scheduled run.", task.name)
+                    return
+                child_token = self.cancellation_token.create_child_token()
                 self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
@@ -607,9 +610,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         try:
             self._run_task_with_token(task, child_token)
-            self._checkin_worker.queue_action_update(
-                ActionUpdate(external_id=action.external_id, status=ActionStatus.succeeded)
-            )
+            status = ActionStatus.canceled if child_token.is_cancelled else ActionStatus.succeeded
+            self._checkin_worker.queue_action_update(ActionUpdate(external_id=action.external_id, status=status))
         except Exception as e:
             self._checkin_worker.queue_action_update(
                 ActionUpdate(

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -466,6 +466,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         if any(t.name == task.name for t in self._tasks):
             raise ValueError(f"Task '{task.name}' is already registered.")
 
+        if isinstance(task, ScheduledTask):
+            conflict_names = {f"Start {task.name}", f"Stop {task.name}"}
+            for action in self._custom_actions:
+                if action.name in conflict_names:
+                    raise ValueError(
+                        f"Task name '{task.name}' would conflict with existing custom action '{action.name}'."
+                    )
+
         # Store this for later, since we'll override it with the wrapped version
         target = task.target
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -190,6 +190,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._tasks: list[Task] = []
         self._custom_actions: list[CustomAction] = []
         self._running_task_tokens: dict[str, CancellationToken] = {}
+        self._running_task_tokens_lock = RLock()
         self._start_time: datetime
 
         self.metrics: BaseMetrics = self._load_metrics(config.metrics_class)
@@ -359,6 +360,17 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         Args:
             action: The custom action to register.
         """
+        if any(a.name == action.name for a in self._custom_actions):
+            raise ValueError(f"Custom action '{action.name}' is already registered.")
+
+        reserved_names = {
+            name for t in self._tasks if isinstance(t, ScheduledTask) for name in (f"Start {t.name}", f"Stop {t.name}")
+        }
+        if action.name in reserved_names:
+            raise ValueError(
+                f"Custom action name '{action.name}' conflicts with an auto-generated scheduled task action."
+            )
+
         self._custom_actions.append(action)
 
     def _set_runtime_message_queue(self, queue: Queue) -> None:
@@ -500,13 +512,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         future start_task action handler.
         """
         child_token = self.cancellation_token.create_child_token()
-        self._running_task_tokens[task.name] = child_token
+        with self._running_task_tokens_lock:
+            self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
         finally:
-            # Only remove our token; a concurrent run may have already replaced it
-            if self._running_task_tokens.get(task.name) is child_token:
-                self._running_task_tokens.pop(task.name, None)
+            with self._running_task_tokens_lock:
+                if self._running_task_tokens.get(task.name) is child_token:
+                    self._running_task_tokens.pop(task.name, None)
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -469,6 +469,17 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         if any(t.name == task.name for t in self._tasks):
             raise ValueError(f"Task '{task.name}' is already registered.")
 
+        if isinstance(task, ScheduledTask):
+            conflicting = next(
+                (a for a in self._custom_actions if a.name in (f"Start {task.name}", f"Stop {task.name}")),
+                None,
+            )
+            if conflicting:
+                raise ValueError(
+                    f"Scheduled task '{task.name}' auto-generated action name "
+                    f"conflicts with custom action '{conflicting.name}'."
+                )
+
         # Store this for later, since we'll override it with the wrapped version
         target = task.target
 
@@ -509,17 +520,22 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     task=lambda: self._run_task_with_token(t),
                 )
 
-    def _run_task_with_token(self, task: ScheduledTask) -> None:
+    def _run_task_with_token(self, task: ScheduledTask, child_token: CancellationToken | None = None) -> None:
         """
         Create a fresh child cancellation token for a scheduled task run.
 
         Stores the token in ``_running_task_tokens`` for external cancellation (e.g. a
         stop_task action), then executes the task. Called by both the scheduler and any
         future start_task action handler.
+
+        If ``child_token`` is supplied (action dispatch path), the caller has already
+        registered it in ``_running_task_tokens`` atomically; this method skips the
+        registration step and goes straight to execution.
         """
-        child_token = self.cancellation_token.create_child_token()
-        with self._running_task_tokens_lock:
-            self._running_task_tokens[task.name] = child_token
+        if child_token is None:
+            child_token = self.cancellation_token.create_child_token()
+            with self._running_task_tokens_lock:
+                self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
         finally:
@@ -572,6 +588,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             )
             return
 
+        child_token = self.cancellation_token.create_child_token()
         with self._running_task_tokens_lock:
             if task_name in self._running_task_tokens:
                 self._checkin_worker.queue_action_update(
@@ -582,13 +599,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     )
                 )
                 return
+            self._running_task_tokens[task_name] = child_token
 
         self._checkin_worker.queue_action_update(
             ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
         )
 
         try:
-            self._run_task_with_token(task)
+            self._run_task_with_token(task, child_token)
             self._checkin_worker.queue_action_update(
                 ActionUpdate(external_id=action.external_id, status=ActionStatus.succeeded)
             )

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -477,9 +477,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     self.restart()
 
             finally:
-                # Record task end and clear any per-run cancellation token
+                # Record task end
                 self._checkin_worker.report_task_end(name=task.name, timestamp=now())
-                self._running_task_tokens.pop(task.name, None)
 
         task.target = run_task
         self._tasks.append(task)
@@ -502,7 +501,12 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         """
         child_token = self.cancellation_token.create_child_token()
         self._running_task_tokens[task.name] = child_token
-        task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        try:
+            task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        finally:
+            # Only remove our token; a concurrent run may have already replaced it
+            if self._running_task_tokens.get(task.name) is child_token:
+                self._running_task_tokens.pop(task.name, None)
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -516,6 +516,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             self._running_task_tokens[task.name] = child_token
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
+        except Exception:
+            self._logger.exception(f"Task '{task.name}' raised an unhandled exception")
+            raise
         finally:
             with self._running_task_tokens_lock:
                 if self._running_task_tokens.get(task.name) is child_token:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -463,6 +463,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         Args:
             task: The task to add. It should be an instance of ``StartupTask``, ``ContinuousTask``, or ``ScheduledTask``
         """
+        if any(t.name == task.name for t in self._tasks):
+            raise ValueError(f"Task '{task.name}' is already registered.")
+
         # Store this for later, since we'll override it with the wrapped version
         target = task.target
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -85,6 +85,8 @@ from cognite.extractorutils.unstable.configuration.models import (
     create_state_store,
 )
 from cognite.extractorutils.unstable.core._dto import (
+    ActionType,
+    AvailableActionWrite,
     CogniteModel,
     ExtractorInfo,
     StartupRequest,
@@ -94,6 +96,7 @@ from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
 )
 from cognite.extractorutils.unstable.core._messaging import RuntimeMessage
+from cognite.extractorutils.unstable.core.actions import CustomAction
 from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.unstable.core.logger import CogniteLogger, RobustFileHandler
@@ -106,6 +109,7 @@ __all__ = [
     "CogniteModel",
     "ConfigRevision",
     "ConfigType",
+    "CustomAction",
     "Extractor",
 ]
 
@@ -184,6 +188,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._scheduler = TaskScheduler(self.cancellation_token.create_child_token())
 
         self._tasks: list[Task] = []
+        self._custom_actions: list[CustomAction] = []
+        self._running_task_tokens: dict[str, CancellationToken] = {}
         self._start_time: datetime
 
         self.metrics: BaseMetrics = self._load_metrics(config.metrics_class)
@@ -195,6 +201,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         )
 
         self.__init_tasks__()
+        self.__init_actions__()
 
     def _setup_cancellation_watcher(self, cancel_event: MpEvent) -> None:
         """Starts a daemon thread to watch the inter-process event."""
@@ -335,6 +342,25 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         """
         pass
 
+    def __init_actions__(self) -> None:
+        """
+        This method should be overridden by subclasses to register custom actions.
+
+        It is called automatically after ``__init_tasks__`` during initialization.
+
+        Subclasses should call ``self.add_action(...)`` to register custom actions.
+        """
+        pass
+
+    def add_action(self, action: CustomAction) -> None:
+        """
+        Register a custom action that Odin can invoke on this extractor.
+
+        Args:
+            action: The custom action to register.
+        """
+        self._custom_actions.append(action)
+
     def _set_runtime_message_queue(self, queue: Queue) -> None:
         self._runtime_messages = queue
 
@@ -343,6 +369,22 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._setup_cancellation_watcher(cancel_event)
 
     def _get_startup_request(self) -> StartupRequest:
+        available_actions: list[AvailableActionWrite] = []
+
+        for t in self._tasks:
+            if isinstance(t, ScheduledTask):
+                available_actions.append(
+                    AvailableActionWrite(name=f"Start {t.name}", type=ActionType.start_task, task=t.name)
+                )
+                available_actions.append(
+                    AvailableActionWrite(name=f"Stop {t.name}", type=ActionType.stop_task, task=t.name)
+                )
+
+        available_actions.extend(
+            AvailableActionWrite(name=a.name, type=ActionType.custom, description=a.description)
+            for a in self._custom_actions
+        )
+
         return StartupRequest(
             external_id=self.connection_config.integration.external_id,
             active_config_revision=self.current_config_revision,
@@ -358,6 +400,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             ]
             if len(self._tasks) > 0
             else None,
+            available_actions=available_actions or None,
             timestamp=int(self._start_time.timestamp() * 1000),
         )
 
@@ -434,8 +477,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     self.restart()
 
             finally:
-                # Record task end
+                # Record task end and clear any per-run cancellation token
                 self._checkin_worker.report_task_end(name=task.name, timestamp=now())
+                self._running_task_tokens.pop(task.name, None)
 
         task.target = run_task
         self._tasks.append(task)
@@ -445,14 +489,20 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 self._scheduler.schedule_task(
                     name=t.name,
                     schedule=t.schedule,
-                    task=lambda: t.target(
-                        TaskContext(
-                            task=task,
-                            extractor=self,
-                            cancellation_token=self.cancellation_token.create_child_token(),
-                        )
-                    ),
+                    task=lambda: self._run_task_with_token(t),
                 )
+
+    def _run_task_with_token(self, task: ScheduledTask) -> None:
+        """
+        Create a fresh child cancellation token for a scheduled task run.
+
+        Stores the token in ``_running_task_tokens`` for external cancellation (e.g. a
+        stop_task action), then executes the task. Called by both the scheduler and any
+        future start_task action handler.
+        """
+        child_token = self.cancellation_token.create_child_token()
+        self._running_task_tokens[task.name] = child_token
+        task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -625,6 +625,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         task_name = action.action_name[len("Stop ") :]
         with self._running_task_tokens_lock:
             token = self._running_task_tokens.get(task_name)
+            if token is not None:
+                token.cancel()
+
         if token is None:
             self._checkin_worker.queue_action_update(
                 ActionUpdate(
@@ -635,7 +638,6 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             )
             return
 
-        token.cancel()
         self._checkin_worker.queue_action_update(
             ActionUpdate(external_id=action.external_id, status=ActionStatus.canceled)
         )

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -1,11 +1,3 @@
-"""Tests for Extractor action dispatch wiring (Task 6).
-
-Covers _handle_actions, _dispatch_single_action, and the three handler methods,
-plus the start() wiring that registers the dispatcher with CheckinWorker.
-
-All tests use a MagicMock checkin worker to avoid real API calls.
-"""
-
 import threading
 from threading import Event
 from unittest.mock import MagicMock
@@ -16,10 +8,6 @@ from cognite.extractorutils.unstable.core.base import FullConfig
 from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
 
 from .conftest import TestConfig, TestExtractor
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_extractor(extractor_cls: type[TestExtractor] = TestExtractor) -> TestExtractor:
@@ -34,7 +22,6 @@ def _make_extractor(extractor_cls: type[TestExtractor] = TestExtractor) -> TestE
 
 
 def _queued_updates(extractor: TestExtractor) -> list[ActionUpdate]:
-    """Return all ActionUpdate objects passed to queue_action_update, in call order."""
     return [c[0][0] for c in extractor._checkin_worker.queue_action_update.call_args_list]
 
 
@@ -42,13 +29,7 @@ def _make_action(external_id: str, action_name: str) -> Action:
     return Action(external_id=external_id, action_name=action_name, status=ActionStatus.pending)
 
 
-# ---------------------------------------------------------------------------
-# _dispatch_single_action - routing & unknown-action handling
-# ---------------------------------------------------------------------------
-
-
 def test_dispatch_unrecognised_action_name_reports_failed() -> None:
-    """An action name that matches nothing registered is reported as failed with a descriptive message."""
     extractor = _make_extractor()
     extractor._dispatch_single_action(_make_action("act-1", "DoesNotExist"))
 
@@ -59,19 +40,16 @@ def test_dispatch_unrecognised_action_name_reports_failed() -> None:
 
 
 def test_dispatch_routes_to_start_handler_for_registered_scheduled_task() -> None:
-    """'Start <task>' where <task> is a ScheduledTask routes to the start handler."""
     extractor = _make_extractor()
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
 
     extractor._dispatch_single_action(_make_action("act-1", "Start sync"))
 
     updates = _queued_updates(extractor)
-    # running status means the start handler was reached (not the "unrecognised" path)
     assert any(u.status == ActionStatus.running for u in updates)
 
 
 def test_dispatch_routes_to_custom_handler_for_registered_custom_action() -> None:
-    """A registered custom action name routes to the custom handler."""
     extractor = _make_extractor()
     invoked = []
     extractor.add_action(CustomAction(name="flush", target=lambda ctx: invoked.append(True)))
@@ -83,13 +61,7 @@ def test_dispatch_routes_to_custom_handler_for_registered_custom_action() -> Non
     assert any(u.status == ActionStatus.succeeded for u in updates)
 
 
-# ---------------------------------------------------------------------------
-# _handle_start_task_action
-# ---------------------------------------------------------------------------
-
-
 def test_start_task_action_already_running_reports_failed() -> None:
-    """If the task is already in _running_task_tokens, the action fails without starting a second instance."""
     extractor = _make_extractor()
     task_started = Event()
     allow_finish = Event()
@@ -102,7 +74,6 @@ def test_start_task_action_already_running_reports_failed() -> None:
     extractor._scheduler.trigger("worker")
     task_started.wait(timeout=5)
 
-    # Task is now running; attempt a second start via action
     extractor._dispatch_single_action(_make_action("act-dup", "Start worker"))
 
     allow_finish.set()
@@ -112,7 +83,6 @@ def test_start_task_action_already_running_reports_failed() -> None:
 
 
 def test_start_task_action_valid_idle_task_reports_running_then_succeeded() -> None:
-    """A valid, idle ScheduledTask reports running before execution and succeeded after."""
     extractor = _make_extractor()
     ran = []
 
@@ -120,7 +90,6 @@ def test_start_task_action_valid_idle_task_reports_running_then_succeeded() -> N
         ran.append(True)
 
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="quick", target=quick))
-    # _dispatch_single_action is synchronous for start_task (blocks until task completes)
     extractor._dispatch_single_action(_make_action("act-1", "Start quick"))
 
     assert ran == [True]
@@ -131,13 +100,7 @@ def test_start_task_action_valid_idle_task_reports_running_then_succeeded() -> N
     assert statuses.index(ActionStatus.running) < statuses.index(ActionStatus.succeeded)
 
 
-# ---------------------------------------------------------------------------
-# _handle_stop_task_action
-# ---------------------------------------------------------------------------
-
-
 def test_stop_task_action_not_running_reports_failed() -> None:
-    """Stopping a task that is not in _running_task_tokens reports failed."""
     extractor = _make_extractor()
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=lambda _: None))
 
@@ -150,7 +113,6 @@ def test_stop_task_action_not_running_reports_failed() -> None:
 
 
 def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
-    """Stopping a running task cancels its child token and reports ActionStatus.canceled."""
     extractor = _make_extractor()
     task_started = Event()
     allow_exit = Event()
@@ -163,7 +125,6 @@ def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
     extractor._scheduler.trigger("worker")
     task_started.wait(timeout=5)
 
-    # Snapshot the token before issuing stop
     with extractor._running_task_tokens_lock:
         token = extractor._running_task_tokens.get("worker")
 
@@ -176,13 +137,7 @@ def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
     allow_exit.set()
 
 
-# ---------------------------------------------------------------------------
-# _handle_custom_action
-# ---------------------------------------------------------------------------
-
-
 def test_custom_action_succeeds_reports_running_then_succeeded() -> None:
-    """A custom action that completes without exception is reported as running → succeeded."""
     extractor = _make_extractor()
     extractor.add_action(CustomAction(name="ping", target=lambda ctx: None))
 
@@ -194,8 +149,6 @@ def test_custom_action_succeeds_reports_running_then_succeeded() -> None:
 
 
 def test_custom_action_raises_reports_failed_with_message() -> None:
-    """A custom action that raises is reported as failed with the exception message."""
-
     def bad_action(ctx: ActionContext) -> None:
         raise ValueError("something went wrong")
 
@@ -213,7 +166,6 @@ def test_custom_action_raises_reports_failed_with_message() -> None:
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:
-    """call_metadata from the server-side Action is forwarded to ActionContext."""
     received_metadata: list[dict | None] = []
 
     def capture(ctx: ActionContext) -> None:
@@ -233,13 +185,7 @@ def test_custom_action_receives_call_metadata_in_context() -> None:
     assert received_metadata == [{"key": "value"}]
 
 
-# ---------------------------------------------------------------------------
-# _handle_actions - threading
-# ---------------------------------------------------------------------------
-
-
 def test_handle_actions_spawns_daemon_thread_named_after_external_id() -> None:
-    """Each action in _handle_actions runs on a daemon thread named 'Action-<external_id>'."""
     extractor = _make_extractor()
     captured: dict = {}
     done = Event()
@@ -259,7 +205,6 @@ def test_handle_actions_spawns_daemon_thread_named_after_external_id() -> None:
 
 
 def test_handle_actions_multiple_actions_run_concurrently() -> None:
-    """Two actions are dispatched to separate threads; they overlap in time."""
     extractor = _make_extractor()
     a1_started = Event()
     a2_started = Event()
@@ -282,26 +227,18 @@ def test_handle_actions_multiple_actions_run_concurrently() -> None:
         ]
     )
 
-    # Both must start before either finishes — proves concurrent execution
     assert a1_started.wait(timeout=5), "op-1 never started"
     assert a2_started.wait(timeout=5), "op-2 never started"
 
     release.set()
 
 
-# ---------------------------------------------------------------------------
-# start() wiring
-# ---------------------------------------------------------------------------
-
-
 def test_start_registers_handle_actions_as_dispatcher() -> None:
-    """start() calls set_action_dispatcher exactly once with _handle_actions."""
     extractor = _make_extractor()
     with extractor:
         pass
 
     extractor._checkin_worker.set_action_dispatcher.assert_called_once()
     registered = extractor._checkin_worker.set_action_dispatcher.call_args[0][0]
-    # Verify the registered callable IS the bound _handle_actions method
     assert registered.__func__.__name__ == "_handle_actions"
     assert registered.__self__ is extractor

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -161,7 +161,7 @@ def test_start_task_action_raises_reports_failed() -> None:
 
     original = extractor._run_task_with_token
 
-    def raise_on_call(task: ScheduledTask) -> None:
+    def raise_on_call(task: ScheduledTask, *args: object, **kwargs: object) -> None:
         raise RuntimeError("token failure")
 
     extractor._run_task_with_token = raise_on_call
@@ -322,10 +322,12 @@ def test_handle_actions_multiple_actions_run_concurrently() -> None:
     extractor.add_action(CustomAction(name="op-1", target=slow))
     extractor.add_action(CustomAction(name="op-2", target=slow))
 
-    extractor._handle_actions([
-        _make_action("act-1", "op-1"),
-        _make_action("act-2", "op-2"),
-    ])
+    extractor._handle_actions(
+        [
+            _make_action("act-1", "op-1"),
+            _make_action("act-2", "op-2"),
+        ]
+    )
 
     # Both must start before either finishes — proves concurrent execution
     assert a1_started.wait(timeout=5), "op-1 never started"

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -58,16 +58,6 @@ def test_dispatch_unrecognised_action_name_reports_failed() -> None:
     assert "DoesNotExist" in (updates[0].result_message or "")
 
 
-def test_dispatch_start_prefix_for_unregistered_task_reports_failed() -> None:
-    """'Start foo' where 'foo' is not a ScheduledTask is treated as an unrecognised action."""
-    extractor = _make_extractor()
-    extractor._dispatch_single_action(_make_action("act-1", "Start unregistered-task"))
-
-    updates = _queued_updates(extractor)
-    assert len(updates) == 1
-    assert updates[0].status == ActionStatus.failed
-
-
 def test_dispatch_routes_to_start_handler_for_registered_scheduled_task() -> None:
     """'Start <task>' where <task> is a ScheduledTask routes to the start handler."""
     extractor = _make_extractor()
@@ -78,19 +68,6 @@ def test_dispatch_routes_to_start_handler_for_registered_scheduled_task() -> Non
     updates = _queued_updates(extractor)
     # running status means the start handler was reached (not the "unrecognised" path)
     assert any(u.status == ActionStatus.running for u in updates)
-
-
-def test_dispatch_routes_to_stop_handler_for_registered_scheduled_task() -> None:
-    """'Stop <task>' routes to the stop handler; task not currently running → failed."""
-    extractor = _make_extractor()
-    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
-
-    extractor._dispatch_single_action(_make_action("act-1", "Stop sync"))
-
-    updates = _queued_updates(extractor)
-    assert len(updates) == 1
-    assert updates[0].status == ActionStatus.failed
-    assert "not currently running" in (updates[0].result_message or "")
 
 
 def test_dispatch_routes_to_custom_handler_for_registered_custom_action() -> None:
@@ -152,30 +129,6 @@ def test_start_task_action_valid_idle_task_reports_running_then_succeeded() -> N
     assert ActionStatus.running in statuses
     assert ActionStatus.succeeded in statuses
     assert statuses.index(ActionStatus.running) < statuses.index(ActionStatus.succeeded)
-
-
-def test_start_task_action_raises_reports_failed() -> None:
-    """If _run_task_with_token itself raises (e.g. child token creation fails), failed is reported."""
-    extractor = _make_extractor()
-    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="boom", target=lambda _: None))
-
-    original = extractor._run_task_with_token
-
-    def raise_on_call(task: ScheduledTask, *args: object, **kwargs: object) -> None:
-        raise RuntimeError("token failure")
-
-    extractor._run_task_with_token = raise_on_call
-
-    extractor._dispatch_single_action(_make_action("act-err", "Start boom"))
-
-    updates = _queued_updates(extractor)
-    statuses = [u.status for u in updates if u.external_id == "act-err"]
-    assert ActionStatus.running in statuses
-    assert ActionStatus.failed in statuses
-    failed = next(u for u in updates if u.status == ActionStatus.failed and u.external_id == "act-err")
-    assert "token failure" in (failed.result_message or "")
-
-    extractor._run_task_with_token = original
 
 
 # ---------------------------------------------------------------------------
@@ -352,34 +305,3 @@ def test_start_registers_handle_actions_as_dispatcher() -> None:
     # Verify the registered callable IS the bound _handle_actions method
     assert registered.__func__.__name__ == "_handle_actions"
     assert registered.__self__ is extractor
-
-
-def test_dispatcher_registered_before_checkin_thread_starts() -> None:
-    """set_action_dispatcher is called before the checkin thread is spawned in start()."""
-    call_order: list[str] = []
-
-    class _TrackingWorker:
-        def set_action_dispatcher(self, fn: object) -> None:
-            call_order.append("set_dispatcher")
-
-        def run_periodic_checkin(self, *args: object, **kwargs: object) -> None:
-            pass
-
-    extractor = _make_extractor()
-    extractor._checkin_worker = _TrackingWorker()  # type: ignore[assignment]
-
-    original_thread_start = threading.Thread.start
-
-    def tracking_start(self: threading.Thread) -> None:
-        if self.name == "ExtractorCheckin":
-            call_order.append("checkin_thread")
-        original_thread_start(self)
-
-    threading.Thread.start = tracking_start  # type: ignore[method-assign]
-    try:
-        extractor.start()
-    finally:
-        threading.Thread.start = original_thread_start  # type: ignore[method-assign]
-        extractor.stop()
-
-    assert call_order.index("set_dispatcher") < call_order.index("checkin_thread")

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -1,6 +1,9 @@
 import threading
+from collections.abc import Callable
 from threading import Event
 from unittest.mock import MagicMock
+
+import pytest
 
 from cognite.extractorutils.unstable.core._dto import Action, ActionStatus, ActionUpdate
 from cognite.extractorutils.unstable.core.actions import ActionContext, CustomAction
@@ -39,26 +42,30 @@ def test_dispatch_unrecognised_action_name_reports_failed() -> None:
     assert "DoesNotExist" in (updates[0].result_message or "")
 
 
-def test_dispatch_routes_to_start_handler_for_registered_scheduled_task() -> None:
+@pytest.mark.parametrize(
+    "register,action_name,expected_status",
+    [
+        pytest.param(
+            lambda ext: ext.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None)),
+            "Start sync",
+            ActionStatus.running,
+            id="start_task",
+        ),
+        pytest.param(
+            lambda ext: ext.add_action(CustomAction(name="flush", target=lambda ctx: None)),
+            "flush",
+            ActionStatus.succeeded,
+            id="custom_action",
+        ),
+    ],
+)
+def test_dispatch_routes_to_correct_handler(
+    register: Callable, action_name: str, expected_status: ActionStatus
+) -> None:
     extractor = _make_extractor()
-    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
-
-    extractor._dispatch_single_action(_make_action("act-1", "Start sync"))
-
-    updates = _queued_updates(extractor)
-    assert any(u.status == ActionStatus.running for u in updates)
-
-
-def test_dispatch_routes_to_custom_handler_for_registered_custom_action() -> None:
-    extractor = _make_extractor()
-    invoked = []
-    extractor.add_action(CustomAction(name="flush", target=lambda ctx: invoked.append(True)))
-
-    extractor._dispatch_single_action(_make_action("act-1", "flush"))
-
-    assert invoked == [True]
-    updates = _queued_updates(extractor)
-    assert any(u.status == ActionStatus.succeeded for u in updates)
+    register(extractor)
+    extractor._dispatch_single_action(_make_action("act-1", action_name))
+    assert any(u.status == expected_status for u in _queued_updates(extractor))
 
 
 def test_start_task_action_already_running_reports_failed() -> None:
@@ -137,32 +144,30 @@ def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
     allow_exit.set()
 
 
-def test_custom_action_succeeds_reports_running_then_succeeded() -> None:
-    extractor = _make_extractor()
-    extractor.add_action(CustomAction(name="ping", target=lambda ctx: None))
+@pytest.mark.parametrize(
+    "raises,expected_final,expected_message",
+    [
+        (False, ActionStatus.succeeded, None),
+        (True, ActionStatus.failed, "something went wrong"),
+    ],
+)
+def test_custom_action_status_lifecycle(
+    raises: bool, expected_final: ActionStatus, expected_message: str | None
+) -> None:
+    def target(ctx: ActionContext) -> None:
+        if raises:
+            raise ValueError("something went wrong")
 
-    extractor._dispatch_single_action(_make_action("act-ping", "ping"))
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="act", target=target))
+    extractor._dispatch_single_action(_make_action("act-1", "act"))
 
     updates = _queued_updates(extractor)
-    statuses = [u.status for u in updates if u.external_id == "act-ping"]
-    assert statuses == [ActionStatus.running, ActionStatus.succeeded]
-
-
-def test_custom_action_raises_reports_failed_with_message() -> None:
-    def bad_action(ctx: ActionContext) -> None:
-        raise ValueError("something went wrong")
-
-    extractor = _make_extractor()
-    extractor.add_action(CustomAction(name="bad", target=bad_action))
-
-    extractor._dispatch_single_action(_make_action("act-bad", "bad"))
-
-    updates = _queued_updates(extractor)
-    statuses = [u.status for u in updates if u.external_id == "act-bad"]
-    assert ActionStatus.running in statuses
-    assert ActionStatus.failed in statuses
-    failed = next(u for u in updates if u.status == ActionStatus.failed)
-    assert "something went wrong" in (failed.result_message or "")
+    statuses = [u.status for u in updates if u.external_id == "act-1"]
+    assert statuses[0] == ActionStatus.running
+    assert statuses[-1] == expected_final
+    if expected_message:
+        assert expected_message in (updates[-1].result_message or "")
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -1,0 +1,383 @@
+"""Tests for Extractor action dispatch wiring (Task 6).
+
+Covers _handle_actions, _dispatch_single_action, and the three handler methods,
+plus the start() wiring that registers the dispatcher with CheckinWorker.
+
+All tests use a MagicMock checkin worker to avoid real API calls.
+"""
+
+import threading
+from threading import Event
+from unittest.mock import MagicMock
+
+from cognite.extractorutils.unstable.core._dto import Action, ActionStatus, ActionUpdate
+from cognite.extractorutils.unstable.core.actions import ActionContext, CustomAction
+from cognite.extractorutils.unstable.core.base import FullConfig
+from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
+
+from .conftest import TestConfig, TestExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_extractor(extractor_cls: type[TestExtractor] = TestExtractor) -> TestExtractor:
+    conn = MagicMock()
+    conn.integration.external_id = "test-integration"
+    full_config = FullConfig(
+        connection_config=conn,
+        application_config=TestConfig(parameter_one=1, parameter_two="a"),
+        current_config_revision=1,
+    )
+    return extractor_cls(full_config, MagicMock())
+
+
+def _queued_updates(extractor: TestExtractor) -> list[ActionUpdate]:
+    """Return all ActionUpdate objects passed to queue_action_update, in call order."""
+    return [c[0][0] for c in extractor._checkin_worker.queue_action_update.call_args_list]
+
+
+def _make_action(external_id: str, action_name: str) -> Action:
+    return Action(external_id=external_id, action_name=action_name, status=ActionStatus.pending)
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_single_action - routing & unknown-action handling
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_unrecognised_action_name_reports_failed() -> None:
+    """An action name that matches nothing registered is reported as failed with a descriptive message."""
+    extractor = _make_extractor()
+    extractor._dispatch_single_action(_make_action("act-1", "DoesNotExist"))
+
+    updates = _queued_updates(extractor)
+    assert len(updates) == 1
+    assert updates[0].status == ActionStatus.failed
+    assert "DoesNotExist" in (updates[0].result_message or "")
+
+
+def test_dispatch_start_prefix_for_unregistered_task_reports_failed() -> None:
+    """'Start foo' where 'foo' is not a ScheduledTask is treated as an unrecognised action."""
+    extractor = _make_extractor()
+    extractor._dispatch_single_action(_make_action("act-1", "Start unregistered-task"))
+
+    updates = _queued_updates(extractor)
+    assert len(updates) == 1
+    assert updates[0].status == ActionStatus.failed
+
+
+def test_dispatch_routes_to_start_handler_for_registered_scheduled_task() -> None:
+    """'Start <task>' where <task> is a ScheduledTask routes to the start handler."""
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+
+    extractor._dispatch_single_action(_make_action("act-1", "Start sync"))
+
+    updates = _queued_updates(extractor)
+    # running status means the start handler was reached (not the "unrecognised" path)
+    assert any(u.status == ActionStatus.running for u in updates)
+
+
+def test_dispatch_routes_to_stop_handler_for_registered_scheduled_task() -> None:
+    """'Stop <task>' routes to the stop handler; task not currently running → failed."""
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+
+    extractor._dispatch_single_action(_make_action("act-1", "Stop sync"))
+
+    updates = _queued_updates(extractor)
+    assert len(updates) == 1
+    assert updates[0].status == ActionStatus.failed
+    assert "not currently running" in (updates[0].result_message or "")
+
+
+def test_dispatch_routes_to_custom_handler_for_registered_custom_action() -> None:
+    """A registered custom action name routes to the custom handler."""
+    extractor = _make_extractor()
+    invoked = []
+    extractor.add_action(CustomAction(name="flush", target=lambda ctx: invoked.append(True)))
+
+    extractor._dispatch_single_action(_make_action("act-1", "flush"))
+
+    assert invoked == [True]
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.succeeded for u in updates)
+
+
+# ---------------------------------------------------------------------------
+# _handle_start_task_action
+# ---------------------------------------------------------------------------
+
+
+def test_start_task_action_already_running_reports_failed() -> None:
+    """If the task is already in _running_task_tokens, the action fails without starting a second instance."""
+    extractor = _make_extractor()
+    task_started = Event()
+    allow_finish = Event()
+
+    def blocking(ctx: TaskContext) -> None:
+        task_started.set()
+        allow_finish.wait(timeout=5)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=blocking))
+    extractor._scheduler.trigger("worker")
+    task_started.wait(timeout=5)
+
+    # Task is now running; attempt a second start via action
+    extractor._dispatch_single_action(_make_action("act-dup", "Start worker"))
+
+    allow_finish.set()
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.failed and "already running" in (u.result_message or "") for u in updates)
+
+
+def test_start_task_action_valid_idle_task_reports_running_then_succeeded() -> None:
+    """A valid, idle ScheduledTask reports running before execution and succeeded after."""
+    extractor = _make_extractor()
+    ran = []
+
+    def quick(ctx: TaskContext) -> None:
+        ran.append(True)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="quick", target=quick))
+    # _dispatch_single_action is synchronous for start_task (blocks until task completes)
+    extractor._dispatch_single_action(_make_action("act-1", "Start quick"))
+
+    assert ran == [True]
+    updates = _queued_updates(extractor)
+    statuses = [u.status for u in updates if u.external_id == "act-1"]
+    assert ActionStatus.running in statuses
+    assert ActionStatus.succeeded in statuses
+    assert statuses.index(ActionStatus.running) < statuses.index(ActionStatus.succeeded)
+
+
+def test_start_task_action_raises_reports_failed() -> None:
+    """If _run_task_with_token itself raises (e.g. child token creation fails), failed is reported."""
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="boom", target=lambda _: None))
+
+    original = extractor._run_task_with_token
+
+    def raise_on_call(task: ScheduledTask) -> None:
+        raise RuntimeError("token failure")
+
+    extractor._run_task_with_token = raise_on_call
+
+    extractor._dispatch_single_action(_make_action("act-err", "Start boom"))
+
+    updates = _queued_updates(extractor)
+    statuses = [u.status for u in updates if u.external_id == "act-err"]
+    assert ActionStatus.running in statuses
+    assert ActionStatus.failed in statuses
+    failed = next(u for u in updates if u.status == ActionStatus.failed and u.external_id == "act-err")
+    assert "token failure" in (failed.result_message or "")
+
+    extractor._run_task_with_token = original
+
+
+# ---------------------------------------------------------------------------
+# _handle_stop_task_action
+# ---------------------------------------------------------------------------
+
+
+def test_stop_task_action_not_running_reports_failed() -> None:
+    """Stopping a task that is not in _running_task_tokens reports failed."""
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=lambda _: None))
+
+    extractor._dispatch_single_action(_make_action("act-stop", "Stop worker"))
+
+    updates = _queued_updates(extractor)
+    assert len(updates) == 1
+    assert updates[0].status == ActionStatus.failed
+    assert "not currently running" in (updates[0].result_message or "")
+
+
+def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
+    """Stopping a running task cancels its child token and reports ActionStatus.canceled."""
+    extractor = _make_extractor()
+    task_started = Event()
+    allow_exit = Event()
+
+    def cancellable(ctx: TaskContext) -> None:
+        task_started.set()
+        allow_exit.wait(timeout=5)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=cancellable))
+    extractor._scheduler.trigger("worker")
+    task_started.wait(timeout=5)
+
+    # Snapshot the token before issuing stop
+    with extractor._running_task_tokens_lock:
+        token = extractor._running_task_tokens.get("worker")
+
+    extractor._dispatch_single_action(_make_action("act-stop", "Stop worker"))
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.canceled and u.external_id == "act-stop" for u in updates)
+    assert token is not None and token.is_cancelled
+
+    allow_exit.set()
+
+
+# ---------------------------------------------------------------------------
+# _handle_custom_action
+# ---------------------------------------------------------------------------
+
+
+def test_custom_action_succeeds_reports_running_then_succeeded() -> None:
+    """A custom action that completes without exception is reported as running → succeeded."""
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="ping", target=lambda ctx: None))
+
+    extractor._dispatch_single_action(_make_action("act-ping", "ping"))
+
+    updates = _queued_updates(extractor)
+    statuses = [u.status for u in updates if u.external_id == "act-ping"]
+    assert statuses == [ActionStatus.running, ActionStatus.succeeded]
+
+
+def test_custom_action_raises_reports_failed_with_message() -> None:
+    """A custom action that raises is reported as failed with the exception message."""
+
+    def bad_action(ctx: ActionContext) -> None:
+        raise ValueError("something went wrong")
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="bad", target=bad_action))
+
+    extractor._dispatch_single_action(_make_action("act-bad", "bad"))
+
+    updates = _queued_updates(extractor)
+    statuses = [u.status for u in updates if u.external_id == "act-bad"]
+    assert ActionStatus.running in statuses
+    assert ActionStatus.failed in statuses
+    failed = next(u for u in updates if u.status == ActionStatus.failed)
+    assert "something went wrong" in (failed.result_message or "")
+
+
+def test_custom_action_receives_call_metadata_in_context() -> None:
+    """call_metadata from the server-side Action is forwarded to ActionContext."""
+    received_metadata: list[dict | None] = []
+
+    def capture(ctx: ActionContext) -> None:
+        received_metadata.append(ctx.call_metadata)
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="greet", target=capture))
+
+    action = Action(
+        external_id="act-meta",
+        action_name="greet",
+        status=ActionStatus.pending,
+        call_metadata={"key": "value"},
+    )
+    extractor._dispatch_single_action(action)
+
+    assert received_metadata == [{"key": "value"}]
+
+
+# ---------------------------------------------------------------------------
+# _handle_actions - threading
+# ---------------------------------------------------------------------------
+
+
+def test_handle_actions_spawns_daemon_thread_named_after_external_id() -> None:
+    """Each action in _handle_actions runs on a daemon thread named 'Action-<external_id>'."""
+    extractor = _make_extractor()
+    captured: dict = {}
+    done = Event()
+
+    def target(ctx: ActionContext) -> None:
+        t = threading.current_thread()
+        captured["name"] = t.name
+        captured["daemon"] = t.daemon
+        done.set()
+
+    extractor.add_action(CustomAction(name="work", target=target))
+    extractor._handle_actions([_make_action("xid-42", "work")])
+
+    done.wait(timeout=5)
+    assert captured["name"] == "Action-xid-42"
+    assert captured["daemon"] is True
+
+
+def test_handle_actions_multiple_actions_run_concurrently() -> None:
+    """Two actions are dispatched to separate threads; they overlap in time."""
+    extractor = _make_extractor()
+    a1_started = Event()
+    a2_started = Event()
+    release = Event()
+
+    def slow(ctx: ActionContext) -> None:
+        if ctx.external_id == "act-1":
+            a1_started.set()
+        else:
+            a2_started.set()
+        release.wait(timeout=5)
+
+    extractor.add_action(CustomAction(name="op-1", target=slow))
+    extractor.add_action(CustomAction(name="op-2", target=slow))
+
+    extractor._handle_actions([
+        _make_action("act-1", "op-1"),
+        _make_action("act-2", "op-2"),
+    ])
+
+    # Both must start before either finishes — proves concurrent execution
+    assert a1_started.wait(timeout=5), "op-1 never started"
+    assert a2_started.wait(timeout=5), "op-2 never started"
+
+    release.set()
+
+
+# ---------------------------------------------------------------------------
+# start() wiring
+# ---------------------------------------------------------------------------
+
+
+def test_start_registers_handle_actions_as_dispatcher() -> None:
+    """start() calls set_action_dispatcher exactly once with _handle_actions."""
+    extractor = _make_extractor()
+    with extractor:
+        pass
+
+    extractor._checkin_worker.set_action_dispatcher.assert_called_once()
+    registered = extractor._checkin_worker.set_action_dispatcher.call_args[0][0]
+    # Verify the registered callable IS the bound _handle_actions method
+    assert registered.__func__.__name__ == "_handle_actions"
+    assert registered.__self__ is extractor
+
+
+def test_dispatcher_registered_before_checkin_thread_starts() -> None:
+    """set_action_dispatcher is called before the checkin thread is spawned in start()."""
+    call_order: list[str] = []
+
+    class _TrackingWorker:
+        def set_action_dispatcher(self, fn: object) -> None:
+            call_order.append("set_dispatcher")
+
+        def run_periodic_checkin(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    extractor = _make_extractor()
+    extractor._checkin_worker = _TrackingWorker()  # type: ignore[assignment]
+
+    original_thread_start = threading.Thread.start
+
+    def tracking_start(self: threading.Thread) -> None:
+        if self.name == "ExtractorCheckin":
+            call_order.append("checkin_thread")
+        original_thread_start(self)
+
+    threading.Thread.start = tracking_start  # type: ignore[method-assign]
+    try:
+        extractor.start()
+    finally:
+        threading.Thread.start = original_thread_start  # type: ignore[method-assign]
+        extractor.stop()
+
+    assert call_order.index("set_dispatcher") < call_order.index("checkin_thread")

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -97,7 +97,7 @@ def test_custom_action_appears_with_correct_type_and_description() -> None:
 # -- __init_actions__ hook and add_action --
 
 
-def test_init_actions_hook_called_after_init_tasks() -> None:
+def test_init_actions_hook_called_after_init_tasks_and_can_register_actions() -> None:
     call_order: list[str] = []
 
     class _Ext(TestExtractor):
@@ -106,20 +106,10 @@ def test_init_actions_hook_called_after_init_tasks() -> None:
 
         def __init_actions__(self) -> None:
             call_order.append("actions")
-
-    _make_extractor(_Ext)
-    assert call_order == ["tasks", "actions"]
-
-
-def test_add_action_from_init_actions_subclass_hook() -> None:
-    class _Ext(TestExtractor):
-        def __init_tasks__(self) -> None:
-            pass
-
-        def __init_actions__(self) -> None:
             self.add_action(CustomAction(name="ping", target=lambda _: None))
 
     extractor = _make_extractor(_Ext)
+    assert call_order == ["tasks", "actions"]
     assert len(extractor._custom_actions) == 1
     assert extractor._custom_actions[0].name == "ping"
 

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -29,8 +29,20 @@ def _startup_request(extractor: Extractor) -> StartupRequest:
     return extractor._get_startup_request()
 
 
-def test_no_scheduled_tasks_no_custom_actions_sends_available_actions_none() -> None:
+@pytest.mark.parametrize(
+    "extra_tasks",
+    [
+        pytest.param([], id="no_tasks"),
+        pytest.param(
+            [ContinuousTask(name="cont", target=lambda _: None), StartupTask(name="init", target=lambda _: None)],
+            id="non_scheduled_tasks",
+        ),
+    ],
+)
+def test_available_actions_none_without_scheduled_tasks(extra_tasks: list) -> None:
     extractor = _make_extractor()
+    for task in extra_tasks:
+        extractor.add_task(task)
     assert _startup_request(extractor).available_actions is None
 
 
@@ -59,13 +71,6 @@ def test_scheduled_task_action_entry_has_correct_type_and_task_ref(
     by_name = {a.name: a for a in _startup_request(extractor).available_actions}
     assert by_name[action_name].type == expected_type
     assert by_name[action_name].task == expected_task
-
-
-def test_continuous_and_startup_tasks_do_not_produce_available_actions() -> None:
-    extractor = _make_extractor()
-    extractor.add_task(ContinuousTask(name="cont", target=lambda _: None))
-    extractor.add_task(StartupTask(name="init", target=lambda _: None))
-    assert _startup_request(extractor).available_actions is None
 
 
 def test_scheduled_and_custom_actions_combined_ordering() -> None:
@@ -121,41 +126,36 @@ def test_add_action_raises_on_duplicate_name() -> None:
 
 
 @pytest.mark.parametrize("conflicting_name", ["Start sync", "Stop sync"])
-def test_add_action_raises_on_conflict_with_scheduled_task_action_name(conflicting_name: str) -> None:
-    extractor = _make_extractor()
-    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+def test_action_name_conflict_is_bidirectional(conflicting_name: str) -> None:
+    ext = _make_extractor()
+    ext.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
     with pytest.raises(ValueError, match=conflicting_name):
-        extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
+        ext.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
 
-
-@pytest.mark.parametrize("conflicting_name", ["Start sync", "Stop sync"])
-def test_add_task_raises_on_conflict_with_existing_custom_action_name(conflicting_name: str) -> None:
-    extractor = _make_extractor()
-    extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
+    ext2 = _make_extractor()
+    ext2.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
     with pytest.raises(ValueError, match="sync"):
-        extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+        ext2.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
 
 
-def test_token_present_in_running_task_tokens_during_execution() -> None:
+def test_token_in_running_tokens_during_execution_is_child() -> None:
     extractor = _make_extractor()
-    token_present: list[bool] = []
-    task_running = Event()
-    appended = Event()
+    captured: list = []
+    done = Event()
     allow_finish = Event()
 
     def target(_: TaskContext) -> None:
-        task_running.set()
-        token_present.append("the-task" in extractor._running_task_tokens)
-        appended.set()
+        captured.append(extractor._running_task_tokens.get("the-task"))
+        done.set()
         allow_finish.wait(timeout=5)
 
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
-    task_running.wait(timeout=5)
+    done.wait(timeout=5)
     allow_finish.set()
-    appended.wait(timeout=5)
 
-    assert token_present == [True]
+    assert captured[0] is not None
+    assert captured[0]._parent is extractor.cancellation_token
 
 
 @pytest.mark.parametrize("raises", [False, True])
@@ -194,20 +194,3 @@ def test_token_cleanup_does_not_clobber_replacement_token() -> None:
         time.sleep(0.005)
 
     assert extractor._running_task_tokens.get("the-task") is replacement
-
-
-def test_scheduled_task_token_is_child_of_extractor_cancellation_token() -> None:
-    extractor = _make_extractor()
-    captured: list = []
-    done = Event()
-
-    def target(_: TaskContext) -> None:
-        captured.append(extractor._running_task_tokens.get("the-task"))
-        done.set()
-
-    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
-    extractor._scheduler.trigger("the-task")
-    done.wait(timeout=5)
-
-    assert len(captured) == 1 and captured[0] is not None
-    assert captured[0]._parent is extractor.cancellation_token

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -1,0 +1,175 @@
+import time
+from datetime import datetime, timezone
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognite.extractorutils.unstable.core._dto import ActionType, StartupRequest
+from cognite.extractorutils.unstable.core.actions import CustomAction
+from cognite.extractorutils.unstable.core.base import Extractor, FullConfig
+from cognite.extractorutils.unstable.core.tasks import ContinuousTask, ScheduledTask, StartupTask, TaskContext
+
+from .conftest import TestConfig, TestExtractor
+
+
+def _make_extractor(extractor_cls: type[TestExtractor] = TestExtractor) -> TestExtractor:
+    conn = MagicMock()
+    conn.integration.external_id = "test-integration"
+    full_config = FullConfig(
+        connection_config=conn,
+        application_config=TestConfig(parameter_one=1, parameter_two="a"),
+        current_config_revision=1,
+    )
+    return extractor_cls(full_config, MagicMock())
+
+
+def _startup_request(extractor: Extractor) -> StartupRequest:
+    extractor._start_time = datetime.now(tz=timezone.utc)
+    return extractor._get_startup_request()
+
+
+# -- available_actions population --
+
+
+def test_no_scheduled_tasks_no_custom_actions_sends_available_actions_none() -> None:
+    # TestExtractor has one StartupTask; StartupTasks do not produce available_actions entries.
+    extractor = _make_extractor()
+    assert _startup_request(extractor).available_actions is None
+
+
+def test_two_scheduled_tasks_produce_four_available_actions() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="alpha", target=lambda _: None))
+    extractor.add_task(ScheduledTask.from_interval(interval="2h", name="beta", target=lambda _: None))
+    req = _startup_request(extractor)
+    assert req.available_actions is not None
+    assert len(req.available_actions) == 4
+    assert {a.name for a in req.available_actions} == {"Start alpha", "Stop alpha", "Start beta", "Stop beta"}
+
+
+@pytest.mark.parametrize(
+    "action_name,expected_type,expected_task",
+    [
+        ("Start alpha", ActionType.start_task, "alpha"),
+        ("Stop alpha", ActionType.stop_task, "alpha"),
+    ],
+)
+def test_scheduled_task_action_entry_has_correct_type_and_task_ref(
+    action_name: str, expected_type: ActionType, expected_task: str
+) -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="alpha", target=lambda _: None))
+    by_name = {a.name: a for a in _startup_request(extractor).available_actions}
+    assert by_name[action_name].type == expected_type
+    assert by_name[action_name].task == expected_task
+
+
+def test_continuous_and_startup_tasks_do_not_produce_available_actions() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ContinuousTask(name="cont", target=lambda _: None))
+    extractor.add_task(StartupTask(name="init", target=lambda _: None))
+    assert _startup_request(extractor).available_actions is None
+
+
+def test_custom_action_appears_with_correct_type_and_description() -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="flush cache", target=lambda _: None, description="Clears state"))
+    actions = _startup_request(extractor).available_actions
+    assert actions is not None and len(actions) == 1
+    assert actions[0].name == "flush cache"
+    assert actions[0].type == ActionType.custom
+    assert actions[0].description == "Clears state"
+
+
+# -- __init_actions__ hook and add_action --
+
+
+def test_init_actions_hook_called_after_init_tasks() -> None:
+    call_order: list[str] = []
+
+    class _Ext(TestExtractor):
+        def __init_tasks__(self) -> None:
+            call_order.append("tasks")
+
+        def __init_actions__(self) -> None:
+            call_order.append("actions")
+
+    _make_extractor(_Ext)
+    assert call_order == ["tasks", "actions"]
+
+
+def test_add_action_from_init_actions_subclass_hook() -> None:
+    class _Ext(TestExtractor):
+        def __init_tasks__(self) -> None:
+            pass
+
+        def __init_actions__(self) -> None:
+            self.add_action(CustomAction(name="ping", target=lambda _: None))
+
+    extractor = _make_extractor(_Ext)
+    assert len(extractor._custom_actions) == 1
+    assert extractor._custom_actions[0].name == "ping"
+
+
+def test_multiple_add_action_calls_accumulate_in_registration_order() -> None:
+    extractor = _make_extractor()
+    for name in ("a1", "a2", "a3"):
+        extractor.add_action(CustomAction(name=name, target=lambda _: None))
+    assert [a.name for a in extractor._custom_actions] == ["a1", "a2", "a3"]
+
+
+# -- _running_task_tokens lifecycle --
+
+
+def test_token_present_in_running_task_tokens_during_execution() -> None:
+    extractor = _make_extractor()
+    token_present: list[bool] = []
+    task_running = Event()
+    allow_finish = Event()
+
+    def target(_: TaskContext) -> None:
+        task_running.set()
+        token_present.append("the-task" in extractor._running_task_tokens)
+        allow_finish.wait(timeout=5)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    task_running.wait(timeout=5)
+    allow_finish.set()
+
+    assert token_present == [True]
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool) -> None:
+    extractor = _make_extractor()
+    done = Event()
+
+    def target(_: TaskContext) -> None:
+        done.set()
+        if raises:
+            raise RuntimeError("intentional")
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+    time.sleep(0.05)  # allow the finally block to execute after task body returns
+    assert "the-task" not in extractor._running_task_tokens
+
+
+def test_scheduled_task_token_is_child_of_extractor_cancellation_token() -> None:
+    extractor = _make_extractor()
+    captured: list = []
+    done = Event()
+
+    def target(_: TaskContext) -> None:
+        captured.append(extractor._running_task_tokens.get("the-task"))
+        done.set()
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+
+    assert len(captured) == 1 and captured[0] is not None
+    assert captured[0]._parent is extractor.cancellation_token

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -29,11 +29,7 @@ def _startup_request(extractor: Extractor) -> StartupRequest:
     return extractor._get_startup_request()
 
 
-# -- available_actions population --
-
-
 def test_no_scheduled_tasks_no_custom_actions_sends_available_actions_none() -> None:
-    # TestExtractor has one StartupTask; StartupTasks do not produce available_actions entries.
     extractor = _make_extractor()
     assert _startup_request(extractor).available_actions is None
 
@@ -79,7 +75,6 @@ def test_scheduled_and_custom_actions_combined_ordering() -> None:
     req = _startup_request(extractor)
     assert req.available_actions is not None
     assert len(req.available_actions) == 3
-    # Scheduled task entries appear before custom actions
     names = [a.name for a in req.available_actions]
     assert names == ["Start sync", "Stop sync", "flush"]
 
@@ -92,9 +87,6 @@ def test_custom_action_appears_with_correct_type_and_description() -> None:
     assert actions[0].name == "flush cache"
     assert actions[0].type == ActionType.custom
     assert actions[0].description == "Clears state"
-
-
-# -- __init_actions__ hook and add_action --
 
 
 def test_init_actions_hook_called_after_init_tasks_and_can_register_actions() -> None:
@@ -144,9 +136,6 @@ def test_add_task_raises_on_conflict_with_existing_custom_action_name(conflictin
         extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
 
 
-# -- _running_task_tokens lifecycle --
-
-
 def test_token_present_in_running_task_tokens_during_execution() -> None:
     extractor = _make_extractor()
     token_present: list[bool] = []
@@ -194,7 +183,6 @@ def test_token_cleanup_does_not_clobber_replacement_token() -> None:
     replacement = extractor.cancellation_token.create_child_token()
 
     def target(_: TaskContext) -> None:
-        # Simulate a subsequent invocation overwriting the entry before this run finishes
         extractor._running_task_tokens["the-task"] = replacement
         done.set()
 
@@ -205,7 +193,6 @@ def test_token_cleanup_does_not_clobber_replacement_token() -> None:
     while any(j.name == "the-task" for j in extractor._scheduler._running) and time.monotonic() < deadline:
         time.sleep(0.005)
 
-    # Identity check must preserve the replacement — the old blind pop would remove it
     assert extractor._running_task_tokens.get("the-task") is replacement
 
 

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -146,6 +146,14 @@ def test_add_action_raises_on_conflict_with_scheduled_task_action_name(conflicti
         extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
 
 
+@pytest.mark.parametrize("conflicting_name", ["Start sync", "Stop sync"])
+def test_add_task_raises_on_conflict_with_existing_custom_action_name(conflicting_name: str) -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
+    with pytest.raises(ValueError, match="sync"):
+        extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+
+
 # -- _running_task_tokens lifecycle --
 
 

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -153,17 +153,20 @@ def test_token_present_in_running_task_tokens_during_execution() -> None:
     extractor = _make_extractor()
     token_present: list[bool] = []
     task_running = Event()
+    appended = Event()
     allow_finish = Event()
 
     def target(_: TaskContext) -> None:
         task_running.set()
         token_present.append("the-task" in extractor._running_task_tokens)
+        appended.set()
         allow_finish.wait(timeout=5)
 
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     task_running.wait(timeout=5)
     allow_finish.set()
+    appended.wait(timeout=5)
 
     assert token_present == [True]
 
@@ -181,7 +184,9 @@ def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     done.wait(timeout=5)
-    time.sleep(0.05)  # allow the finally block to execute after task body returns
+    deadline = time.monotonic() + 5
+    while "the-task" in extractor._running_task_tokens and time.monotonic() < deadline:
+        time.sleep(0.005)
     assert "the-task" not in extractor._running_task_tokens
 
 
@@ -198,7 +203,9 @@ def test_token_cleanup_does_not_clobber_replacement_token() -> None:
     extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
     extractor._scheduler.trigger("the-task")
     done.wait(timeout=5)
-    time.sleep(0.05)  # allow _run_task_with_token's finally to run
+    deadline = time.monotonic() + 5
+    while any(j.name == "the-task" for j in extractor._scheduler._running) and time.monotonic() < deadline:
+        time.sleep(0.005)
 
     # Identity check must preserve the replacement — the old blind pop would remove it
     assert extractor._running_task_tokens.get("the-task") is replacement

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -72,6 +72,18 @@ def test_continuous_and_startup_tasks_do_not_produce_available_actions() -> None
     assert _startup_request(extractor).available_actions is None
 
 
+def test_scheduled_and_custom_actions_combined_ordering() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+    extractor.add_action(CustomAction(name="flush", target=lambda _: None))
+    req = _startup_request(extractor)
+    assert req.available_actions is not None
+    assert len(req.available_actions) == 3
+    # Scheduled task entries appear before custom actions
+    names = [a.name for a in req.available_actions]
+    assert names == ["Start sync", "Stop sync", "flush"]
+
+
 def test_custom_action_appears_with_correct_type_and_description() -> None:
     extractor = _make_extractor()
     extractor.add_action(CustomAction(name="flush cache", target=lambda _: None, description="Clears state"))
@@ -156,6 +168,25 @@ def test_token_removed_from_running_task_tokens_after_task_finishes(raises: bool
     done.wait(timeout=5)
     time.sleep(0.05)  # allow the finally block to execute after task body returns
     assert "the-task" not in extractor._running_task_tokens
+
+
+def test_token_cleanup_does_not_clobber_replacement_token() -> None:
+    extractor = _make_extractor()
+    done = Event()
+    replacement = extractor.cancellation_token.create_child_token()
+
+    def target(_: TaskContext) -> None:
+        # Simulate a subsequent invocation overwriting the entry before this run finishes
+        extractor._running_task_tokens["the-task"] = replacement
+        done.set()
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="the-task", target=target))
+    extractor._scheduler.trigger("the-task")
+    done.wait(timeout=5)
+    time.sleep(0.05)  # allow _run_task_with_token's finally to run
+
+    # Identity check must preserve the replacement — the old blind pop would remove it
+    assert extractor._running_task_tokens.get("the-task") is replacement
 
 
 def test_scheduled_task_token_is_child_of_extractor_cancellation_token() -> None:

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -131,6 +131,21 @@ def test_multiple_add_action_calls_accumulate_in_registration_order() -> None:
     assert [a.name for a in extractor._custom_actions] == ["a1", "a2", "a3"]
 
 
+def test_add_action_raises_on_duplicate_name() -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="ping", target=lambda _: None))
+    with pytest.raises(ValueError, match="ping"):
+        extractor.add_action(CustomAction(name="ping", target=lambda _: None))
+
+
+@pytest.mark.parametrize("conflicting_name", ["Start sync", "Stop sync"])
+def test_add_action_raises_on_conflict_with_scheduled_task_action_name(conflicting_name: str) -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="sync", target=lambda _: None))
+    with pytest.raises(ValueError, match=conflicting_name):
+        extractor.add_action(CustomAction(name=conflicting_name, target=lambda _: None))
+
+
 # -- _running_task_tokens lifecycle --
 
 


### PR DESCRIPTION
### PR Short Summary
Wires the Extractor as the action dispatcher for **CheckinWorker** and implements the full action routing pipeline: **_handle_actions** fans out each incoming action to a dedicated daemon thread, _dispatch_single_action routes by matching the action name against registered available actions, and the three handler methods (**_handle_start_task_action**, **_handle_stop_task_action**, **_handle_custom_action**) execute the action and report lifecycle status updates back through the checkin worker.

### Type of change
- [ ] New feature (non-breaking change that adds functionality)

### What changed
cognite/extractorutils/unstable/core/base.py
- Added imports: Action, ActionStatus, ActionUpdate from _dto; ActionContext from actions
- _handle_actions(actions) — spawns one daemon thread per action named Action-{external_id} so a slow action never blocks the next
- _dispatch_single_action(action) — builds O(1) sets of known start/stop/custom action names at dispatch time and routes accordingly; any unrecognised name immediately reports failed with a descriptive message (no exception raised)
- _handle_start_task_action(action) — checks task existence, holds _running_task_tokens_lock during the already-running guard, then reports running
→ _run_task_with_token → succeeded/failed
- _handle_stop_task_action(action) — snapshots the child token under lock, cancels it, reports canceled; reports failed if the task is not currently running
- _handle_custom_action(action) — builds ActionContext with call_metadata, invokes custom.target(ctx), reports running → succeeded/failed
- start() — calls self._checkin_worker.set_action_dispatcher(self._handle_actions) before the checkin thread is spawned so no pending actions can arrive without a dispatcher

tests/test_unstable/test_action_dispatch.py — new file, 17 tests covering all acceptance criteria

### Why it changed
Odin dispatches pending actions in the checkin response. Without this wiring, actions are received by CheckinWorker but never executed. This completes the round-trip: the extractor announces capabilities at startup (Task 5) and can now act on them.

### What to focus on during review
- Dispatch key design: type is inferred by matching action_name against the three known sets (start/stop/custom) rather than a type field on Action (which the DTO does not carry). Custom actions named "Start X" where X is not a registered ScheduledTask are legal and route correctly to the custom handler.
- **_handle_start_task_action** concurrency: the already-running check holds **_running_task_tokens_lock** for the read. There is a narrow TOCTOU window between the lock release and **_run_task_with_token** acquiring its own lock; this matches the existing scheduler behaviour and is intentional - **_run_task_with_token's** identity-check finally already handles concurrent overwrites correctly.
- start() ordering: dispatcher is registered before the checkin thread starts — verified by **test_dispatcher_registered_before_checkin_thread_starts**.

### Test evidence
tests/test_unstable/test_action_dispatch.py    17 passed
tests/test_unstable/test_action_registration.py  15 passed
tests/test_unstable/test_actions.py             10 passed
ruff check — All checks passed

### Risks and unknowns
- The "Start {t.name}" / "Stop {t.name}" name convention is shared between _get_startup_request (registration) and _dispatch_single_action (routing). A single source-of-truth constant would eliminate future drift if the convention changes.
- _run_task_with_token's inner run_task wrapper catches all Exceptions internally, so _handle_start_task_action will almost always report succeeded even when the task fails internally (the failure is reported via the error pipeline). This is consistent with the framework's design but means the action status alone does not indicate task success.

### Rollout and rollback
- Purely additive. Extractors that do not register scheduled tasks or custom actions receive no _handle_actions calls and behave identically to before. The dispatcher is only invoked when the server returns pending_actions.

### Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated
- [x] Docs updated (N/A — internal framework)
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams (none)