### PR TITLE
fix(odin): Update stop action status to succeeded instead of canceled

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -696,7 +696,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             return
 
         self._checkin_worker.queue_action_update(
-            ActionUpdate(external_id=action.external_id, status=ActionStatus.canceled)
+            ActionUpdate(external_id=action.external_id, status=ActionStatus.succeeded)
         )
 
     def _handle_custom_action(self, action: Action) -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -121,7 +121,7 @@ def test_stop_task_action_not_running_reports_failed() -> None:
     assert "not currently running" in (updates[0].result_message or "")
 
 
-def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
+def test_stop_task_action_cancels_child_token_and_reports_succeeded() -> None:
     extractor = _make_extractor()
     task_started = Event()
     allow_exit = Event()
@@ -140,7 +140,7 @@ def test_stop_task_action_cancels_child_token_and_reports_canceled() -> None:
     extractor._dispatch_single_action(_make_action("act-stop", "Stop worker"))
 
     updates = _queued_updates(extractor)
-    assert any(u.status == ActionStatus.canceled and u.external_id == "act-stop" for u in updates)
+    assert any(u.status == ActionStatus.succeeded and u.external_id == "act-stop" for u in updates)
     assert token is not None and token.is_cancelled
 
     allow_exit.set()
@@ -206,7 +206,7 @@ def test_stop_action_cancels_boot_launched_continuous_task() -> None:
     extractor._dispatch_single_action(_make_action("act-stop", "Stop listener"))
 
     updates = _queued_updates(extractor)
-    assert any(u.status == ActionStatus.canceled and u.external_id == "act-stop" for u in updates)
+    assert any(u.status == ActionStatus.succeeded and u.external_id == "act-stop" for u in updates)
     assert task_exited.wait(timeout=5)
     deadline = time.monotonic() + 5
     while "listener" in extractor._running_task_tokens and time.monotonic() < deadline:


### PR DESCRIPTION
## Summary
Fixes stop-task actions incorrectly reporting `Canceled` instead of `Succeeded` when they successfully stop the target task.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
- `cognite/extractorutils/unstable/core/base.py::_handle_stop_task_action`: report `ActionStatus.succeeded` (was `ActionStatus.canceled`) when the target task's `CancellationToken` is found and cancelled.
- Updated the two affected assertions in `tests/test_unstable/test_action_dispatch.py` (`test_stop_task_action_cancels_child_token_and_reports_succeeded`, `test_stop_action_cancels_boot_launched_continuous_task`) to expect `succeeded`.

## Why it changed
`ActionStatus.canceled` is meant to mean "this action was itself canceled," not "this action successfully performed a cancellation." A stop action that does its job correctly was showing up as aborted in Odin, misleading operators.

## What to focus on during review
- Confirm no downstream consumer (Odin UI/alerting) treats a stop action's terminal status as a signal distinct from `succeeded` in a way that depended on the old `canceled` value.

## Test evidence
- `python -m pytest tests/test_unstable/test_action_dispatch.py -q` → 27 passed.

## Risks and unknowns
- None identified; single status value change, `failed`/token-not-found path unaffected.

## Rollout and rollback
- No flags/migrations. Plain code revert if needed.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated (or N/A with reason)
- [ ] Docs updated (or N/A) — N/A, internal status semantics, not user-facing docs
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams — N/A, not breaking