### PR TITLE
EDG-733 Bump the version of pre_commit and setup_uv

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     -   id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
     -   id: ruff-format
-    rev: v0.15.22
+    rev: v0.16.0
 -   repo: local
     hooks:
     -   id: mypy

--- a/cognite/extractorutils/unstable/core/_dto.py
+++ b/cognite/extractorutils/unstable/core/_dto.py
@@ -120,7 +120,7 @@ IdentifierType = Annotated[str, StringConstraints(min_length=1, max_length=255)]
 TaskList = Annotated[list["Task"], Len(min_length=1, max_length=1000)]
 JSONType = TypeAliasType(  # type: ignore[misc]
     "JSONType",
-    bool | int | float | str | None | list[Optional["JSONType"]] | dict[str, Optional["JSONType"]],  # type: ignore[misc]
+    bool | int | float | str | list[Optional["JSONType"]] | dict[str, Optional["JSONType"]] | None,  # type: ignore[misc]
 )
 
 

--- a/cognite/extractorutils/uploader/files.py
+++ b/cognite/extractorutils/uploader/files.py
@@ -249,7 +249,7 @@ class IOFileUploadQueue(AbstractUploadQueue):
         overwrite_existing: bool = False,
         cancellation_token: CancellationToken | None = None,
         max_parallelism: int | None = None,
-        failure_logging_path: None | str = None,
+        failure_logging_path: str | None = None,
         ssl_verify: bool | str = True,
     ) -> None:
         # Super sets post_upload and threshold


### PR DESCRIPTION
This PR bumps the versions of `ruff-pre-commit` and `astral-sh/setup-uv` and fixing some format issues raised during the pre-commit with the bumped version of the `ruff`.