### PR TITLE
EDGE-614 update renovate.json to use the renovate-config-public repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "local>cognitedata/renovate-config-public"
   ],
-  "ignoreDeps": ["python"]
+  "ignoreDeps": ["python"],
+  "pinDigests": true
 }


### PR DESCRIPTION
This PR updates the renovate.json which now should point to the repo `renovate-config-public` which defines the renovate settings.