### PR TITLE
Add dependabot config for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ registries:
     password: ${{secrets.ARTIFACTORY_READONLY_TOKEN}}
 
 updates:
-  - package-ecosystem: uv 
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+registries:
+  artifactory-python:
+    type: python-index
+    url: https://cognite.jfrog.io/cognite/api/pypi/snakepit/simple
+    username: ${{secrets.ARTIFACTORY_READONLY_TOKEN_USER}}
+    password: ${{secrets.ARTIFACTORY_READONLY_TOKEN}}
+
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: daily
+    registries:
+      - artifactory-python
+    cooldown:
+      default-days: 7
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,13 @@ registries:
     password: ${{secrets.ARTIFACTORY_READONLY_TOKEN}}
 
 updates:
-  - package-ecosystem: uv
+  - package-ecosystem: uv 
     directory: /
     schedule:
       interval: daily
     registries:
       - artifactory-python
-    cooldown:
-      default-days: 7
-    groups:
-      python-minor-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
+    # Security updates only: version-update PRs are disabled, but this block
+    # still supplies the private registry credentials Dependabot needs to
+    # resolve security fixes.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Enables Dependabot security updates for the uv ecosystem, using the snakepit Artifactory index for resolution. Version-update PRs are disabled (open-pull-requests-limit: 0) since Renovate handles those.