### PR TITLE
feat(odin): Action support in ContinuousTask

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -382,12 +382,13 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             raise ValueError(f"Custom action '{action.name}' is already registered.")
 
         reserved_names = {
-            name for t in self._tasks if isinstance(t, ScheduledTask) for name in (f"Start {t.name}", f"Stop {t.name}")
+            name
+            for t in self._tasks
+            if isinstance(t, (ScheduledTask, ContinuousTask))
+            for name in (f"Start {t.name}", f"Stop {t.name}")
         }
         if action.name in reserved_names:
-            raise ValueError(
-                f"Custom action name '{action.name}' conflicts with an auto-generated scheduled task action."
-            )
+            raise ValueError(f"Custom action name '{action.name}' conflicts with an auto-generated task action.")
 
         self._custom_actions.append(action)
 
@@ -402,7 +403,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         available_actions: list[AvailableActionWrite] = []
 
         for t in self._tasks:
-            if isinstance(t, ScheduledTask):
+            if isinstance(t, (ScheduledTask, ContinuousTask)):
                 available_actions.append(
                     AvailableActionWrite(name=f"Start {t.name}", type=ActionType.start_task, task=t.name)
                 )
@@ -422,7 +423,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             tasks=[
                 DtoTask(
                     type=TaskType.continuous if isinstance(t, ContinuousTask) else TaskType.batch,
-                    action=isinstance(t, ScheduledTask),
+                    action=isinstance(t, (ScheduledTask, ContinuousTask)),
                     description=t.description,
                     name=t.name,
                 )
@@ -484,7 +485,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         if any(t.name == task.name for t in self._tasks):
             raise ValueError(f"Task '{task.name}' is already registered.")
 
-        if isinstance(task, ScheduledTask):
+        if isinstance(task, (ScheduledTask, ContinuousTask)):
             conflict_names = {f"Start {task.name}", f"Stop {task.name}"}
             for action in self._custom_actions:
                 if action.name in conflict_names:
@@ -532,17 +533,20 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     task=lambda: self._run_task_with_token(t),
                 )
 
-    def _run_task_with_token(self, task: ScheduledTask, child_token: CancellationToken | None = None) -> None:
+    def _run_task_with_token(
+        self, task: ScheduledTask | ContinuousTask, child_token: CancellationToken | None = None
+    ) -> None:
         """
-        Create a fresh child cancellation token for a scheduled task run.
+        Create a fresh child cancellation token for an actionable task run.
 
         Stores the token in ``_running_task_tokens`` for external cancellation (e.g. a
-        stop_task action), then executes the task. Called by both the scheduler and any
-        future start_task action handler.
+        stop_task action), then executes the task. Called by the scheduler (for
+        ``ScheduledTask``), the initial boot-time launch (for ``ContinuousTask``), and the
+        start_task action handler (for both).
 
-        If ``child_token`` is supplied (action dispatch path), the caller has already
-        registered it in ``_running_task_tokens`` atomically; this method skips the
-        registration step and goes straight to execution.
+        If ``child_token`` is supplied (the caller has already registered it in
+        ``_running_task_tokens`` atomically), this method skips the registration step and
+        goes straight to execution.
         """
         if child_token is None:
             with self._running_task_tokens_lock:
@@ -558,6 +562,23 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 if self._running_task_tokens.get(task.name) is child_token:
                     self._running_task_tokens.pop(task.name, None)
 
+    def _launch_continuous_task(self, task: ContinuousTask) -> None:
+        """
+        Start a ``ContinuousTask`` in its own thread, tracked for external Start/Stop actions.
+
+        The token is pre-registered in ``_running_task_tokens`` before the thread starts (rather
+        than letting ``_run_task_with_token`` register it lazily inside the spawned thread), so
+        there is no race window where a Stop/Start action could run before this instance is visible.
+        """
+        child_token = self.cancellation_token.create_child_token()
+        with self._running_task_tokens_lock:
+            self._running_task_tokens[task.name] = child_token
+        Thread(
+            name=pascalize(task.name),
+            target=self._run_task_with_token,
+            args=(task, child_token),
+        ).start()
+
     def _handle_actions(self, actions: list[Action]) -> None:
         for action in actions:
             Thread(
@@ -568,8 +589,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             ).start()
 
     def _dispatch_single_action(self, action: Action) -> None:
-        scheduled_start_names = {f"Start {t.name}" for t in self._tasks if isinstance(t, ScheduledTask)}
-        scheduled_stop_names = {f"Stop {t.name}" for t in self._tasks if isinstance(t, ScheduledTask)}
+        actionable_tasks = [t for t in self._tasks if isinstance(t, (ScheduledTask, ContinuousTask))]
+        scheduled_start_names = {f"Start {t.name}" for t in actionable_tasks}
+        scheduled_stop_names = {f"Stop {t.name}" for t in actionable_tasks}
         custom_names = {a.name for a in self._custom_actions}
 
         if action.action_name in scheduled_start_names:
@@ -590,7 +612,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
     def _handle_start_task_action(self, action: Action) -> None:
         task_name = action.action_name[len("Start ") :]
         task = next(
-            (t for t in self._tasks if t.name == task_name and isinstance(t, ScheduledTask)),
+            (t for t in self._tasks if t.name == task_name and isinstance(t, (ScheduledTask, ContinuousTask))),
             None,
         )
         if task is None:
@@ -598,7 +620,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 ActionUpdate(
                     external_id=action.external_id,
                     status=ActionStatus.failed,
-                    result_message=f"No scheduled task named '{task_name}' found",
+                    result_message=f"No startable task named '{task_name}' found",
                 )
             )
             return
@@ -835,17 +857,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._logger.info("Startup done")
 
         for task in continuous:
-            Thread(
-                name=pascalize(task.name),
-                target=task.target,
-                args=(
-                    TaskContext(
-                        task=task,
-                        extractor=self,
-                        cancellation_token=self.cancellation_token.create_child_token(),
-                    ),
-                ),
-            ).start()
+            self._launch_continuous_task(task)
 
         if has_scheduled:
             self._scheduler.run()

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -569,15 +569,33 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         The token is pre-registered in ``_running_task_tokens`` before the thread starts (rather
         than letting ``_run_task_with_token`` register it lazily inside the spawned thread), so
         there is no race window where a Stop/Start action could run before this instance is visible.
+
+        If starting the thread itself fails (e.g. a thread/resource limit in a constrained
+        environment), the failure is reported as a fatal error for this task rather than left to
+        propagate — one task failing to launch should not crash the whole extractor or prevent the
+        remaining continuous tasks from starting.
         """
         child_token = self.cancellation_token.create_child_token()
         with self._running_task_tokens_lock:
             self._running_task_tokens[task.name] = child_token
-        Thread(
-            name=pascalize(task.name),
-            target=self._run_task_with_token,
-            args=(task, child_token),
-        ).start()
+        try:
+            Thread(
+                name=pascalize(task.name),
+                target=self._run_task_with_token,
+                args=(task, child_token),
+            ).start()
+        except Exception as e:
+            with self._running_task_tokens_lock:
+                if self._running_task_tokens.get(task.name) is child_token:
+                    self._running_task_tokens.pop(task.name, None)
+            message = f"Failed to launch continuous task '{task.name}'"
+            self._logger.log(level=ErrorLevel.fatal.log_level, msg=message, exc_info=e)
+            self._new_error(
+                level=ErrorLevel.fatal,
+                description=message,
+                details=str(e),
+                task_name=task.name,
+            ).instant()
 
     def _handle_actions(self, actions: list[Action]) -> None:
         for action in actions:

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -123,6 +123,11 @@ __all__ = [
 
 _T = TypeVar("_T", bound=ExtractorConfig)
 
+ACTIONABLE_TASK_TYPES: tuple[type[ScheduledTask], type[ContinuousTask]] = (ScheduledTask, ContinuousTask)
+"""Task types that get auto-generated ``Start``/``Stop`` actions and are tracked in
+``_running_task_tokens``. Kept as a single constant so every ``isinstance`` check that gates this
+behavior stays in sync - add a type here (and only here) to make a new task type actionable."""
+
 
 class FullConfig(Generic[_T]):
     """
@@ -384,7 +389,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         reserved_names = {
             name
             for t in self._tasks
-            if isinstance(t, (ScheduledTask, ContinuousTask))
+            if isinstance(t, ACTIONABLE_TASK_TYPES)
             for name in (f"Start {t.name}", f"Stop {t.name}")
         }
         if action.name in reserved_names:
@@ -403,7 +408,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         available_actions: list[AvailableActionWrite] = []
 
         for t in self._tasks:
-            if isinstance(t, (ScheduledTask, ContinuousTask)):
+            if isinstance(t, ACTIONABLE_TASK_TYPES):
                 available_actions.append(
                     AvailableActionWrite(name=f"Start {t.name}", type=ActionType.start_task, task=t.name)
                 )
@@ -423,7 +428,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             tasks=[
                 DtoTask(
                     type=TaskType.continuous if isinstance(t, ContinuousTask) else TaskType.batch,
-                    action=isinstance(t, (ScheduledTask, ContinuousTask)),
+                    action=isinstance(t, ACTIONABLE_TASK_TYPES),
                     description=t.description,
                     name=t.name,
                 )
@@ -485,7 +490,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         if any(t.name == task.name for t in self._tasks):
             raise ValueError(f"Task '{task.name}' is already registered.")
 
-        if isinstance(task, (ScheduledTask, ContinuousTask)):
+        if isinstance(task, ACTIONABLE_TASK_TYPES):
             conflict_names = {f"Start {task.name}", f"Stop {task.name}"}
             for action in self._custom_actions:
                 if action.name in conflict_names:
@@ -607,7 +612,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             ).start()
 
     def _dispatch_single_action(self, action: Action) -> None:
-        actionable_tasks = [t for t in self._tasks if isinstance(t, (ScheduledTask, ContinuousTask))]
+        actionable_tasks = [t for t in self._tasks if isinstance(t, ACTIONABLE_TASK_TYPES)]
         scheduled_start_names = {f"Start {t.name}" for t in actionable_tasks}
         scheduled_stop_names = {f"Stop {t.name}" for t in actionable_tasks}
         custom_names = {a.name for a in self._custom_actions}
@@ -630,7 +635,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
     def _handle_start_task_action(self, action: Action) -> None:
         task_name = action.action_name[len("Start ") :]
         task = next(
-            (t for t in self._tasks if t.name == task_name and isinstance(t, (ScheduledTask, ContinuousTask))),
+            (t for t in self._tasks if t.name == task_name and isinstance(t, ACTIONABLE_TASK_TYPES)),
             None,
         )
         if task is None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -2,13 +2,14 @@ import threading
 import time
 from collections.abc import Callable
 from threading import Event
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from cognite.extractorutils.unstable.core._dto import MAX_MESSAGE_LENGTH, Action, ActionStatus, ActionUpdate
 from cognite.extractorutils.unstable.core.actions import ActionContext, ActionError, CustomAction
 from cognite.extractorutils.unstable.core.base import FullConfig
+from cognite.extractorutils.unstable.core.errors import ErrorLevel
 from cognite.extractorutils.unstable.core.tasks import ContinuousTask, ScheduledTask, TaskContext
 
 from .conftest import TestConfig, TestExtractor
@@ -166,6 +167,25 @@ def test_launch_continuous_task_is_tracked_before_thread_starts() -> None:
 
     task_started.wait(timeout=5)
     allow_exit.set()
+
+
+def test_launch_continuous_task_reports_fatal_error_and_keeps_going_if_thread_start_fails() -> None:
+    extractor = _make_extractor()
+    task = ContinuousTask(name="listener", target=lambda ctx: None)
+    extractor.add_task(task)
+
+    with patch.object(threading.Thread, "start", side_effect=RuntimeError("can't start new thread")):
+        extractor._launch_continuous_task(task)  # must not raise
+
+    # The pre-registered token must be cleaned up rather than leaking forever.
+    assert "listener" not in extractor._running_task_tokens
+
+    reported = [c.args[0] for c in extractor._checkin_worker.report_error.call_args_list]
+    assert len(reported) == 1
+    error = reported[0]
+    assert error.level == ErrorLevel.fatal
+    assert error._task_name == "listener"
+    assert "listener" in error.description
 
 
 def test_stop_action_cancels_boot_launched_continuous_task() -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from collections.abc import Callable
 from threading import Event
 from unittest.mock import MagicMock
@@ -8,7 +9,7 @@ import pytest
 from cognite.extractorutils.unstable.core._dto import MAX_MESSAGE_LENGTH, Action, ActionStatus, ActionUpdate
 from cognite.extractorutils.unstable.core.actions import ActionContext, ActionError, CustomAction
 from cognite.extractorutils.unstable.core.base import FullConfig
-from cognite.extractorutils.unstable.core.tasks import ScheduledTask, TaskContext
+from cognite.extractorutils.unstable.core.tasks import ContinuousTask, ScheduledTask, TaskContext
 
 from .conftest import TestConfig, TestExtractor
 
@@ -142,6 +143,120 @@ def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
     assert token is not None and token.is_cancelled
 
     allow_exit.set()
+
+
+def test_launch_continuous_task_is_tracked_before_thread_starts() -> None:
+    extractor = _make_extractor()
+    task_started = Event()
+    allow_exit = Event()
+
+    def cancellable(ctx: TaskContext) -> None:
+        task_started.set()
+        allow_exit.wait(timeout=5)
+
+    task = ContinuousTask(name="listener", target=cancellable)
+    extractor.add_task(task)
+
+    extractor._launch_continuous_task(task)
+    # No race: the token is registered synchronously by _launch_continuous_task, before the
+    # spawned thread even starts, so it must already be present here.
+    with extractor._running_task_tokens_lock:
+        token = extractor._running_task_tokens.get("listener")
+    assert token is not None
+
+    task_started.wait(timeout=5)
+    allow_exit.set()
+
+
+def test_stop_action_cancels_boot_launched_continuous_task() -> None:
+    extractor = _make_extractor()
+    task_started = Event()
+    task_exited = Event()
+
+    def cancellable(ctx: TaskContext) -> None:
+        task_started.set()
+        ctx.cancellation_token.wait()
+        task_exited.set()
+
+    task = ContinuousTask(name="listener", target=cancellable)
+    extractor.add_task(task)
+    extractor._launch_continuous_task(task)
+    task_started.wait(timeout=5)
+
+    extractor._dispatch_single_action(_make_action("act-stop", "Stop listener"))
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.canceled and u.external_id == "act-stop" for u in updates)
+    assert task_exited.wait(timeout=5)
+    deadline = time.monotonic() + 5
+    while "listener" in extractor._running_task_tokens and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert "listener" not in extractor._running_task_tokens
+
+
+def test_start_action_on_running_continuous_task_reports_failed() -> None:
+    extractor = _make_extractor()
+    task_started = Event()
+    allow_exit = Event()
+
+    def cancellable(ctx: TaskContext) -> None:
+        task_started.set()
+        allow_exit.wait(timeout=5)
+
+    task = ContinuousTask(name="listener", target=cancellable)
+    extractor.add_task(task)
+    extractor._launch_continuous_task(task)
+    task_started.wait(timeout=5)
+
+    extractor._dispatch_single_action(_make_action("act-start", "Start listener"))
+
+    updates = _queued_updates(extractor)
+    assert any(
+        u.status == ActionStatus.failed and "already running" in (u.result_message or "") for u in updates
+    )
+    allow_exit.set()
+
+
+def test_start_action_relaunches_continuous_task_after_stop() -> None:
+    extractor = _make_extractor()
+    run_count = {"n": 0}
+    started = [Event(), Event()]
+
+    def cancellable(ctx: TaskContext) -> None:
+        i = run_count["n"]
+        run_count["n"] += 1
+        started[i].set()
+        ctx.cancellation_token.wait()
+
+    task = ContinuousTask(name="listener", target=cancellable)
+    extractor.add_task(task)
+    extractor._launch_continuous_task(task)
+    assert started[0].wait(timeout=5)
+
+    extractor._dispatch_single_action(_make_action("act-stop", "Stop listener"))
+    deadline = time.monotonic() + 5
+    while "listener" in extractor._running_task_tokens and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert "listener" not in extractor._running_task_tokens
+
+    # The real dispatch path runs this on its own dedicated thread (base.py's _handle_actions);
+    # since a ContinuousTask's target runs indefinitely, _handle_start_task_action blocks for as
+    # long as the task runs, so mirror that here rather than calling it on the test's own thread.
+    start_thread = threading.Thread(
+        target=extractor._dispatch_single_action,
+        args=(_make_action("act-start", "Start listener"),),
+        daemon=True,
+    )
+    start_thread.start()
+    assert started[1].wait(timeout=5)
+    assert run_count["n"] == 2
+
+    with extractor._running_task_tokens_lock:
+        token = extractor._running_task_tokens.get("listener")
+    assert token is not None
+    token.cancel()
+    start_thread.join(timeout=5)
+    assert not start_thread.is_alive()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -211,9 +211,7 @@ def test_start_action_on_running_continuous_task_reports_failed() -> None:
     extractor._dispatch_single_action(_make_action("act-start", "Start listener"))
 
     updates = _queued_updates(extractor)
-    assert any(
-        u.status == ActionStatus.failed and "already running" in (u.result_message or "") for u in updates
-    )
+    assert any(u.status == ActionStatus.failed and "already running" in (u.result_message or "") for u in updates)
     allow_exit.set()
 
 

--- a/tests/test_unstable/test_action_registration.py
+++ b/tests/test_unstable/test_action_registration.py
@@ -33,19 +33,16 @@ def _startup_request(extractor: Extractor) -> StartupRequest:
     "extra_tasks",
     [
         pytest.param([], id="no_tasks"),
-        pytest.param(
-            [ContinuousTask(name="cont", target=lambda _: None), StartupTask(name="init", target=lambda _: None)],
-            id="non_scheduled_tasks",
-        ),
+        pytest.param([StartupTask(name="init", target=lambda _: None)], id="startup_task_only"),
     ],
 )
-def test_available_actions_without_scheduled_tasks_only_has_builtins(extra_tasks: list) -> None:
+def test_available_actions_without_actionable_tasks_only_has_builtins(extra_tasks: list) -> None:
     extractor = _make_extractor()
     for task in extra_tasks:
         extractor.add_task(task)
     req = _startup_request(extractor)
     assert req.available_actions is not None
-    # Only built-in actions present — no start/stop actions from scheduled tasks
+    # Only built-in actions present — StartupTask does not get start/stop actions
     task_action_names = {a.name for a in req.available_actions if a.type != ActionType.custom}
     assert task_action_names == set()
 
@@ -58,6 +55,19 @@ def test_two_scheduled_tasks_produce_four_task_start_stop_actions() -> None:
     assert req.available_actions is not None
     task_action_names = {a.name for a in req.available_actions if a.type != ActionType.custom}
     assert task_action_names == {"Start alpha", "Stop alpha", "Start beta", "Stop beta"}
+
+
+def test_continuous_task_also_produces_start_stop_actions() -> None:
+    extractor = _make_extractor()
+    extractor.add_task(ContinuousTask(name="listener", target=lambda _: None))
+    req = _startup_request(extractor)
+    assert req.available_actions is not None
+    task_action_names = {a.name for a in req.available_actions if a.type != ActionType.custom}
+    assert task_action_names == {"Start listener", "Stop listener"}
+    by_name = {a.name: a for a in req.available_actions}
+    assert by_name["Start listener"].type == ActionType.start_task
+    assert by_name["Start listener"].task == "listener"
+    assert by_name["Stop listener"].type == ActionType.stop_task
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Extends the Start/Stop action mechanism (previously `ScheduledTask`-only) to also cover `ContinuousTask`, so a continuously-running task can now be stopped and restarted on demand via Odin, the same way scheduled tasks already can.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
- `base.py`: widened five `isinstance(t, ScheduledTask)` gates to `isinstance(t, (ScheduledTask, ContinuousTask))` — `add_action`'s and `add_task`'s reserved-name checks, `_get_startup_request`'s `Start`/`Stop` action registration and `action=` bool on the reported task, `_dispatch_single_action`'s name-matching sets, and `_handle_start_task_action`'s task lookup.
- `_run_task_with_token`'s type hint widened from `ScheduledTask` to `ScheduledTask | ContinuousTask` — no logic change, it only ever touched `.name`/`.target`.
- Extracted the continuous-task launch out of `run()` into a new `_launch_continuous_task(task)` method. It now pre-registers the task's cancellation token in `_running_task_tokens` *before* starting the thread (previously the token was created and handed straight to the thread, never tracked), then runs the task through `_run_task_with_token` instead of calling `task.target` directly. `run()` now just calls this once per continuous task.
- No changes needed to `_handle_stop_task_action` (already generic — looks up by name only) or to the automatic-scheduling `match` in `add_task` / the task-classification `match` in `run()` (a `ContinuousTask` still isn't auto-scheduled via `TaskScheduler`, and still launches once at boot — it's just trackable now).
- `fetch_logs` and db-extractor needed no changes: `fetch_logs` was already task-type-agnostic, and db-extractor doesn't currently define any `ContinuousTask`.
- Tests: split the one test that asserted `ContinuousTask` gets *no* actions into a `StartupTask`-only variant, added a test confirming `ContinuousTask` now gets `Start`/`Stop` actions with the correct `ActionType`/`task` fields, and added four tests in `test_action_dispatch.py` covering the actual runtime behavior — token registered before the thread starts (no race), `Stop` cancels a boot-launched instance, `Start` on an already-running instance reports `failed`, and `Start` after `Stop` successfully relaunches it.

## Why it changed
- Related issue: EDG-714
- Related docs / discussion: follow-up to the `fetch_logs` result-metadata fix (#555 / 7.13.1) — while testing that, we found Start/Stop was scoped to `ScheduledTask` only, with no way to stop/restart a `ContinuousTask` on demand.

## What to focus on during review
- The core risk is in `_launch_continuous_task`: the token must be registered in `_running_task_tokens` *before* the thread starts, not inside it, or there's a race where a Stop/Start arriving immediately after boot could miss it. Worth double-checking the lock scoping there.
- `_handle_start_task_action` runs the task synchronously inside its own per-action dispatch thread. For a `ContinuousTask` (which runs indefinitely), this means the action's own status stays `running` until a `Stop` cancels it — this is a deliberate design choice (reuses the existing dispatch-thread-per-action model with no new threading), not an oversight, but worth confirming that's the semantic you want rather than, say, reporting `succeeded` immediately after a fire-and-forget launch.
- Crash-then-restart interaction: `_run_task_with_token`'s `finally` clears the registry entry regardless of how the target exited (including a crash, since `add_task`'s wrapped `run_task` swallows exceptions internally before `RESTART_POLICY` decides whether to restart the whole extractor). That means a `Start` action can immediately relaunch a continuous task that crashed on its own — intentional, but double-check it doesn't fight with `RESTART_POLICY` in a way that's surprising for extractors using `WHEN_CONTINUOUS_TASKS_CRASHES`.

## Test evidence
- `poetry run pytest tests/test_unstable/test_action_dispatch.py tests/test_unstable/test_action_registration.py -q` → 43 passed, run repeatedly (3x) to rule out flakiness in the new threading-based tests.
- `poetry run pytest tests/test_unstable/ -q` → 237 passed, 1 failed, 48 errors — the failure and errors are pre-existing (missing `COGNITE_*` env vars in the local shell), confirmed identical against the unmodified base via `git stash`.
- `poetry run mypy cognite/extractorutils/unstable/core/` → no issues (13 files).
- `poetry run ruff check cognite/extractorutils/unstable/core/` → all checks passed.

## Risks and unknowns
- No test exercises the real `Extractor.run()` entrypoint end-to-end (it also drives startup tasks and blocks on the scheduler/cancellation wait, which makes it awkward to test directly) — coverage is via the extracted `_launch_continuous_task` method instead, which is exercised directly.
- Haven't verified behavior when a `ContinuousTask`'s target doesn't check its `cancellation_token` cooperatively — same pre-existing caveat as `ScheduledTask`, just now more visible since Stop is exposed for this task type too.
- CHANGELOG.md not yet updated for this change.

## Rollout and rollback
- Purely additive to the action-dispatch surface (new `isinstance` branches, one extracted method) — no config or migration required.
Existing extractors using only `ScheduledTask`/`StartupTask` are unaffected. Revert is a plain `git revert` of this commit if needed.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated (or N/A with reason)
- [ ] Docs updated (or N/A) — CHANGELOG.md entry still outstanding
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams — N/A, not a breaking change