### PR TITLE
fix(odin): Fix oversize metadata field truncation issue

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -815,7 +815,8 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                         else truncate_message(
                             f"{len(oversized_fields)} metadata field(s) exceeded the "
                             f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped. "
-                            f"Action failed: {e}. Dropped fields: {', '.join(oversized_fields)}"
+                            f"Action failed: {truncate_message(str(e), max_length=500)}. "
+                            f"Dropped fields: {', '.join(oversized_fields)}"
                         )
                     ),
                     result_metadata=filtered_metadata,

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -813,9 +813,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                         str(e)
                         if not oversized_fields
                         else truncate_message(
-                            f"{e} (additionally, {len(oversized_fields)} metadata field(s) exceeded the "
-                            f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped: "
-                            f"{', '.join(oversized_fields)})"
+                            f"{len(oversized_fields)} metadata field(s) exceeded the "
+                            f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped. "
+                            f"Action failed: {e}. Dropped fields: {', '.join(oversized_fields)}"
                         )
                     ),
                     result_metadata=filtered_metadata,

--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -784,9 +784,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                         external_id=action.external_id,
                         status=completed_status,
                         result_message=truncate_message(
-                            f"Action '{custom.name}' {outcome}, but metadata field(s) "
-                            f"{', '.join(oversized_fields)} exceeded the {MAX_METADATA_VALUE_BYTES}-byte-per-value "
-                            f"limit and were dropped from the reported result"
+                            f"Action '{custom.name}' {outcome}, but {len(oversized_fields)} metadata field(s) "
+                            f"exceeded the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped from "
+                            f"the reported result: {', '.join(oversized_fields)}"
                         ),
                         result_metadata=filtered_metadata,
                     )
@@ -813,8 +813,9 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                         str(e)
                         if not oversized_fields
                         else truncate_message(
-                            f"{e} (additionally, metadata field(s) {', '.join(oversized_fields)} exceeded "
-                            f"the {MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped)"
+                            f"{e} (additionally, {len(oversized_fields)} metadata field(s) exceeded the "
+                            f"{MAX_METADATA_VALUE_BYTES}-byte-per-value limit and were dropped: "
+                            f"{', '.join(oversized_fields)})"
                         )
                     ),
                     result_metadata=filtered_metadata,

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -430,11 +430,13 @@ def test_oversized_action_error_with_long_message_truncates_instead_of_crashing(
     assert failed.result_metadata == {"error_type": "invalid_parameter"}
     assert failed.result_message is not None
     assert len(failed.result_message) <= MAX_MESSAGE_LENGTH
-    assert failed.result_message.endswith("...")
     # Regression: the metadata-dropped explanation must survive truncation even when the
-    # (unbounded) ActionError message itself is long enough to be truncated away.
+    # ActionError message itself is long enough to need truncating on its own.
     assert "exceeded" in failed.result_message
     assert "dropped" in failed.result_message
+    # Regression: str(e) is bounded before combining, so there's still room left for the
+    # dropped-field-name list even when the ActionError message alone is very long.
+    assert "error_detail" in failed.result_message
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -431,6 +431,10 @@ def test_oversized_action_error_with_long_message_truncates_instead_of_crashing(
     assert failed.result_message is not None
     assert len(failed.result_message) <= MAX_MESSAGE_LENGTH
     assert failed.result_message.endswith("...")
+    # Regression: the metadata-dropped explanation must survive truncation even when the
+    # (unbounded) ActionError message itself is long enough to be truncated away.
+    assert "exceeded" in failed.result_message
+    assert "dropped" in failed.result_message
 
 
 def test_custom_action_receives_call_metadata_in_context() -> None:

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -407,8 +407,9 @@ def test_oversized_result_metadata_with_many_fields_truncates_message_instead_of
     assert final.result_message is not None
     assert len(final.result_message) <= MAX_MESSAGE_LENGTH
     assert final.result_message.endswith("...")
-    # Regression: the explanation must survive truncation even when the field-name list doesn't.
-    assert "exceeded" in final.result_message
+    # Regression: the explanation, including the count, must survive truncation even when the
+    # field-name list doesn't.
+    assert "45 metadata field(s) exceeded" in final.result_message
     assert "dropped" in final.result_message
 
 

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -407,6 +407,9 @@ def test_oversized_result_metadata_with_many_fields_truncates_message_instead_of
     assert final.result_message is not None
     assert len(final.result_message) <= MAX_MESSAGE_LENGTH
     assert final.result_message.endswith("...")
+    # Regression: the explanation must survive truncation even when the field-name list doesn't.
+    assert "exceeded" in final.result_message
+    assert "dropped" in final.result_message
 
 
 def test_oversized_action_error_with_long_message_truncates_instead_of_crashing() -> None:


### PR DESCRIPTION
## Summary
Fixes truncated custom-action result messages so the explanation of why metadata fields were dropped always survives truncation, instead of being pushed off the end by an unbounded list of field names.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
- `cognite/extractorutils/unstable/core/base.py` — `_handle_custom_action` success path: reordered the oversized-metadata message so the fixed explanation ("N metadata field(s) exceeded the byte limit and were dropped") comes before the unbounded field-name list, and reports a count instead of only names.
- Same reordering applied to the parallel `ActionError` branch's message.
- `tests/test_unstable/test_action_dispatch.py` — added regression assertions to the many-fields test confirming "exceeded"/"dropped" survive truncation.

## Why it changed
- Related issue: [EDG-825](https://cognitedata.atlassian.net/browse/EDG-825)
- Related docs / discussion: PR #572 review comment discussion (`discussion_r3911633979`)

`truncate_message()` truncates from the end at 1000 chars. With the old ordering, a large enough number of oversized fields (e.g. 45, as in the existing regression test) pushed the trailing explanation entirely off the message, leaving only a cut-off list of field names with no indication of what happened or why.

## What to focus on during review
- The `ActionError` branch still has `str(e)` (itself unbounded) ahead of the reordered explanation — reordering doesn't fully protect against a pathologically long `ActionError` message on its own; that's a separate, pre-existing concern out of scope here.
- Message wording change is user-facing (`result_message` surfaced to Odin/callers) — confirm no downstream parsing depends on the old phrasing.

## Test evidence
- `python -m pytest tests/test_unstable/test_action_dispatch.py -q` → 37 passed.
- `python -m pytest tests/test_unstable/ -q` → 248 passed / 1 failed / 48 errors, identical to the pre-change baseline (verified via `git stash`) — failures are pre-existing `KeyError: 'COGNITE...'` env-fixture issues unrelated to this change.

## Risks and unknowns
- `ActionError.__str__()` can itself exceed 1000 chars, in which case the explanation still gets truncated away regardless of ordering — not addressed here, flagged as a possible follow-up.

## Rollout and rollback
- No config/migration changes; pure message-formatting fix. Revert the commit to roll back.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated
- [ ] Docs updated (N/A — no user-facing docs describe this message format)
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams (N/A — non-breaking)

[EDG-825]: https://cognitedata.atlassian.net/browse/EDG-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ