### PR TITLE
fix(odin): Confirm cancellation for a cancel_pending action never dispatched

### DIFF
--- a/cognite/extractorutils/unstable/core/base.py
+++ b/cognite/extractorutils/unstable/core/base.py
@@ -637,6 +637,14 @@ class Extractor(Generic[ConfigType], CogniteLogger):
                 token = self._running_action_tokens.get(action.external_id)
             if token is not None:
                 token.cancel()
+            else:
+                # No in-flight run for this external_id: either never dispatched by this process, or
+                # already finished and cleaned up. Safe to confirm cancellation immediately — Odin
+                # would otherwise wait on an ack that never comes until this integration's next
+                # startup.
+                self._checkin_worker.queue_action_update(
+                    ActionUpdate(external_id=action.external_id, status=ActionStatus.canceled)
+                )
             return
 
         actionable_tasks = [t for t in self._tasks if isinstance(t, ACTIONABLE_TASK_TYPES)]

--- a/tests/test_unstable/test_action_dispatch.py
+++ b/tests/test_unstable/test_action_dispatch.py
@@ -635,13 +635,16 @@ def test_cancel_pending_start_task_action_cancels_running_task_instead_of_redisp
     assert statuses[-1] == ActionStatus.canceled
 
 
-def test_cancel_pending_unknown_action_is_a_no_op() -> None:
+def test_cancel_pending_unknown_action_confirms_canceled() -> None:
     extractor = _make_extractor()
     extractor._dispatch_single_action(
         _make_action("act-unknown", "does not matter", status=ActionStatus.cancel_pending)
     )
 
-    assert _queued_updates(extractor) == []
+    updates = _queued_updates(extractor)
+    assert len(updates) == 1
+    assert updates[0].external_id == "act-unknown"
+    assert updates[0].status == ActionStatus.canceled
 
 
 def test_custom_action_reports_canceled_when_target_raises_action_error_after_cancellation() -> None:


### PR DESCRIPTION
## Summary
The extractor now explicitly confirms cancellation when it receives a `cancel_pending` action it has no record of (never dispatched, or already finished), instead of silently doing nothing.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Refactor (no functional change)
- [ ] Documentation update
- [ ] Chore / tooling / CI

## What changed
- `_dispatch_single_action`'s `cancel_pending` branch (`unstable/core/base.py`) now queues an explicit `ActionUpdate(status=canceled)` when no local `CancellationToken` is found for the action's `external_id`, instead of a silent no-op.
- Renamed/rewrote `test_cancel_pending_unknown_action_is_a_no_op` → `test_cancel_pending_unknown_action_confirms_canceled` to lock in the new behavior.

## Why it changed
- Related issue: EDG-826 (companion to the odin-side fix in the same ticket)
- Related docs / discussion: N/A

Odin is changing how it handles cancelling a `pending` action: instead of finalizing to `canceled` immediately (which gave this extractor no chance to stop work it may have already started locally), it now always moves the action to `cancel_pending` and waits for this extractor to acknowledge. For actions this extractor genuinely never dispatched (or already finished and cleaned up), the old silent no-op meant Odin would wait indefinitely for an ack that would only ever arrive at this integration's next startup. This change closes that gap by confirming immediately.

## What to focus on during review
- Safety of reporting `canceled` for an already-finished action: if the action already completed and reported a terminal status (`succeeded`/`failed`/`canceled`) via an earlier checkin, this late `canceled` ack is harmless — Odin's `execute_update_triggered_actions` treats any of those as terminal and drops later updates for the same action as a no-op.
- `ActionUpdate`'s own `status` validator already rejects `pending`/`cancel_pending`, so `canceled` is the only valid choice here — no new validation needed.

## Test evidence
- `pre-commit run --all-files` (ruff check, ruff format, mypy) — clean.
- `uv run pytest tests/test_unstable/test_action_dispatch.py -q` — 37 passed.
- `uv run pytest tests/test_unstable/ -q` — same 1 failed / 248 passed / 48 errors as on `master` with no changes applied (confirmed via a stashed re-run); all pre-existing, unrelated (mostly missing-credential setup errors for live-CDF integration tests), not introduced by this change.
- Proof-of-effect: reverted `base.py` locally and confirmed `test_cancel_pending_unknown_action_confirms_canceled` fails (`0 == 1` — no update queued) against the old code, passes with the fix.

## Risks and unknowns
- This is one half of a two-repo fix; it has no effect on its own until Odin's companion change (separate PR, EDG-826) ships, since today Odin never re-delivers a `pending` action as `cancel_pending` in the first place.
- Skipped a changelog/version entry in this PR — this repo's convention (confirmed via `git log`, e.g. `a88af30` vs the separate `8648712` "Release" commit) keeps version bumps as their own dedicated commit, not bundled with individual fixes.

## Rollout and rollback
- No config or schema changes. Extractors need to upgrade to pick up this behavior; until they do, an Odin-side cancel on an undispatched action resolves at the extractor's next startup instead of its next checkin (documented as an accepted tradeoff in the companion odin PR).
- Rollback is a plain revert of the one code change; no state to migrate.

## Checklist
- [x] Self-reviewed the diff
- [x] Tests added or updated (or N/A with reason)
- [ ] Docs updated (or N/A) — N/A, internal dispatch behavior, no public API change
- [x] No secrets, credentials, or PII committed
- [x] Breaking changes called out above and communicated to affected teams — non-breaking; additive behavior only