### PR TITLE
fix(odin): Fix fetch logs result metadata

### DIFF
--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -67,7 +67,18 @@ class WithExternalId(CogniteModel):
     external_id: str
 
 
-MessageType = Annotated[str, StringConstraints(min_length=0, max_length=1000)]
+MAX_MESSAGE_LENGTH = 1000
+"""Matches the ``max_length`` enforced by ``MessageType`` below; pydantic raises a ValidationError past this."""
+
+MessageType = Annotated[str, StringConstraints(min_length=0, max_length=MAX_MESSAGE_LENGTH)]
+
+
+def truncate_message(message: str, max_length: int = MAX_MESSAGE_LENGTH) -> str:
+    """Truncate ``message`` (marking it with a trailing ``...``) so it fits within ``max_length`` characters."""
+    if len(message) <= max_length:
+        return message
+    suffix = "..."
+    return message[: max_length - len(suffix)] + suffix
 
 
 class TaskUpdate(CogniteModel):

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -15,6 +15,17 @@ from typing_extensions import TypeAliasType
 from cognite.extractorutils.unstable.core.errors import Error as InternalError
 from cognite.extractorutils.unstable.core.errors import ErrorLevel
 
+MAX_METADATA_VALUE_BYTES = 512
+"""CDF's per-value size limit for metadata dict fields (e.g. action result metadata). The Integrations
+API rejects the whole checkin request otherwise, with "Metadata values may be at most 512 bytes"."""
+
+
+def oversized_metadata_fields(metadata: dict[str, str] | None) -> list[str]:
+    """Return the keys of ``metadata`` whose UTF-8 encoded value exceeds ``MAX_METADATA_VALUE_BYTES``."""
+    if not metadata:
+        return []
+    return [key for key, value in metadata.items() if len(value.encode("utf-8")) > MAX_METADATA_VALUE_BYTES]
+
 
 class CogniteModel(BaseModel):
     """

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -24,7 +24,7 @@ def oversized_metadata_fields(metadata: dict[str, str] | None) -> list[str]:
     """Return the keys of ``metadata`` whose UTF-8 encoded value exceeds ``MAX_METADATA_VALUE_BYTES``."""
     if not metadata:
         return []
-    return [key for key, value in metadata.items() if len(value.encode("utf-8")) > MAX_METADATA_VALUE_BYTES]
+    return [key for key, value in metadata.items() if len(str(value).encode("utf-8")) > MAX_METADATA_VALUE_BYTES]
 
 
 class CogniteModel(BaseModel):

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -27,6 +27,20 @@ def oversized_metadata_fields(metadata: dict[str, str] | None) -> list[str]:
     return [key for key, value in metadata.items() if len(str(value).encode("utf-8")) > MAX_METADATA_VALUE_BYTES]
 
 
+def drop_oversized_metadata_fields(metadata: dict[str, str] | None) -> tuple[dict[str, str] | None, list[str]]:
+    """
+    Remove any oversized fields from ``metadata``.
+
+    Returns the remaining metadata (``None`` if nothing is left, so callers can pass it straight
+    into a ``dict[str, str] | None`` field) alongside the keys that were dropped.
+    """
+    oversized_fields = oversized_metadata_fields(metadata)
+    if not oversized_fields:
+        return metadata, []
+    filtered = {key: value for key, value in (metadata or {}).items() if key not in oversized_fields}
+    return filtered or None, oversized_fields
+
+
 class CogniteModel(BaseModel):
     """
     Base class for DTO classes based on pydantic.

--- a/cognite/extractorutils/unstable/core/_log_upload_action.py
+++ b/cognite/extractorutils/unstable/core/_log_upload_action.py
@@ -13,6 +13,7 @@ from cognite.client import CogniteClient
 
 from cognite.extractorutils.unstable.configuration.models import ExtractorConfig, LogFileHandlerConfig
 from cognite.extractorutils.unstable.core._bounded_reader import BoundedReader
+from cognite.extractorutils.unstable.core._dto import MAX_METADATA_VALUE_BYTES
 from cognite.extractorutils.unstable.core.actions import ActionContext, ActionError
 
 _logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ class _FileUploadResult:
     log_date: date
     file_external_id: str
     status: Literal["uploaded", "skipped_too_large", "failed"]
+    file_id: int | None = None  # CDF's internal (numeric) file id; set only when status == "uploaded"
     size_bytes: int | None = None
     error: str | None = None
 
@@ -158,7 +160,7 @@ def _upload_candidate(
     try:
         with open(candidate.path, "rb") as f:
             reader: BinaryIO = BoundedReader(f, actual_size) if candidate.is_current else f  # type: ignore[assignment]
-            cdf_client.files.upload_bytes(
+            uploaded = cdf_client.files.upload_bytes(
                 content=reader,
                 name=f"{external_id}.log",
                 external_id=external_id,
@@ -170,6 +172,7 @@ def _upload_candidate(
             log_date=candidate.log_date,
             file_external_id=external_id,
             status="uploaded",
+            file_id=uploaded.id,
             size_bytes=actual_size,
         )
     except Exception as e:
@@ -246,37 +249,45 @@ def fetch_logs_action(ctx: ActionContext) -> None:
 
     counts = Counter(r.status for r in upload_results)
 
-    # Per-file entries: upload results (sorted by date) + missing dates (skipped by candidate builder)
+    # Per-file entries: upload results (sorted by date) + missing dates (skipped by candidate builder).
     files_list: list[dict[str, str]] = []
     for r in upload_results:
-        entry: dict[str, str] = {
-            "date": str(r.log_date),
-            "file_external_id": r.file_external_id,
-            "status": r.status,
-        }
-        if r.size_bytes is not None:
+        entry: dict[str, str] = {"date": str(r.log_date), "status": r.status}
+        if r.file_id is not None:
+            entry["id"] = str(r.file_id)
+        if r.status != "uploaded" and r.size_bytes is not None:
             entry["size_bytes"] = str(r.size_bytes)
         if r.error:
             entry["error"] = r.error
         files_list.append(entry)
-    files_list.extend(
-        {
-            "date": str(skipped_date),
-            "file_external_id": _file_external_id(integration_external_id, skipped_date),
-            "status": "skipped",
-        }
-        for skipped_date in skipped_dates
-    )
+    files_list.extend({"date": str(skipped_date), "status": "skipped"} for skipped_date in skipped_dates)
     files_list.sort(key=lambda e: e["date"])
 
-    ctx.set_result(
-        f"{counts['uploaded']} of {num_days} log files uploaded to CDF Files",
-        metadata={
-            "total_files": str(num_days),
-            "uploaded_files": str(counts["uploaded"]),
-            "missing_files": str(len(skipped_dates)),
-            "skipped_too_large_files": str(counts["skipped_too_large"]),
-            "failed_files": str(counts["failed"]),
-            "files": json.dumps(files_list),
-        },
-    )
+    result_message = f"{counts['uploaded']} of {num_days} log files uploaded to CDF Files"
+    metadata: dict[str, str] = {
+        "total_files": str(num_days),
+        "uploaded_files": str(counts["uploaded"]),
+        "missing_files": str(len(skipped_dates)),
+        "skipped_too_large_files": str(counts["skipped_too_large"]),
+        "failed_files": str(counts["failed"]),
+    }
+
+    # The per-file breakdown is supplementary detail on top of the counts above. For date ranges
+    # near MAX_DATE_RANGE_DAYS it can exceed CDF's 512-byte-per-metadata-value limit (each entry
+    # embeds a full file_external_id), which would otherwise get the whole result rejected. Rather
+    # than risk that, only attach it when it demonstrably fits — the aggregate counts always do,
+    # regardless of range length, and full per-file detail has already been logged individually above.
+    files_json = json.dumps(files_list, separators=(",", ":"))
+    if len(files_json.encode("utf-8")) <= MAX_METADATA_VALUE_BYTES:
+        metadata["files"] = files_json
+    else:
+        _logger.info(
+            "fetch_logs: per-file detail (%d bytes) would exceed the %d-byte metadata value limit; omitting "
+            "'files' from the reported result. Full per-file detail for this invocation is available above "
+            "in the extractor's own logs.",
+            len(files_json.encode("utf-8")),
+            MAX_METADATA_VALUE_BYTES,
+        )
+        result_message += " (per-file detail omitted from result metadata — see extractor logs for full detail)"
+
+    ctx.set_result(result_message, metadata=metadata)

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -96,6 +96,7 @@ from cognite.extractorutils.unstable.core._dto import (
     StartupRequest,
     TaskType,
     drop_oversized_metadata_fields,
+    truncate_message,
 )
 from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
@@ -689,7 +690,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     ActionUpdate(
                         external_id=action.external_id,
                         status=ActionStatus.failed,
-                        result_message=(
+                        result_message=truncate_message(
                             f"Action '{custom.name}' completed successfully, but metadata field(s) "
                             f"{', '.join(oversized_fields)} exceeded the {MAX_METADATA_VALUE_BYTES}-byte-per-value "
                             f"limit and were dropped from the reported result"
@@ -715,7 +716,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     result_message=(
                         str(e)
                         if not oversized_fields
-                        else (
+                        else truncate_message(
                             f"{e} (additionally, metadata field(s) {', '.join(oversized_fields)} exceeded "
                             f"the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped)"
                         )

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -719,7 +719,11 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                             f"the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped)"
                         )
                     ),
-                    result_metadata=None if oversized_fields else e.result_metadata,
+                    result_metadata=(
+                        {k: v for k, v in e.result_metadata.items() if k not in oversized_fields}
+                        if e.result_metadata
+                        else None
+                    ),
                 )
             )
         except Exception as e:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -95,7 +95,7 @@ from cognite.extractorutils.unstable.core._dto import (
     ExtractorInfo,
     StartupRequest,
     TaskType,
-    oversized_metadata_fields,
+    drop_oversized_metadata_fields,
 )
 from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
@@ -678,22 +678,23 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         try:
             custom.target(ctx)
-            oversized_fields = oversized_metadata_fields(ctx._result_metadata)
+            filtered_metadata, oversized_fields = drop_oversized_metadata_fields(ctx._result_metadata)
             if oversized_fields:
-                # The action itself ran to completion — only reporting the result back to Odin
-                # failed, because a metadata value is too large to send. Fail the action instead
-                # of queuing a payload that Odin would reject (which would otherwise poison the
-                # checkin batch and retry forever, since checkin bundles all pending updates
-                # together and requeues the whole batch on any rejection).
+                # The action itself ran to completion — only reporting the full result back to Odin
+                # failed, because a metadata value is too large to send. Fail the action instead of
+                # queuing a payload that Odin would reject (which would otherwise poison the checkin
+                # batch and retry forever, since checkin bundles all pending updates together and
+                # requeues the whole batch on any rejection). Non-oversized fields are still reported.
                 self._checkin_worker.queue_action_update(
                     ActionUpdate(
                         external_id=action.external_id,
                         status=ActionStatus.failed,
                         result_message=(
-                            f"Action '{custom.name}' completed successfully, but its result could not be "
-                            f"reported: metadata field(s) {', '.join(oversized_fields)} exceed the "
-                            f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit"
+                            f"Action '{custom.name}' completed successfully, but metadata field(s) "
+                            f"{', '.join(oversized_fields)} exceeded the {MAX_METADATA_VALUE_BYTES}-byte-per-value "
+                            f"limit and were dropped from the reported result"
                         ),
+                        result_metadata=filtered_metadata,
                     )
                 )
             else:
@@ -706,7 +707,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     )
                 )
         except ActionError as e:
-            oversized_fields = oversized_metadata_fields(e.result_metadata)
+            filtered_metadata, oversized_fields = drop_oversized_metadata_fields(e.result_metadata)
             self._checkin_worker.queue_action_update(
                 ActionUpdate(
                     external_id=action.external_id,
@@ -719,11 +720,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                             f"the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped)"
                         )
                     ),
-                    result_metadata=(
-                        {k: v for k, v in e.result_metadata.items() if k not in oversized_fields}
-                        if e.result_metadata
-                        else None
-                    ),
+                    result_metadata=filtered_metadata,
                 )
             )
         except Exception as e:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -85,6 +85,7 @@ from cognite.extractorutils.unstable.configuration.models import (
     create_state_store,
 )
 from cognite.extractorutils.unstable.core._dto import (
+    MAX_METADATA_VALUE_BYTES,
     Action,
     ActionStatus,
     ActionType,
@@ -94,6 +95,7 @@ from cognite.extractorutils.unstable.core._dto import (
     ExtractorInfo,
     StartupRequest,
     TaskType,
+    oversized_metadata_fields,
 )
 from cognite.extractorutils.unstable.core._dto import (
     Task as DtoTask,
@@ -676,21 +678,48 @@ class Extractor(Generic[ConfigType], CogniteLogger):
 
         try:
             custom.target(ctx)
-            self._checkin_worker.queue_action_update(
-                ActionUpdate(
-                    external_id=action.external_id,
-                    status=ActionStatus.succeeded,
-                    result_message=ctx._result_message,
-                    result_metadata=ctx._result_metadata,
+            oversized_fields = oversized_metadata_fields(ctx._result_metadata)
+            if oversized_fields:
+                # The action itself ran to completion — only reporting the result back to Odin
+                # failed, because a metadata value is too large to send. Fail the action instead
+                # of queuing a payload that Odin would reject (which would otherwise poison the
+                # checkin batch and retry forever, since checkin bundles all pending updates
+                # together and requeues the whole batch on any rejection).
+                self._checkin_worker.queue_action_update(
+                    ActionUpdate(
+                        external_id=action.external_id,
+                        status=ActionStatus.failed,
+                        result_message=(
+                            f"Action '{custom.name}' completed successfully, but its result could not be "
+                            f"reported: metadata field(s) {', '.join(oversized_fields)} exceed the "
+                            f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit"
+                        ),
+                    )
                 )
-            )
+            else:
+                self._checkin_worker.queue_action_update(
+                    ActionUpdate(
+                        external_id=action.external_id,
+                        status=ActionStatus.succeeded,
+                        result_message=ctx._result_message,
+                        result_metadata=ctx._result_metadata,
+                    )
+                )
         except ActionError as e:
+            oversized_fields = oversized_metadata_fields(e.result_metadata)
             self._checkin_worker.queue_action_update(
                 ActionUpdate(
                     external_id=action.external_id,
                     status=ActionStatus.failed,
-                    result_message=str(e),
-                    result_metadata=e.result_metadata,
+                    result_message=(
+                        str(e)
+                        if not oversized_fields
+                        else (
+                            f"{e} (additionally, metadata field(s) {', '.join(oversized_fields)} exceeded "
+                            f"the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped)"
+                        )
+                    ),
+                    result_metadata=None if oversized_fields else e.result_metadata,
                 )
             )
         except Exception as e:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -184,6 +184,38 @@ def test_action_error_sets_result_metadata_and_keeps_failed_status() -> None:
     assert failed.result_message == "bad input"
 
 
+def test_oversized_result_metadata_fails_action_instead_of_reporting_succeeded() -> None:
+    def target(ctx: ActionContext) -> None:
+        ctx.set_result("done", metadata={"blob": "x" * 600})
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="big-result", target=target))
+    extractor._dispatch_single_action(_make_action("act-big", "big-result"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.failed
+    assert final.result_metadata is None
+    assert "big-result" in (final.result_message or "")
+    assert "blob" in (final.result_message or "")
+    assert "512" in (final.result_message or "")
+
+
+def test_oversized_action_error_metadata_drops_metadata_but_keeps_original_message() -> None:
+    def target(ctx: ActionContext) -> None:
+        raise ActionError("bad input", error_type="invalid_parameter", details="x" * 600)
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="strict-big", target=target))
+    extractor._dispatch_single_action(_make_action("act-strict-big", "strict-big"))
+
+    updates = _queued_updates(extractor)
+    failed = next(u for u in updates if u.status == ActionStatus.failed)
+    assert failed.result_metadata is None
+    assert "bad input" in (failed.result_message or "")
+    assert "512" in (failed.result_message or "")
+
+
 def test_custom_action_receives_call_metadata_in_context() -> None:
     received_metadata: list[dict | None] = []
 

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cognite.extractorutils.unstable.core._dto import Action, ActionStatus, ActionUpdate
+from cognite.extractorutils.unstable.core._dto import MAX_MESSAGE_LENGTH, Action, ActionStatus, ActionUpdate
 from cognite.extractorutils.unstable.core.actions import ActionContext, ActionError, CustomAction
 from cognite.extractorutils.unstable.core.base import FullConfig
 from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
@@ -232,6 +232,50 @@ def test_oversized_action_error_metadata_all_fields_oversized_normalizes_to_none
     updates = _queued_updates(extractor)
     failed = next(u for u in updates if u.status == ActionStatus.failed)
     assert failed.result_metadata is None
+
+
+def test_oversized_result_metadata_with_many_fields_truncates_message_instead_of_crashing() -> None:
+    # Regression test: ctx.set_result() places no cap on the number or length of metadata keys, so
+    # joining many oversized field names into the failure message could exceed MessageType's
+    # 1000-char limit and raise a pydantic.ValidationError while constructing the ActionUpdate —
+    # which, for this branch, would be swallowed by the generic `except Exception` fallback and
+    # silently discard the valid metadata this whole mechanism exists to preserve.
+    def target(ctx: ActionContext) -> None:
+        oversized = {f"oversized_field_number_{i:03d}": "x" * 600 for i in range(45)}
+        ctx.set_result("done", metadata={"summary": "ok", **oversized})
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="huge-result", target=target))
+    extractor._dispatch_single_action(_make_action("act-huge", "huge-result"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.failed
+    assert final.result_metadata == {"summary": "ok"}
+    assert final.result_message is not None
+    assert len(final.result_message) <= MAX_MESSAGE_LENGTH
+    assert final.result_message.endswith("...")
+
+
+def test_oversized_action_error_with_long_message_truncates_instead_of_crashing() -> None:
+    # Regression test: ActionError places no length limit on its own message either, so appending
+    # the "metadata field(s) dropped" note could push the combined result_message past the 1000-char
+    # limit. Unlike the success-path branch, this ActionUpdate(...) call isn't nested in any further
+    # try/except, so a ValidationError here would escape _handle_custom_action entirely and kill the
+    # dispatch thread, leaving the action stuck at "running" forever.
+    def target(ctx: ActionContext) -> None:
+        raise ActionError("x" * 1200, error_type="invalid_parameter", details="y" * 600)
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="strict-huge-msg", target=target))
+    extractor._dispatch_single_action(_make_action("act-strict-huge-msg", "strict-huge-msg"))
+
+    updates = _queued_updates(extractor)
+    failed = next(u for u in updates if u.status == ActionStatus.failed)
+    assert failed.result_metadata == {"error_type": "invalid_parameter"}
+    assert failed.result_message is not None
+    assert len(failed.result_message) <= MAX_MESSAGE_LENGTH
+    assert failed.result_message.endswith("...")
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -201,7 +201,7 @@ def test_oversized_result_metadata_fails_action_instead_of_reporting_succeeded()
     assert "512" in (final.result_message or "")
 
 
-def test_oversized_action_error_metadata_drops_metadata_but_keeps_original_message() -> None:
+def test_oversized_action_error_metadata_drops_only_oversized_field() -> None:
     def target(ctx: ActionContext) -> None:
         raise ActionError("bad input", error_type="invalid_parameter", details="x" * 600)
 
@@ -211,8 +211,9 @@ def test_oversized_action_error_metadata_drops_metadata_but_keeps_original_messa
 
     updates = _queued_updates(extractor)
     failed = next(u for u in updates if u.status == ActionStatus.failed)
-    assert failed.result_metadata is None
+    assert failed.result_metadata == {"error_type": "invalid_parameter"}
     assert "bad input" in (failed.result_message or "")
+    assert "error_detail" in (failed.result_message or "")
     assert "512" in (failed.result_message or "")
 
 

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -184,9 +184,9 @@ def test_action_error_sets_result_metadata_and_keeps_failed_status() -> None:
     assert failed.result_message == "bad input"
 
 
-def test_oversized_result_metadata_fails_action_instead_of_reporting_succeeded() -> None:
+def test_oversized_result_metadata_fails_action_but_keeps_valid_fields() -> None:
     def target(ctx: ActionContext) -> None:
-        ctx.set_result("done", metadata={"blob": "x" * 600})
+        ctx.set_result("done", metadata={"summary": "ok", "blob": "x" * 600})
 
     extractor = _make_extractor()
     extractor.add_action(CustomAction(name="big-result", target=target))
@@ -195,7 +195,7 @@ def test_oversized_result_metadata_fails_action_instead_of_reporting_succeeded()
     updates = _queued_updates(extractor)
     final = updates[-1]
     assert final.status == ActionStatus.failed
-    assert final.result_metadata is None
+    assert final.result_metadata == {"summary": "ok"}
     assert "big-result" in (final.result_message or "")
     assert "blob" in (final.result_message or "")
     assert "512" in (final.result_message or "")
@@ -215,6 +215,23 @@ def test_oversized_action_error_metadata_drops_only_oversized_field() -> None:
     assert "bad input" in (failed.result_message or "")
     assert "error_detail" in (failed.result_message or "")
     assert "512" in (failed.result_message or "")
+
+
+def test_oversized_action_error_metadata_all_fields_oversized_normalizes_to_none() -> None:
+    # Regression test: error_type itself is caller-supplied and unbounded (ActionError places no
+    # length limit on it), so it — not just the optional error_detail — can end up oversized. When
+    # every field is dropped, result_metadata must be None (field omitted from the checkin payload),
+    # not {} (field sent as an empty object, an untested Integrations API edge case).
+    def target(ctx: ActionContext) -> None:
+        raise ActionError("bad input", error_type="x" * 600)
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="strict-huge", target=target))
+    extractor._dispatch_single_action(_make_action("act-strict-huge", "strict-huge"))
+
+    updates = _queued_updates(extractor)
+    failed = next(u for u in updates if u.status == ActionStatus.failed)
+    assert failed.result_metadata is None
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from cognite.extractorutils.unstable.core._dto import (
+    MAX_METADATA_VALUE_BYTES,
     Action,
     ActionStatus,
     ActionType,
@@ -11,6 +12,7 @@ from cognite.extractorutils.unstable.core._dto import (
     CheckinResponse,
     ExtractorInfo,
     StartupRequest,
+    oversized_metadata_fields,
 )
 
 
@@ -229,3 +231,30 @@ def test_action_status_lookup_by_value(value: str) -> None:
 def test_action_status_invalid_value_raises() -> None:
     with pytest.raises(ValueError):
         ActionStatus("unknown_status")
+
+
+@pytest.mark.parametrize("metadata", [None, {}])
+def test_oversized_metadata_fields_empty_or_none_returns_empty_list(metadata: dict[str, str] | None) -> None:
+    assert oversized_metadata_fields(metadata) == []
+
+
+def test_oversized_metadata_fields_flags_only_the_oversized_keys() -> None:
+    metadata = {"small": "ok", "big": "x" * (MAX_METADATA_VALUE_BYTES + 1)}
+    assert oversized_metadata_fields(metadata) == ["big"]
+
+
+@pytest.mark.parametrize(
+    "size,expect_flagged",
+    [(MAX_METADATA_VALUE_BYTES, False), (MAX_METADATA_VALUE_BYTES + 1, True)],
+)
+def test_oversized_metadata_fields_boundary_is_inclusive_of_the_limit(size: int, expect_flagged: bool) -> None:
+    flagged = oversized_metadata_fields({"value": "x" * size})
+    assert flagged == (["value"] if expect_flagged else [])
+
+
+def test_oversized_metadata_fields_non_string_value_is_coerced_instead_of_raising() -> None:
+    # Regression test: metadata is typed dict[str, str], but that's not enforced at runtime, and
+    # set_result() is a user-facing API that extractor authors call directly. A non-string value
+    # must not crash the check with an AttributeError on `.encode`.
+    assert oversized_metadata_fields({"count": 3}) == []  # type: ignore[dict-item]
+    assert oversized_metadata_fields({"count": 10**600}) == ["count"]  # type: ignore[dict-item]

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -12,6 +12,7 @@ from cognite.extractorutils.unstable.core._dto import (
     CheckinResponse,
     ExtractorInfo,
     StartupRequest,
+    drop_oversized_metadata_fields,
     oversized_metadata_fields,
 )
 
@@ -258,3 +259,27 @@ def test_oversized_metadata_fields_non_string_value_is_coerced_instead_of_raisin
     # must not crash the check with an AttributeError on `.encode`.
     assert oversized_metadata_fields({"count": 3}) == []  # type: ignore[dict-item]
     assert oversized_metadata_fields({"count": 10**600}) == ["count"]  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize("metadata", [None, {}, {"small": "ok"}])
+def test_drop_oversized_metadata_fields_returns_input_unchanged_when_nothing_oversized(
+    metadata: dict[str, str] | None,
+) -> None:
+    assert drop_oversized_metadata_fields(metadata) == (metadata, [])
+
+
+def test_drop_oversized_metadata_fields_keeps_only_the_non_oversized_keys() -> None:
+    metadata = {"small": "ok", "big": "x" * (MAX_METADATA_VALUE_BYTES + 1)}
+    filtered, dropped = drop_oversized_metadata_fields(metadata)
+    assert filtered == {"small": "ok"}
+    assert dropped == ["big"]
+
+
+def test_drop_oversized_metadata_fields_normalizes_to_none_when_nothing_remains() -> None:
+    # Both fields oversized (or the only field is oversized) must leave `None`, not `{}` — an empty
+    # dict would still serialize as an explicit `resultMetadata: {}` in the checkin payload (only
+    # `None` fields are excluded), an untested edge case for the Integrations API.
+    metadata = {"big": "x" * (MAX_METADATA_VALUE_BYTES + 1)}
+    filtered, dropped = drop_oversized_metadata_fields(metadata)
+    assert filtered is None
+    assert dropped == ["big"]

--- a/tests/test_unstable/test_dto.py
+++ b/tests/test_unstable/test_dto.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from cognite.extractorutils.unstable.core._dto import (
+    MAX_MESSAGE_LENGTH,
     MAX_METADATA_VALUE_BYTES,
     Action,
     ActionStatus,
@@ -14,6 +15,7 @@ from cognite.extractorutils.unstable.core._dto import (
     StartupRequest,
     drop_oversized_metadata_fields,
     oversized_metadata_fields,
+    truncate_message,
 )
 
 
@@ -283,3 +285,21 @@ def test_drop_oversized_metadata_fields_normalizes_to_none_when_nothing_remains(
     filtered, dropped = drop_oversized_metadata_fields(metadata)
     assert filtered is None
     assert dropped == ["big"]
+
+
+@pytest.mark.parametrize("length", [0, MAX_MESSAGE_LENGTH - 1, MAX_MESSAGE_LENGTH])
+def test_truncate_message_leaves_short_messages_unchanged(length: int) -> None:
+    message = "x" * length
+    assert truncate_message(message) == message
+
+
+def test_truncate_message_shortens_long_messages_to_the_limit_with_a_marker() -> None:
+    # Regression test: ActionUpdate.result_message is a pydantic MessageType capped at
+    # MAX_MESSAGE_LENGTH chars; constructing one with a longer message raises ValidationError.
+    # Messages built from unbounded inputs (action names, metadata keys, exception text) must be
+    # truncated before they ever reach ActionUpdate(...).
+    message = "x" * (MAX_MESSAGE_LENGTH + 250)
+    truncated = truncate_message(message)
+    assert len(truncated) == MAX_MESSAGE_LENGTH
+    assert truncated.endswith("...")
+    assert truncated.startswith("x" * (MAX_MESSAGE_LENGTH - 3))

--- a/tests/test_unstable/test_log_upload_action.py
+++ b/tests/test_unstable/test_log_upload_action.py
@@ -308,6 +308,56 @@ def test_valid_exact_max_days_range_succeeds_at_dispatch(tmp_path: Path) -> None
     assert ActionStatus.failed not in statuses
 
 
+def _write_daily_rotated_files(log_path: Path, start: date, end: date) -> None:
+    current = start
+    while current <= end:
+        rotated = log_path.parent / f"{log_path.name}.{current.isoformat()}"
+        rotated.write_bytes(b"log line\n" * 50)
+        current += timedelta(days=1)
+
+
+def test_max_range_with_uploads_keeps_files_metadata_within_budget(tmp_path: Path) -> None:
+    # Regression test: 'files' used to embed each file's full external_id, which for a real
+    # MAX_DATE_RANGE_DAYS range exceeds CDF's 512-byte metadata value limit. It now references the
+    # compact numeric CDF file id instead, so it must fit even in the worst case (max int64 id).
+    start = date(2026, 6, 1)
+    end = start + timedelta(days=MAX_DATE_RANGE_DAYS - 1)
+    log_path = tmp_path / "extractor.log"
+    _write_daily_rotated_files(log_path, start, end)
+
+    extractor = _make_extractor(log_path=log_path)
+    extractor.cognite_client.files.upload_bytes.return_value = MagicMock(id=9223372036854775807)
+    updates = _dispatch(extractor, {"start_date": str(start), "end_date": str(end)})
+    succeeded = next(u for u in updates if u.status == ActionStatus.succeeded)
+    assert succeeded.result_metadata is not None
+    assert succeeded.result_metadata["uploaded_files"] == str(MAX_DATE_RANGE_DAYS)
+    assert "files" in succeeded.result_metadata
+    files = json.loads(succeeded.result_metadata["files"])
+    assert len(files) == MAX_DATE_RANGE_DAYS
+    assert all(f["status"] == "uploaded" and f["id"] == "9223372036854775807" for f in files)
+    assert "file_external_id" not in files[0]
+
+
+def test_files_metadata_omitted_when_still_oversized(tmp_path: Path) -> None:
+    # Defense in depth: even with the compact schema, a pathological case (e.g. long per-file error
+    # messages) could still overflow the budget. The action must still succeed on the aggregate
+    # counts, gracefully omitting 'files' rather than producing an oversized result that Odin would
+    # reject and retry forever.
+    start = date(2026, 6, 1)
+    end = start + timedelta(days=MAX_DATE_RANGE_DAYS - 1)
+    log_path = tmp_path / "extractor.log"
+    _write_daily_rotated_files(log_path, start, end)
+
+    extractor = _make_extractor(log_path=log_path)
+    extractor.cognite_client.files.upload_bytes.side_effect = RuntimeError("x" * 150)
+    updates = _dispatch(extractor, {"start_date": str(start), "end_date": str(end)})
+    succeeded = next(u for u in updates if u.status == ActionStatus.succeeded)
+    assert succeeded.result_metadata is not None
+    assert succeeded.result_metadata["failed_files"] == str(MAX_DATE_RANGE_DAYS)
+    assert "files" not in succeeded.result_metadata
+    assert "omitted" in (succeeded.result_message or "")
+
+
 def test_range_spanning_rotated_and_live_file(tmp_path: Path) -> None:
     # Covers the common case: start_date = yesterday (rotated file), end_date = today (live file).
     base = tmp_path / "extractor.log"
@@ -414,9 +464,10 @@ def test_upload_candidate_bounded_reader_content_is_actually_consumable(tmp_path
     candidate = LogFileCandidate(log_date=_PAST_TODAY, path=path, is_current=True)
     consumed: dict[str, object] = {}
 
-    def capture_upload(*, content: BoundedReader, **kwargs: object) -> None:
+    def capture_upload(*, content: BoundedReader, **kwargs: object) -> MagicMock:
         consumed["length"] = len(content)
         consumed["bytes"] = content.read()
+        return MagicMock(id=123)
 
     mock_client = MagicMock()
     mock_client.files.upload_bytes.side_effect = capture_upload


### PR DESCRIPTION
### Summary
Fixes the fetch_logs action so its result metadata can't exceed CDF's 512-byte-per-value limit, and prevents oversized metadata from silently poisoning the checkin batch.

### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### What changed
- `cognite/extractorutils/unstable/core/_dto.py`: added **MAX_METADATA_VALUE_BYTES** (512) constant and **oversized_metadata_fields()** helper to detect metadata dict values exceeding CDF's per-value byte limit.
- `cognite/extractorutils/unstable/core/_log_upload_action.py`:
  - **_FileUploadResult** now carries file_id (the numeric CDF file ID returned by upload_bytes), set only when status == "uploaded".
  - Per-file files metadata entries now use the compact numeric id instead of the full file_external_id string, and only include size_bytes for non-uploaded entries - shrinking the payload so it fits within **MAX_METADATA_VALUE_BYTES** even at **MAX_DATE_RANGE_DAYS**.
  - Added a size check before attaching files to the result metadata: if the serialized JSON still exceeds the 512-byte limit, it's omitted (with a log line and a note appended to the result message) rather than risking the whole result being rejected. The aggregate counts (total_files, uploaded_files, etc.) are always included regardless.
- `cognite/extractorutils/unstable/core/base.py`: in **_dispatch_single_action**, both the success and ActionError paths now check **oversized_metadata_fields()** before queuing the checkin update:
  - Success path: if any result metadata field is oversized, the action is reported as failed instead (with an explanatory message) rather than queuing a payload Odin would reject.
  - ActionError path: if **e.result_metadata** has oversized fields, they're dropped and the failure message notes which fields were dropped, instead of sending metadata that would get rejected.
- Tests added/updated in `tests/test_unstable/test_action_dispatch.py` and `tests/test_unstable/test_log_upload_action.py` covering all of the above.

### Why it changed
- Related issue: EDG-678
- Related docs / discussion: Odin's checkin API rejects the entire batch of pending action updates if any single metadata value exceeds 512 bytes ("Metadata values may be at most 512 bytes"). Because checkin bundles all pending updates and requeues the whole batch on rejection, one oversized files value (previously embedding full file external IDs per day) could poison retries indefinitely for **fetch_logs** runs over long date ranges.

### What to focus on during review
- The reasoning in **base.py** for turning an otherwise-successful action into a failed checkin update when its result metadata is oversized - confirm this fail-closed behaviour (vs. silently truncating/dropping just the offending field) is the desired tradeoff.
- The fallback behaviour in **_log_upload_action.py** when files still doesn't fit even after switching to numeric IDs (aggregate counts still reported, files omitted, message annotated).
- Whether omitting file_external_id from per-file entries (replaced by numeric id) is acceptable for any downstream consumers of that metadata field.

### Test evidence
- New/updated unit tests: `test_oversized_result_metadata_fails_action_instead_of_reporting_succeeded`,
`test_oversized_action_error_metadata_drops_metadata_but_keeps_original_message`, `test_max_range_with_uploads_keeps_files_metadata_within_budget`,
`test_files_metadata_omitted_when_still_oversized`.

### Risks and unknowns
- Any external tooling/dashboards that currently parse **file_external_id** out of the files metadata field would need to switch to reconstructing it from id/date, or querying CDF by file ID.

### Rollout and rollback
- No migrations or config changes. Pure behaviour change in metadata reporting, revertible via normal git revert.
