### PR TITLE
fix(odin): Fix checkin worker picklable

### DIFF
--- a/cognite/extractorutils/unstable/core/checkin_worker.py
+++ b/cognite/extractorutils/unstable/core/checkin_worker.py
@@ -101,6 +101,28 @@ class CheckinWorker:
         self._lock = RLock()
         self._flush_lock = RLock()
 
+    def __getstate__(self) -> dict[str, object]:
+        """
+        Return the worker's state for pickling, dropping the locks.
+
+        The worker is passed to ``multiprocessing.Process`` as a target argument, which pickles it
+        when the process is started with the ``spawn`` method (the default on macOS and Windows).
+        ``threading.RLock`` cannot be pickled, and a lock inherited from the parent process would be
+        meaningless in the child anyway, so the locks are recreated fresh in ``__setstate__`` instead.
+        """
+        state = self.__dict__.copy()
+        del state["_lock"]
+        del state["_flush_lock"]
+        return state
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        """
+        Restore the worker's state after unpickling, recreating the locks dropped by ``__getstate__``.
+        """
+        self.__dict__.update(state)
+        self._lock = RLock()
+        self._flush_lock = RLock()
+
     @property
     def active_revision(self) -> ConfigRevision:
         """Get the active configuration revision."""

--- a/tests/test_unstable/test_checkin_worker.py
+++ b/tests/test_unstable/test_checkin_worker.py
@@ -615,5 +615,10 @@ def test_checkin_worker_is_picklable_with_spawn_start_method() -> None:
         assert result_queue.get(timeout=10) == 3
     finally:
         process.join(timeout=10)
+        if process.is_alive():
+            # Only reached if the process failed to exit on its own (e.g. the assert above raised
+            # before the process could finish); avoids leaking a background process in that case.
+            process.terminate()
+        process.join(timeout=5)
 
     assert process.exitcode == 0

--- a/tests/test_unstable/test_checkin_worker.py
+++ b/tests/test_unstable/test_checkin_worker.py
@@ -1,13 +1,17 @@
 import logging
+import pickle
 from collections.abc import Callable
 from datetime import datetime, timezone
-from multiprocessing import Event, Queue
+from multiprocessing import Event, Queue, get_context
 from threading import Thread
 from time import sleep
 
 import faker
 import pytest
 import requests_mock
+from cognite.client import CogniteClient
+from cognite.client.config import ClientConfig
+from cognite.client.credentials import OAuthClientCredentials
 
 from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import ConnectionConfig
@@ -16,6 +20,39 @@ from cognite.extractorutils.unstable.core.checkin_worker import CheckinWorker
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 from cognite.extractorutils.util import now
 from tests.test_unstable.conftest import TestConfig, TestExtractor
+
+
+def _make_local_cognite_client() -> CogniteClient:
+    """
+    Build a CogniteClient that never talks to the network, for tests that only exercise pickling.
+
+    Avoids the live-integration `connection_config` fixture, which provisions a real integration
+    in a CDF project and therefore requires dev credentials to be set in the environment.
+    """
+    return CogniteClient(
+        ClientConfig(
+            client_name="test-checkin-worker-pickling",
+            project="test-project",
+            base_url="https://api.cognitedata.com",
+            credentials=OAuthClientCredentials(
+                token_url="https://example.com/token",
+                client_id="client-id",
+                client_secret="client-secret",
+                scopes=["scope"],
+            ),
+        )
+    )
+
+
+def _put_active_revision_in_queue(worker: CheckinWorker, result_queue: "Queue[int]") -> None:
+    """
+    Module-level target for the spawn-based multiprocessing test below.
+
+    A spawned child process re-imports this function by qualified name, so it must be a
+    top-level, module-scoped callable rather than a closure or a lambda.
+    """
+    with worker._lock, worker._flush_lock:
+        result_queue.put(worker.active_revision)
 
 
 def test_report_startup_request(
@@ -536,3 +573,47 @@ def test_run_report_periodic_checkin_requeue(
     # initial 2 requests for auth and startup, then 1 for expected number of check-ins
     assert requests_mock.call_count == 2 + 1
     assert len(worker._errors) == 2
+
+
+def test_checkin_worker_pickle_round_trip() -> None:
+    """
+    __getstate__/__setstate__ must drop the un-picklable RLocks and recreate fresh, usable ones,
+    while preserving the rest of the worker's state.
+    """
+    worker = CheckinWorker(_make_local_cognite_client(), "test-integration", logging.getLogger(__name__))
+    worker.active_revision = 5
+    worker.report_task_start("some-task")
+
+    restored: CheckinWorker = pickle.loads(pickle.dumps(worker))  # noqa: S301 (data is produced in-process, not untrusted)
+
+    assert restored.active_revision == 5
+    assert len(restored._task_updates) == 1
+    assert restored._lock is not worker._lock
+    assert restored._flush_lock is not worker._flush_lock
+
+    # The recreated locks must actually be usable, not left in some broken or shared state.
+    with restored._lock, restored._flush_lock:
+        pass
+
+
+def test_checkin_worker_is_picklable_with_spawn_start_method() -> None:
+    """
+    Runtime._spawn_extractor passes a live CheckinWorker to multiprocessing.Process as a target argument.
+
+    On macOS and Windows, the default start method is "spawn", which pickles every argument passed to
+    Process(...). This reproduces that path directly: threading.RLock instances used to make the whole
+    worker unpicklable, crashing the extractor with a TypeError before any provider/destination code ran.
+    """
+    worker = CheckinWorker(_make_local_cognite_client(), "test-integration", logging.getLogger(__name__))
+    worker.active_revision = 3
+
+    ctx = get_context("spawn")
+    result_queue: Queue[int] = ctx.Queue()
+    process = ctx.Process(target=_put_active_revision_in_queue, args=(worker, result_queue))
+    process.start()
+    try:
+        assert result_queue.get(timeout=10) == 3
+    finally:
+        process.join(timeout=10)
+
+    assert process.exitcode == 0


### PR DESCRIPTION
Summary

Fixes CheckinWorker so it can be pickled, unblocking extractor startup on macOS/Windows where multiprocessing defaults to the spawn start method.

Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

What changed

- cognite/extractorutils/unstable/core/checkin_worker.py: added CheckinWorker.__getstate__/__setstate__. __getstate__ drops _lock and _flush_lock
(both threading.RLock) from the pickled state; __setstate__ recreates fresh RLock instances after unpickling.
- cognite/extractorutils/unstable/core/runtime.py: removed a leftover local-checkout debug log line (unrelated stray change already on the branch).
- .gitignore: resolved an unrelated, unresolved merge-conflict marker block (<<<<<<< Updated upstream / ======= / >>>>>>> Stashed changes) already
present on the branch, collapsing it to the single intended /files entry.
- tests/test_unstable/test_checkin_worker.py: added two tests, test_checkin_worker_pickle_round_trip and
test_checkin_worker_is_picklable_with_spawn_start_method (see below).

Why it changed

- Related issue: EDG-679 (https://cognitedata.atlassian.net/browse/EDG-679)
- Runtime._spawn_extractor passes a live CheckinWorker instance as an argument to multiprocessing.Process(...). On Linux, the default start method
is fork, which doesn't pickle args, so the bug is invisible in CI/Docker. On macOS and Windows, the default start method is spawn, which pickles
every argument. CheckinWorker held threading.RLock instances (_lock, _flush_lock), and RLock objects can't be pickled, so the extractor crashed
immediately on startup with TypeError: cannot pickle '_thread.RLock' object before any provider/destination code ran — a full local-dev blocker on
macOS/Windows.

What to focus on during review

- The __getstate__/__setstate__ pair only strips the two locks; every other attribute (including the CogniteClient, Logger, queued errors/task
updates/action updates, and active_revision) round-trips through pickling unchanged. Worth double-checking no other non-picklable attribute gets
added to CheckinWorker in the future without updating __getstate__.
- Locks are intentionally not preserved across the pickle boundary — a lock inherited from the parent process would be meaningless in the child
anyway, so fresh locks are correct here rather than something to reconcile.
- Typed the state dict as dict[str, object] rather than dict[str, Any] to keep ANN401 clean, per repo convention.
- The two unrelated cleanups (runtime.py debug log line, .gitignore conflict block) were pre-existing on this branch before I started — flagging in
case you want them split into a separate commit, though they're trivial enough I folded them in.

Test evidence

- test_checkin_worker_pickle_round_trip: pickles/unpickles a CheckinWorker directly and asserts queued state (active_revision, _task_updates)
survives, and that the recreated _lock/_flush_lock are new, distinct, usable RLock objects.
- test_checkin_worker_is_picklable_with_spawn_start_method: reproduces the actual bug — spawns a real
multiprocessing.get_context("spawn").Process(...) with a live CheckinWorker as a target arg, matching Runtime._spawn_extractor's exact usage.
- Verified both tests fail with the exact reported TypeError: cannot pickle '_thread.RLock' object when the fix is reverted, and pass with it
applied.
- ruff check / ruff format --check: clean on all changed files.
- mypy: clean on checkin_worker.py and runtime.py.
- Full non-integration unit suite (tests/tests_unit): 133 passed, 1 pre-existing unrelated failure (test_load_config_keyvault, missing
KEYVAULT_TENANT_ID env var — confirmed failing on master too, unrelated to this change).
- tests/test_unstable and tests/tests_integration require live CDF dev credentials (COGNITE_DEV_* env vars) not available in this environment —
pre-existing constraint, not something this change affects; the two new tests were deliberately written to avoid needing those credentials.

Risks and unknowns

- None identified for the core fix — it's a narrow, additive change (drop/recreate two locks) with no behavioral change on fork-based platforms
(Linux), which is why the bug was invisible there in the first place.
- Separately, unrelated to this ticket: .gitignore line 144 has a stray ======= merge-conflict marker already committed on master (predates this
branch). Harmless to git (matches no files) but worth a follow-up cleanup PR.

Rollout and rollback

- No migrations, flags, or config changes. Pure library code change — revert is a straightforward git revert if needed.

Checklist

- [x] Self-reviewed the diff
- [x] Tests added or updated (or N/A with reason)
- [ ] Docs updated (or N/A) — N/A, no public API/behavior change requiring doc updates
- [x] No secrets, credentials, or PII committed
- [ ] Breaking changes called out above and communicated to affected teams — N/A, not a breaking change