### PR TITLE
fix(odin): Fixed cancelling an in-flight action

### DIFF
--- a/cognite/extractorutils/unstable/core/actions.py
+++ b/cognite/extractorutils/unstable/core/actions.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Generic
 
+from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import ConfigType
 from cognite.extractorutils.unstable.core._dto import ActionStatus, ActionUpdate
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
@@ -27,6 +28,10 @@ class ActionContext(Generic[ConfigType], CogniteLogger):
 
     ``external_id`` and ``call_metadata`` come from the pending action payload sent by Odin and are
     available for use when reporting results back to the server.
+
+    ``cancellation_token`` is cancelled if the user cancels this specific action invocation from Odin
+    while it is running. Long-running custom actions should check ``cancellation_token.is_cancelled``
+    (or use ``cancellation_token.wait(...)`` instead of blocking sleeps) to exit early when cancelled.
     """
 
     def __init__(
@@ -34,6 +39,7 @@ class ActionContext(Generic[ConfigType], CogniteLogger):
         action: "CustomAction",
         extractor: "Extractor[ConfigType]",
         external_id: str,
+        cancellation_token: CancellationToken,
         call_metadata: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
@@ -41,6 +47,7 @@ class ActionContext(Generic[ConfigType], CogniteLogger):
         self._extractor = extractor
         self.external_id = external_id
         self.call_metadata = call_metadata
+        self.cancellation_token = cancellation_token
         self._result_message: str | None = None
         self._result_metadata: dict[str, str] | None = None
 

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -203,6 +203,11 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         self._custom_actions: list[CustomAction] = []
         self._running_task_tokens: dict[str, CancellationToken] = {}
         self._running_task_tokens_lock = RLock()
+        # Keyed by Action.external_id (not task name) so a `cancel_pending` re-delivery of an
+        # in-flight start_task/custom action can be cancelled instead of re-dispatched. Populated by
+        # _handle_start_task_action/_handle_custom_action, consulted by _dispatch_single_action.
+        self._running_action_tokens: dict[str, CancellationToken] = {}
+        self._running_action_tokens_lock = RLock()
         self._start_time: datetime
 
         self.metrics: BaseMetrics = self._load_metrics(config.metrics_class)
@@ -612,6 +617,16 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             ).start()
 
     def _dispatch_single_action(self, action: Action) -> None:
+        if action.status == ActionStatus.cancel_pending:
+            # Odin re-delivers an already-dispatched action once a user cancels it, with its status
+            # flipped to cancel_pending. This is not a fresh invocation: cancel the token tracking the
+            # in-flight run (if we have one) and stop, rather than re-running the action's handler.
+            with self._running_action_tokens_lock:
+                token = self._running_action_tokens.get(action.external_id)
+            if token is not None:
+                token.cancel()
+            return
+
         actionable_tasks = [t for t in self._tasks if isinstance(t, ACTIONABLE_TASK_TYPES)]
         scheduled_start_names = {f"Start {t.name}" for t in actionable_tasks}
         scheduled_stop_names = {f"Stop {t.name}" for t in actionable_tasks}
@@ -661,6 +676,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 return
             self._running_task_tokens[task_name] = child_token
 
+        with self._running_action_tokens_lock:
+            self._running_action_tokens[action.external_id] = child_token
+
         self._checkin_worker.queue_action_update(
             ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
         )
@@ -677,6 +695,10 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     result_message=str(e),
                 )
             )
+        finally:
+            with self._running_action_tokens_lock:
+                if self._running_action_tokens.get(action.external_id) is child_token:
+                    self._running_action_tokens.pop(action.external_id, None)
 
     def _handle_stop_task_action(self, action: Action) -> None:
         task_name = action.action_name[len("Stop ") :]
@@ -711,6 +733,10 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             )
             return
 
+        action_token = self.cancellation_token.create_child_token()
+        with self._running_action_tokens_lock:
+            self._running_action_tokens[action.external_id] = action_token
+
         self._checkin_worker.queue_action_update(
             ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
         )
@@ -720,11 +746,13 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             extractor=self,
             external_id=action.external_id,
             call_metadata=action.call_metadata,
+            cancellation_token=action_token,
         )
 
         try:
             custom.target(ctx)
             filtered_metadata, oversized_fields = drop_oversized_metadata_fields(ctx._result_metadata)
+            completed_status = ActionStatus.canceled if action_token.is_cancelled else ActionStatus.succeeded
             if oversized_fields:
                 # The action itself ran to completion — only reporting the full result back to Odin
                 # failed, because a metadata value is too large to send. Fail the action instead of
@@ -747,7 +775,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 self._checkin_worker.queue_action_update(
                     ActionUpdate(
                         external_id=action.external_id,
-                        status=ActionStatus.succeeded,
+                        status=completed_status,
                         result_message=ctx._result_message,
                         result_metadata=ctx._result_metadata,
                     )
@@ -777,6 +805,10 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     result_message=str(e),
                 )
             )
+        finally:
+            with self._running_action_tokens_lock:
+                if self._running_action_tokens.get(action.external_id) is action_token:
+                    self._running_action_tokens.pop(action.external_id, None)
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -781,11 +781,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     )
                 )
         except ActionError as e:
+            # As with start_task actions, a cooperative abort in response to cancellation may surface
+            # as an ActionError rather than a clean return; report that as canceled, not failed.
+            status = ActionStatus.canceled if action_token.is_cancelled else ActionStatus.failed
             filtered_metadata, oversized_fields = drop_oversized_metadata_fields(e.result_metadata)
             self._checkin_worker.queue_action_update(
                 ActionUpdate(
                     external_id=action.external_id,
-                    status=ActionStatus.failed,
+                    status=status,
                     result_message=(
                         str(e)
                         if not oversized_fields
@@ -798,10 +801,11 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 )
             )
         except Exception as e:
+            status = ActionStatus.canceled if action_token.is_cancelled else ActionStatus.failed
             self._checkin_worker.queue_action_update(
                 ActionUpdate(
                     external_id=action.external_id,
-                    status=ActionStatus.failed,
+                    status=status,
                     result_message=str(e),
                 )
             )

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -543,6 +543,22 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                     task=lambda: self._run_task_with_token(t),
                 )
 
+    @staticmethod
+    def _release_if_owned(
+        tokens: dict[str, CancellationToken], lock: RLock, key: str, token: CancellationToken
+    ) -> None:
+        """
+        Remove ``key`` from ``tokens`` only if it still maps to ``token``.
+
+        Used when cleaning up a task/action's cancellation-token registration on completion or
+        error. The identity check guards against clobbering a newer registration that may have
+        already replaced this one under the same key (e.g. a task restarted with a fresh token
+        before this cleanup ran).
+        """
+        with lock:
+            if tokens.get(key) is token:
+                tokens.pop(key, None)
+
     def _run_task_with_token(
         self, task: ScheduledTask | ContinuousTask, child_token: CancellationToken | None = None
     ) -> None:
@@ -568,9 +584,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
         try:
             task.target(TaskContext(task=task, extractor=self, cancellation_token=child_token))
         finally:
-            with self._running_task_tokens_lock:
-                if self._running_task_tokens.get(task.name) is child_token:
-                    self._running_task_tokens.pop(task.name, None)
+            self._release_if_owned(self._running_task_tokens, self._running_task_tokens_lock, task.name, child_token)
 
     def _launch_continuous_task(self, task: ContinuousTask) -> None:
         """
@@ -595,9 +609,7 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 args=(task, child_token),
             ).start()
         except Exception as e:
-            with self._running_task_tokens_lock:
-                if self._running_task_tokens.get(task.name) is child_token:
-                    self._running_task_tokens.pop(task.name, None)
+            self._release_if_owned(self._running_task_tokens, self._running_task_tokens_lock, task.name, child_token)
             message = f"Failed to launch continuous task '{task.name}'"
             self._logger.log(level=ErrorLevel.fatal.log_level, msg=message, exc_info=e)
             self._new_error(
@@ -676,14 +688,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 return
             self._running_task_tokens[task_name] = child_token
 
-        with self._running_action_tokens_lock:
-            self._running_action_tokens[action.external_id] = child_token
-
-        self._checkin_worker.queue_action_update(
-            ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
-        )
-
         try:
+            with self._running_action_tokens_lock:
+                self._running_action_tokens[action.external_id] = child_token
+
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
+            )
+
             self._run_task_with_token(task, child_token)
             status = ActionStatus.canceled if child_token.is_cancelled else ActionStatus.succeeded
             self._checkin_worker.queue_action_update(ActionUpdate(external_id=action.external_id, status=status))
@@ -696,9 +708,13 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 )
             )
         finally:
-            with self._running_action_tokens_lock:
-                if self._running_action_tokens.get(action.external_id) is child_token:
-                    self._running_action_tokens.pop(action.external_id, None)
+            # Guards against a leaked "running" registration if something between here and
+            # _run_task_with_token's own cleanup (e.g. the ActionUpdate construction above) ever
+            # raises before _run_task_with_token gets a chance to run its own finally.
+            self._release_if_owned(self._running_task_tokens, self._running_task_tokens_lock, task_name, child_token)
+            self._release_if_owned(
+                self._running_action_tokens, self._running_action_tokens_lock, action.external_id, child_token
+            )
 
     def _handle_stop_task_action(self, action: Action) -> None:
         task_name = action.action_name[len("Stop ") :]
@@ -734,22 +750,23 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             return
 
         action_token = self.cancellation_token.create_child_token()
-        with self._running_action_tokens_lock:
-            self._running_action_tokens[action.external_id] = action_token
-
-        self._checkin_worker.queue_action_update(
-            ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
-        )
-
-        ctx = ActionContext(
-            action=custom,
-            extractor=self,
-            external_id=action.external_id,
-            call_metadata=action.call_metadata,
-            cancellation_token=action_token,
-        )
 
         try:
+            with self._running_action_tokens_lock:
+                self._running_action_tokens[action.external_id] = action_token
+
+            self._checkin_worker.queue_action_update(
+                ActionUpdate(external_id=action.external_id, status=ActionStatus.running)
+            )
+
+            ctx = ActionContext(
+                action=custom,
+                extractor=self,
+                external_id=action.external_id,
+                call_metadata=action.call_metadata,
+                cancellation_token=action_token,
+            )
+
             custom.target(ctx)
             filtered_metadata, oversized_fields = drop_oversized_metadata_fields(ctx._result_metadata)
             completed_status = ActionStatus.canceled if action_token.is_cancelled else ActionStatus.succeeded
@@ -813,9 +830,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 )
             )
         finally:
-            with self._running_action_tokens_lock:
-                if self._running_action_tokens.get(action.external_id) is action_token:
-                    self._running_action_tokens.pop(action.external_id, None)
+            self._release_if_owned(
+                self._running_action_tokens, self._running_action_tokens_lock, action.external_id, action_token
+            )
 
     def start(self) -> None:
         """

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -754,17 +754,20 @@ class Extractor(Generic[ConfigType], CogniteLogger):
             filtered_metadata, oversized_fields = drop_oversized_metadata_fields(ctx._result_metadata)
             completed_status = ActionStatus.canceled if action_token.is_cancelled else ActionStatus.succeeded
             if oversized_fields:
-                # The action itself ran to completion — only reporting the full result back to Odin
-                # failed, because a metadata value is too large to send. Fail the action instead of
-                # queuing a payload that Odin would reject (which would otherwise poison the checkin
-                # batch and retry forever, since checkin bundles all pending updates together and
-                # requeues the whole batch on any rejection). Non-oversized fields are still reported.
+                # The action itself ran to completion (or was cancelled) — only reporting the full
+                # result back to Odin is affected, because a metadata value is too large to send.
+                # Drop the oversized field(s) instead of queuing a payload that Odin would reject
+                # (which would otherwise poison the checkin batch and retry forever, since checkin
+                # bundles all pending updates together and requeues the whole batch on any rejection).
+                # Non-oversized fields are still reported, and the action's real outcome (succeeded or
+                # canceled) is preserved rather than being overwritten by this reporting issue.
+                outcome = "was canceled" if completed_status == ActionStatus.canceled else "completed successfully"
                 self._checkin_worker.queue_action_update(
                     ActionUpdate(
                         external_id=action.external_id,
-                        status=ActionStatus.failed,
+                        status=completed_status,
                         result_message=truncate_message(
-                            f"Action '{custom.name}' completed successfully, but metadata field(s) "
+                            f"Action '{custom.name}' {outcome}, but metadata field(s) "
                             f"{', '.join(oversized_fields)} exceeded the {MAX_METADATA_VALUE_BYTES}-byte-per-value "
                             f"limit and were dropped from the reported result"
                         ),

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -623,3 +623,47 @@ def test_cancel_pending_unknown_action_is_a_no_op() -> None:
     )
 
     assert _queued_updates(extractor) == []
+
+
+def test_custom_action_reports_canceled_when_target_raises_action_error_after_cancellation() -> None:
+    def target(ctx: ActionContext) -> None:
+        ctx.cancellation_token.cancel()
+        raise ActionError("aborted early", error_type="canceled_mid_run")
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="cooperative", target=target))
+    extractor._dispatch_single_action(_make_action("act-1", "cooperative"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.canceled
+    assert final.result_message == "aborted early"
+
+
+def test_custom_action_reports_canceled_when_target_raises_generic_exception_after_cancellation() -> None:
+    def target(ctx: ActionContext) -> None:
+        ctx.cancellation_token.cancel()
+        raise RuntimeError("connection reset")
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="cooperative", target=target))
+    extractor._dispatch_single_action(_make_action("act-1", "cooperative"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.canceled
+    assert final.result_message == "connection reset"
+
+
+def test_custom_action_reports_failed_when_target_raises_without_cancellation() -> None:
+    def target(ctx: ActionContext) -> None:
+        raise ActionError("bad input", error_type="invalid_parameter")
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="strict", target=target))
+    extractor._dispatch_single_action(_make_action("act-1", "strict"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.failed
+    assert final.result_message == "bad input"

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -317,7 +317,7 @@ def test_action_error_sets_result_metadata_and_keeps_failed_status() -> None:
     assert failed.result_message == "bad input"
 
 
-def test_oversized_result_metadata_fails_action_but_keeps_valid_fields() -> None:
+def test_oversized_result_metadata_keeps_completed_status_and_valid_fields() -> None:
     def target(ctx: ActionContext) -> None:
         ctx.set_result("done", metadata={"summary": "ok", "blob": "x" * 600})
 
@@ -327,11 +327,30 @@ def test_oversized_result_metadata_fails_action_but_keeps_valid_fields() -> None
 
     updates = _queued_updates(extractor)
     final = updates[-1]
-    assert final.status == ActionStatus.failed
+    assert final.status == ActionStatus.succeeded
     assert final.result_metadata == {"summary": "ok"}
     assert "big-result" in (final.result_message or "")
+    assert "completed successfully" in (final.result_message or "")
     assert "blob" in (final.result_message or "")
     assert "512" in (final.result_message or "")
+
+
+def test_oversized_result_metadata_reports_canceled_when_cancelled() -> None:
+    def target(ctx: ActionContext) -> None:
+        ctx.cancellation_token.cancel()
+        ctx.set_result("done", metadata={"summary": "ok", "blob": "x" * 600})
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="big-result-canceled", target=target))
+    extractor._dispatch_single_action(_make_action("act-big-canceled", "big-result-canceled"))
+
+    updates = _queued_updates(extractor)
+    final = updates[-1]
+    assert final.status == ActionStatus.canceled
+    assert final.result_metadata == {"summary": "ok"}
+    assert "was canceled" in (final.result_message or "")
+    assert "completed successfully" not in (final.result_message or "")
+    assert "blob" in (final.result_message or "")
 
 
 def test_oversized_action_error_metadata_drops_only_oversized_field() -> None:
@@ -383,7 +402,7 @@ def test_oversized_result_metadata_with_many_fields_truncates_message_instead_of
 
     updates = _queued_updates(extractor)
     final = updates[-1]
-    assert final.status == ActionStatus.failed
+    assert final.status == ActionStatus.succeeded
     assert final.result_metadata == {"summary": "ok"}
     assert final.result_message is not None
     assert len(final.result_message) <= MAX_MESSAGE_LENGTH

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -686,3 +686,44 @@ def test_custom_action_reports_failed_when_target_raises_without_cancellation() 
     final = updates[-1]
     assert final.status == ActionStatus.failed
     assert final.result_message == "bad input"
+
+
+def test_start_task_action_cleans_up_registration_when_running_update_raises() -> None:
+    # Regression test: registration into _running_task_tokens/_running_action_tokens must happen
+    # inside the same try/finally that cleans them up, so a failure anywhere before the task
+    # actually runs (e.g. constructing the "running" ActionUpdate) can't leave the task stuck
+    # "running" forever.
+    extractor = _make_extractor()
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=lambda _: None))
+
+    def flaky_queue_update(update: ActionUpdate) -> None:
+        if update.status == ActionStatus.running:
+            raise RuntimeError("boom")
+
+    extractor._checkin_worker.queue_action_update.side_effect = flaky_queue_update
+
+    extractor._dispatch_single_action(_make_action("act-1", "Start worker"))
+
+    assert "worker" not in extractor._running_task_tokens
+    assert "act-1" not in extractor._running_action_tokens
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.failed and u.result_message == "boom" for u in updates)
+
+
+def test_custom_action_cleans_up_registration_when_running_update_raises() -> None:
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="flaky", target=lambda ctx: None))
+
+    def flaky_queue_update(update: ActionUpdate) -> None:
+        if update.status == ActionStatus.running:
+            raise RuntimeError("boom")
+
+    extractor._checkin_worker.queue_action_update.side_effect = flaky_queue_update
+
+    extractor._dispatch_single_action(_make_action("act-1", "flaky"))
+
+    assert "act-1" not in extractor._running_action_tokens
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.failed and u.result_message == "boom" for u in updates)

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -30,8 +30,8 @@ def _queued_updates(extractor: TestExtractor) -> list[ActionUpdate]:
     return [c[0][0] for c in extractor._checkin_worker.queue_action_update.call_args_list]
 
 
-def _make_action(external_id: str, action_name: str) -> Action:
-    return Action(external_id=external_id, action_name=action_name, status=ActionStatus.pending)
+def _make_action(external_id: str, action_name: str, status: ActionStatus = ActionStatus.pending) -> Action:
+    return Action(external_id=external_id, action_name=action_name, status=status)
 
 
 def test_dispatch_unrecognised_action_name_reports_failed() -> None:
@@ -531,3 +531,95 @@ def test_action_context_exposes_cdf_client_and_integration_external_id() -> None
     extractor._dispatch_single_action(_make_action("act-p", "probe"))
     assert captured["cdf_client"] is extractor.cognite_client
     assert captured["integration_external_id"] == "test-integration"
+
+
+def test_cancel_pending_custom_action_cancels_token_without_rerunning_target() -> None:
+    call_count = {"n": 0}
+    started = Event()
+    allow_exit = Event()
+
+    def target(ctx: ActionContext) -> None:
+        call_count["n"] += 1
+        started.set()
+        allow_exit.wait(timeout=5)
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="long-running", target=target))
+
+    dispatch_thread = threading.Thread(
+        target=extractor._dispatch_single_action,
+        args=(_make_action("act-1", "long-running"),),
+        daemon=True,
+    )
+    dispatch_thread.start()
+    assert started.wait(timeout=5)
+
+    with extractor._running_action_tokens_lock:
+        token = extractor._running_action_tokens.get("act-1")
+    assert token is not None and not token.is_cancelled
+
+    # Odin re-delivers the same external_id with cancel_pending once the user cancels it.
+    extractor._dispatch_single_action(_make_action("act-1", "long-running", status=ActionStatus.cancel_pending))
+
+    assert token.is_cancelled
+    assert call_count["n"] == 1  # target was not re-invoked by the cancel_pending re-delivery
+
+    allow_exit.set()
+    dispatch_thread.join(timeout=5)
+
+
+def test_custom_action_reports_canceled_when_cancelled_mid_run() -> None:
+    def target(ctx: ActionContext) -> None:
+        ctx.cancellation_token.cancel()
+
+    extractor = _make_extractor()
+    extractor.add_action(CustomAction(name="cooperative", target=target))
+    extractor._dispatch_single_action(_make_action("act-1", "cooperative"))
+
+    updates = _queued_updates(extractor)
+    assert any(u.status == ActionStatus.canceled and u.external_id == "act-1" for u in updates)
+
+
+def test_cancel_pending_start_task_action_cancels_running_task_instead_of_redispatching() -> None:
+    extractor = _make_extractor()
+    task_started = Event()
+    allow_exit = Event()
+
+    def cancellable(ctx: TaskContext) -> None:
+        task_started.set()
+        allow_exit.wait(timeout=5)
+
+    extractor.add_task(ScheduledTask.from_interval(interval="1h", name="worker", target=cancellable))
+
+    dispatch_thread = threading.Thread(
+        target=extractor._dispatch_single_action,
+        args=(_make_action("act-1", "Start worker"),),
+        daemon=True,
+    )
+    dispatch_thread.start()
+    assert task_started.wait(timeout=5)
+
+    # Odin re-delivers the same external_id with cancel_pending once the user cancels it.
+    extractor._dispatch_single_action(_make_action("act-1", "Start worker", status=ActionStatus.cancel_pending))
+
+    with extractor._running_task_tokens_lock:
+        token = extractor._running_task_tokens.get("worker")
+    assert token is not None and token.is_cancelled
+
+    allow_exit.set()
+    dispatch_thread.join(timeout=5)
+
+    updates = _queued_updates(extractor)
+    statuses = [u.status for u in updates if u.external_id == "act-1"]
+    # No spurious "already running" failure from the cancel_pending re-delivery being re-dispatched.
+    assert ActionStatus.failed not in statuses
+    assert statuses[-1] == ActionStatus.canceled
+
+
+def test_cancel_pending_unknown_action_is_a_no_op() -> None:
+    extractor = _make_extractor()
+    extractor._dispatch_single_action(
+        _make_action("act-unknown", "does not matter", status=ActionStatus.cancel_pending)
+    )
+
+    assert _queued_updates(extractor) == []

--- a/tests/test_unstable/test_actions.py
+++ b/tests/test_unstable/test_actions.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.core.actions import ActionContext, CustomAction
 from cognite.extractorutils.unstable.core.errors import Error, ErrorLevel
 
@@ -47,6 +48,7 @@ def test_action_context_attributes(mock_extractor: MagicMock, simple_action: Cus
         action=simple_action,
         extractor=mock_extractor,
         external_id="triggered-action-ext-id",
+        cancellation_token=CancellationToken(),
         call_metadata={"key": "value"},
     )
 
@@ -55,20 +57,26 @@ def test_action_context_attributes(mock_extractor: MagicMock, simple_action: Cus
 
 
 def test_action_context_call_metadata_none(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
-    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+    ctx = ActionContext(
+        action=simple_action, extractor=mock_extractor, external_id="ext-id", cancellation_token=CancellationToken()
+    )
 
     assert ctx.call_metadata is None
 
 
 def test_action_context_logger_name(mock_extractor: MagicMock, simple_action: CustomAction) -> None:
-    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+    ctx = ActionContext(
+        action=simple_action, extractor=mock_extractor, external_id="ext-id", cancellation_token=CancellationToken()
+    )
 
     assert ctx._logger.name == "test-extractor.action.myaction"
 
 
 def test_action_context_logger_name_strips_spaces(mock_extractor: MagicMock) -> None:
     action = CustomAction(name="process data", target=lambda ctx: None)
-    ctx = ActionContext(action=action, extractor=mock_extractor, external_id="ext-id")
+    ctx = ActionContext(
+        action=action, extractor=mock_extractor, external_id="ext-id", cancellation_token=CancellationToken()
+    )
 
     assert ctx._logger.name == "test-extractor.action.processdata"
 
@@ -89,7 +97,9 @@ def test_action_context_error_task_name(
     task_name: str | None,
     expected_task_name: str,
 ) -> None:
-    ctx = ActionContext(action=simple_action, extractor=mock_extractor, external_id="ext-id")
+    ctx = ActionContext(
+        action=simple_action, extractor=mock_extractor, external_id="ext-id", cancellation_token=CancellationToken()
+    )
 
     ctx._new_error(
         level=ErrorLevel.warning, description="Something went wrong", details="some details", task_name=task_name
@@ -108,7 +118,9 @@ def test_action_target_is_callable(mock_extractor: MagicMock) -> None:
         called.append(ctx)
 
     action = CustomAction(name="test", target=my_action)
-    ctx = ActionContext(action=action, extractor=mock_extractor, external_id="ext-id")
+    ctx = ActionContext(
+        action=action, extractor=mock_extractor, external_id="ext-id", cancellation_token=CancellationToken()
+    )
 
     assert callable(action.target)
     action.target(ctx)

--- a/tests/test_unstable/test_log_upload_action.py
+++ b/tests/test_unstable/test_log_upload_action.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from cognite.extractorutils.threading import CancellationToken
 from cognite.extractorutils.unstable.configuration.models import (
     LogFileHandlerConfig,
     LogLevel,
@@ -569,7 +570,9 @@ def test_fetch_logs_action_all_files_missing_still_succeeds(tmp_path: Path) -> N
 def test_set_result_raises_on_second_call() -> None:
     extractor = _make_extractor()
     action = CustomAction(name="test", target=lambda ctx: None)
-    ctx = ActionContext(action=action, extractor=extractor, external_id="test-123")
+    ctx = ActionContext(
+        action=action, extractor=extractor, external_id="test-123", cancellation_token=CancellationToken()
+    )
     ctx.set_result("first result")
     with pytest.raises(RuntimeError, match="set_result\\(\\) has already been called"):
         ctx.set_result("second result")
@@ -631,6 +634,7 @@ def test_report_progress_queues_running_action_update() -> None:
         action=CustomAction(name="test-action", target=lambda ctx: None),
         extractor=extractor,
         external_id="act-progress",
+        cancellation_token=CancellationToken(),
     )
     ctx.report_progress("Uploading: 1/3 files complete")
 


### PR DESCRIPTION
## Summary
Fixes cancelling an in-flight `start_task`/`custom` action, plus three follow-up correctness fixes surfaced during review: status/message accuracy when oversized metadata coincides with cancellation, and a token-registration leak on early failure.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
**Core fix — cancel an in-flight action instead of re-dispatching it:**
- `base.py`: added `_running_action_tokens` (keyed by `Action.external_id`, mirroring `_running_task_tokens`), populated by `_handle_start_task_action`/`_handle_custom_action`.
- `base.py`: `_dispatch_single_action` now checks `action.status` up front — a `cancel_pending` re-delivery (Odin's signal that a user cancelled an already-dispatched action) cancels the tracked token by `external_id` and returns, instead of re-running the handler.
- `base.py`: `_handle_custom_action` reports `ActionStatus.canceled` (not `succeeded`) if the action's token was cancelled before the target returned.
- `actions.py`: `ActionContext` gains a required `cancellation_token: CancellationToken`, so custom actions can cooperatively check `ctx.cancellation_token.is_cancelled`/`.wait(...)`.

**Follow-up fixes (from review):**
- `base.py`: **behavioral change** — the oversized-metadata branch in `_handle_custom_action` used to *always* report `ActionStatus.failed`, regardless of whether the action itself succeeded. It now reports the action's real outcome (`succeeded`/`canceled`) instead — metadata truncation is reflected only in the message and dropped fields, not the status. Any consumer (dashboards, alerting, automation) relying on "oversized metadata → failed" as a signal will see a different status for these actions after this PR. Message wording also no longer claims "completed successfully" when the action was actually cancelled.
- `base.py`: token registration (`_running_action_tokens`, and `_running_task_tokens` for start_task) now happens inside the same `try`/`finally` that cleans it up, in both `_handle_start_task_action` and `_handle_custom_action` — previously a failure between registration and the actual work (e.g. constructing the "running" `ActionUpdate`) would leave the task/action stuck "running" forever with no error ever reported.
- `base.py`: extracted the repeated "release token if still owned" lock/get/pop idiom (5 call sites) into a shared `_release_if_owned` helper.

**Tests:** updated all `ActionContext(...)` call sites (`test_actions.py`, `test_log_upload_action.py`) to pass a token; added 8 new tests to `test_action_dispatch.py` covering cancel-pending re-delivery (custom and start_task actions), cooperative cancellation reporting, oversized-metadata status/wording under cancellation, and registration cleanup on early failure.

## Why it changed
Odin propagates a cancel of a running action by flipping it to `cancel_pending` and re-sending the same `external_id` on the next checkin. The SDK never read `Action.status`, so this was treated as a fresh dispatch — re-running custom action side effects a second time, or spuriously failing an already-running start_task action. The review follow-ups close two adjacent gaps in the same area: status/message accuracy was still wrong in one corner case (oversized metadata + cancellation), and the new token-tracking dicts had the same "register before try" fragility as existing code nearby.

## What to focus on during review
- **Behavioral change:** oversized-metadata custom actions now report `succeeded`/`canceled` instead of always `failed` — see "Follow-up fixes" above. Flag if any downstream consumer depends on the old always-`failed` behavior for this case.
- `ActionContext.cancellation_token` is a new required constructor argument — any external code constructing `ActionContext` directly needs to pass one.
- Cancellation remains cooperative — a custom action that never checks the token still runs to completion; this PR only prevents double-execution and misreported status, not forced interruption.
- `_release_if_owned` is a pure mechanical refactor (verified via test diff against pre-refactor code) — no behavior change intended.

## Test evidence
- `pytest tests/test_unstable/test_action_dispatch.py tests/test_unstable/test_actions.py tests/test_unstable/test_log_upload_action.py -q` → 96 passed.
- `pytest tests/test_unstable/ -q` → 248 passed (48 pre-existing, unrelated errors from missing local env vars; 0 new failures).
- `mypy` / `ruff check` / `ruff format` → clean.

## Risks and unknowns
- The oversized-metadata status change (see above) is the one behavior change with real external-visibility risk in this PR — worth confirming no dashboard/alert depends on the old `failed`-always behavior before merge.
- Custom actions that don't check the cancellation token get no benefit beyond "no longer double-executed" — inherent cooperative-cancellation limitation, not addressed here.
- `stop_task` action behavior is unchanged (completes near-instantly; cancel-pending race window is negligible there).

## Rollout and rollback
No flags/migrations. `ActionContext`'s new required parameter is the only signature change; plain code revert if needed.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated
- [ ] Docs updated (or N/A) — N/A, internal SDK behavior; documented via docstrings
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above — `ActionContext` now requires `cancellation_token`; oversized-metadata status behavior change called out under "What to focus on during review"