### PR TITLE
Release 7.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## 7.13.1
+
+### Fixed
+* In the `unstable` package: Fixed `fetch_logs` action result metadata exceeding CDF's 512-byte-per-value limit on long date ranges, which could cause the entire checkin batch to be rejected and retried indefinitely.
+* In the `unstable` package: Fixed `CheckinWorker` not being picklable, which crashed extractor startup on macOS/Windows where multiprocessing defaults to the `spawn` start method.
+
 ## 7.13.0
 
 ### Added

--- a/cognite/extractorutils/__init__.py
+++ b/cognite/extractorutils/__init__.py
@@ -16,7 +16,7 @@
 Cognite extractor utils is a Python package that simplifies the development of new extractors.
 """
 
-__version__ = "7.13.0"
+__version__ = "7.13.1"
 from .base import Extractor
 
 __all__ = ["Extractor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognite-extractor-utils"
-version = "7.13.0"
+version = "7.13.1"
 description = "Utilities for easier development of extractors for CDF"
 authors = [
     {name = "Mathias Lohne", email = "mathias.lohne@cognite.com"}


### PR DESCRIPTION
### Summary
- Patch release **7.13.1**, bumping the version and documenting two bug fixes merged into the unstable package since **7.13.0**.

### What changed
- `pyproject.toml` / `cognite/extractorutils/__init__.py`: version bump **7.13.0** → **7.13.1**
- `CHANGELOG.md`: added **7.13.1** entry documenting:
  - Fixed fetch_logs action result metadata exceeding CDF's 512-byte-per-value limit on long date ranges, which could cause the entire checkin batch to be rejected and retried indefinitely. (#555, EDG-678)
  - Fixed CheckinWorker not being picklable, which crashed extractor startup on macOS/Windows where multiprocessing defaults to the spawn start method. (#556, EDG-679)

### Type of change
- Chore / release

### Test plan
- Both underlying fixes (#555, #556) were tested and merged independently